### PR TITLE
Widen versioning constraint to analyzer to >=0.39.4 <0.40.0

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.5+1
+
+* Widen versioning constraint to analyzer to >=0.39.4 <0.40.0
+
 ## 2.2.5
 
 * Update dependencies. In particular, analyzer can now be 0.39.10.

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.2.5
+version: 2.2.5+1
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
@@ -7,7 +7,7 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=2.3.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.39.4 <=0.39.10'
+  analyzer: '>=0.39.4 <0.40.0'
   build: ^1.3.0
   build_resolvers: ^1.3.0
   build_config: ^0.4.0


### PR DESCRIPTION

I had some trouble with build runner after doing a pub upgrade, in the end I noticed that some unwanted versions were used because of the analyzer version constraint in reflectable. So I increased it, I haven't observed any issues with it. But I don't know if the limit was intentional.