### PR TITLE
Fix constant evaluator invocation

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.8
+
+* Update dependencies to include analyzer 0.40.4, with 0.40.3 as lower bound
+  because of a breaking change.
+
 ## 2.2.7
 
 * Update dependencies to support analyzers up to version 0.40.3.

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -1867,7 +1867,8 @@ class _ReflectorDomain {
       [Set<String> typeVariablesInScope]) {
     if (type is TypeParameterType &&
         (typeVariablesInScope == null ||
-            !typeVariablesInScope.contains(type.getDisplayString()))) {
+            !typeVariablesInScope
+                .contains(type.getDisplayString(withNullability: false)))) {
       return false;
     }
     if (type is InterfaceType) {
@@ -2007,8 +2008,9 @@ class _ReflectorDomain {
       }
     } else if (dartType is TypeParameterType &&
         typeVariablesInScope != null &&
-        typeVariablesInScope.contains(dartType.getDisplayString())) {
-      return dartType.getDisplayString();
+        typeVariablesInScope
+            .contains(dartType.getDisplayString(withNullability: false))) {
+      return dartType.getDisplayString(withNullability: false);
     } else {
       return fail();
     }
@@ -3875,7 +3877,7 @@ class BuilderImplementation {
     if (dartType.element is! ClassElement) {
       await _severe(
           errors.applyTemplate(errors.SUPER_ARGUMENT_NON_CLASS,
-              {'type': dartType.getDisplayString()}),
+              {'type': dartType.getDisplayString(withNullability: false)}),
           dartType.element);
       return ec.invokingCapability; // Error default.
     }
@@ -5211,16 +5213,6 @@ class MixinApplication implements ClassElement {
   @override
   bool get isSynthetic => declaredName == null;
 
-  // The `InterfaceTypeImpl` may well call methods on this `MixinApplication`
-  // whose body is unimplemented, but it still provides a slightly better
-  // service than leaving this method unimplemented. We are then allowed to
-  // take one more step, which may be enough.
-  @override
-  InterfaceType get type => InterfaceTypeImpl(
-      element: this,
-      typeArguments: [],
-      nullabilitySuffix: NullabilitySuffix.star);
-
   @override
   InterfaceType instantiate({
     List<DartType> typeArguments,
@@ -5338,8 +5330,7 @@ bool _isPrivateName(String name) {
 
 EvaluationResult _evaluateConstant(
     LibraryElement library, Expression expression) {
-  return ConstantEvaluator(library.source, library.typeProvider)
-      .evaluate(expression);
+  return ConstantEvaluator(library.source, library).evaluate(expression);
 }
 
 /// Returns the result of evaluating [elementAnnotation].

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.2.7
+version: 2.2.8
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
@@ -7,7 +7,7 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=2.3.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.39.4 <=0.40.3'
+  analyzer: '>=0.40.0 <=0.40.4'
   build: ^1.3.0
   build_resolvers: ^1.3.0
   build_config: ^0.4.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://www.github.com/dart-lang/reflectable
 environment:
   sdk: '>=2.3.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.40.0 <=0.40.4'
+  analyzer: '>=0.40.3 <=0.40.4'
   build: ^1.3.0
   build_resolvers: ^1.3.0
   build_config: ^0.4.0

--- a/test_reflectable/pubspec.yaml
+++ b/test_reflectable/pubspec.yaml
@@ -10,11 +10,11 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 dependencies:
   build_runner: any
-  glob: ^1.2.0
+  glob: any
   reflectable:
     path: ../reflectable
 dev_dependencies:
-  analyzer: '>=0.39.4 <=0.40.3'
-  build_test: ^1.2.0
+  analyzer: '>=0.40.3 <=0.40.4'
+  build_test: any
   pedantic: any
   test: any

--- a/test_reflectable/pubspec.yaml
+++ b/test_reflectable/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   reflectable:
     path: ../reflectable
 dev_dependencies:
-  analyzer: '>=0.40.3 <=0.40.4'
+  analyzer: any
   build_test: any
   pedantic: any
   test: any


### PR DESCRIPTION
Unfortunately, the published version 2.2.7 allows analyzer 0.40.3, but that version has a breaking change (affecting `ConstantEvaluator(..., ... /*This argument*/)`), so 2.2.7 only works with analyzers up to 0.40.2. This PR prepares publishing 2.2.8 which adapts the code to work after said change, and supports analyzer 0.40.3 - 0.40.4.