### PR TITLE
Use workaround for 198

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 2.2.6
 
 * Resolve #198 (InconsistentAnalysisException), based on workaround from
-  dart-lang/build#2634.
+  dart-lang/build#2634. Also widen the analyzer version constraint to
+  include all 0.39 versions published at this point.
 
 ## 2.2.5
 

--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.6
+
+* Resolve #198 (InconsistentAnalysisException), based on workaround from
+  dart-lang/build#2634.
+
 ## 2.2.5
 
 * Update dependencies. In particular, analyzer can now be 0.39.10.

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -5428,6 +5428,10 @@ Future<ElementDeclarationResult> _getDeclaration(
 
 Future<ResolvedLibraryResult> _getResolvedLibrary(
     LibraryElement library, Resolver resolver) async {
+  // This is expensive, but seems to be necessary. It is using the workaround
+  // mentioned in dart-lang/build#2634. If we do not fetch a fresh session
+  // then the code generation stops with an `InconsistentAnalysisException`
+  // if there is more than one entry point.
   final freshLibrary = await resolver
       .libraryFor(await resolver.assetIdForElement(library));
   final freshSession = freshLibrary.session;

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -5419,13 +5419,20 @@ Future<void> _emitMessage(String message,
   log.warning(formattedMessage);
 }
 
-// Return the [ElementDeclarationResult] of the given [element].
+/// Return the [ElementDeclarationResult] of the given [element].
+///
+/// Uses the [resolver] to avoid an `InconsistentAnalysisException`.
 Future<ElementDeclarationResult> _getDeclaration(
     Element element, Resolver resolver) async {
   final resolvedLibrary = await _getResolvedLibrary(element.library, resolver);
   return resolvedLibrary.getElementDeclaration(element);
 }
 
+/// Return the [ResolvedLibraryResult] of the given [library].
+///
+/// Uses the [resolver] to resolve the library from the asset ID of the
+/// given [library], thus avoiding an `InconsistentAnalysisException`
+/// which will be thrown if we use `library.session` directly.
 Future<ResolvedLibraryResult> _getResolvedLibrary(
     LibraryElement library, Resolver resolver) async {
   // This is expensive, but seems to be necessary. It is using the workaround

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -21,5 +21,5 @@ dependencies:
   source_span: ^1.5.0
 dev_dependencies:
   build_test: ^1.2.0
-  pedantic: ^1.8.0
+  pedantic: ^1.9.0
   test: ^1.9.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.2.5
+version: 2.2.6
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
@@ -7,12 +7,12 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=2.3.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.39.4 <=0.39.10'
+  analyzer: '>=0.39.4 <=0.39.17'
   build: ^1.3.0
   build_resolvers: ^1.3.0
   build_config: ^0.4.0
   build_runner: ^1.10.0
-  build_runner_core: ^5.2.0
+  build_runner_core: ^6.0.0
   dart_style: ^1.3.0
   glob: ^1.2.0
   logging: ^0.11.0


### PR DESCRIPTION
Issue #198 reports an `InconsistentAnalysisException` when code generation is performed with more than one entry point. A workaround came up in dart-lang/build#2634, and this PR uses that workaround, which does eliminate the dynamic errors. Prepared to publish as version 2.2.6.