### PR TITLE
Update analyzer version and fix 198, 227

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 * Change `build.yaml` to ensure that 'lib/main.dart' will again be considered
   an entry point for code generation.
-* Update dependencies to include analyzer 0.40.5, 0.40.6.
-* Re-fixing issue #198, cf. google/built_value.dart issue #941.
+* Update dependencies to include analyzer 0.40.5, 0.40.6, 0.41.0, 0.41.1.
+* Re-fixing issue #198, cf. `google/built_value.dart` issue #941.
 
 ## 2.2.8
 

--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Change `build.yaml` to ensure that 'lib/main.dart' will again be considered
   an entry point for code generation.
+* Update dependencies to include analyzer 0.40.5, 0.40.6.
+* Re-fixing issue #198, cf. google/built_value.dart issue #941.
 
 ## 2.2.8
 

--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.9
+
+* Change `build.yaml` to ensure that 'lib/main.dart' will again be considered
+  an entry point for code generation.
+
 ## 2.2.8
 
 * Update dependencies to include analyzer 0.40.4, with 0.40.3 as lower bound

--- a/reflectable/build.yaml
+++ b/reflectable/build.yaml
@@ -8,8 +8,6 @@ builders:
     build_to: source
     defaults:
       generate_for:
-        exclude:
-        - lib/**.dart
         include:
         - benchmark/**.dart
         - bin/**.dart

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -5429,7 +5429,11 @@ Future<ResolvedLibraryResult> _getResolvedLibrary(
   // This is expensive, but seems to be necessary. It is using the workaround
   // mentioned in dart-lang/build#2634. If we do not fetch a fresh session
   // then the code generation stops with an `InconsistentAnalysisException`
-  // if there is more than one entry point.
+  // if there is more than one entry point. This workaround turned out to be
+  // insufficient with analyzer 0.40.5, and the while loop was proposed as a
+  // workaround to the workaround in
+  //   https://github.com/google/built_value.dart/issues/
+  //   941#issuecomment-731077220.
   var attempts = 0;
   while (true) {
     try {
@@ -5440,7 +5444,8 @@ Future<ResolvedLibraryResult> _getResolvedLibrary(
     } catch (_) {
       ++attempts;
       if (attempts == 10) {
-        log.severe('Analysis session did not stabilize after ten tries!');
+        log.severe('Internal error: Analysis session '
+          'did not stabilize after ten attempts!');
         return null;
       }
     }

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -695,8 +695,8 @@ class _ReflectorDomain {
     if (constructor.library.isDartCore &&
         constructor.enclosingElement.name == 'List' &&
         constructor.name == '') {
-      return '(b) => ([length]) => '
-          'b ? (length == null ? List() : List(length)) : null';
+      return '(bool b) => ([length]) => '
+          'b ? (length == null ? [] : List.filled(length, null)) : null';
     }
 
     String positionals =
@@ -755,7 +755,7 @@ class _ReflectorDomain {
     }
 
     String prefix = importCollector._getPrefix(constructor.library);
-    return ('($doRunArgument) => (${parameterParts.join(', ')}) => '
+    return ('(bool $doRunArgument) => (${parameterParts.join(', ')}) => '
         '$doRunArgument ? $prefix${await _nameOfConstructor(constructor)}'
         '(${argumentParts.join(', ')}) : null');
   }
@@ -2582,7 +2582,7 @@ Future<String> _staticSettingClosure(_ImportCollector importCollector,
   if (_isPrivateName(className)) {
     await _severe('Cannot access private name $className', classElement);
   }
-  return "r'$setterName': (value) => $prefix$className.$name = value";
+  return "r'$setterName': (dynamic value) => $prefix$className.$name = value";
 }
 
 // Auxiliary function used by `_generateCode`.
@@ -2606,7 +2606,7 @@ Future<String> _topLevelSettingClosure(_ImportCollector importCollector,
   if (_isPrivateName(name)) {
     await _severe('Cannot access private name $name', library);
   }
-  return "r'$setterName': (value) => $prefix$name = value";
+  return "r'$setterName': (dynamic value) => $prefix$name = value";
 }
 
 // Auxiliary function used by `_typeCodeIndex`.

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=2.7.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.40.3 <=0.40.6'
+  analyzer: '>=0.40.3 <=0.41.1'
   build: ^1.3.0
   build_resolvers: ^1.3.0
   build_config: ^0.4.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,13 +1,13 @@
 name: reflectable
-version: 2.2.8
+version: 2.2.9
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
-homepage: https://www.github.com/dart-lang/reflectable
+homepage: https://github.com/google/reflectable.dart
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 dependencies:
-  analyzer: '>=0.40.3 <=0.40.4'
+  analyzer: '>=0.40.3 <=0.40.6'
   build: ^1.3.0
   build_resolvers: ^1.3.0
   build_config: ^0.4.0

--- a/test_reflectable/test/annotated_classes_test.dart
+++ b/test_reflectable/test/annotated_classes_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.annotated_classes_test;
 

--- a/test_reflectable/test/basic_test.dart
+++ b/test_reflectable/test/basic_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 // Tests some basic functionality of instance mirrors and class mirrors.
 

--- a/test_reflectable/test/capabilities_test.dart
+++ b/test_reflectable/test/capabilities_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 // Tests that reflection is constrained according to capabilities.
 // TODO(sigurdm) implement: Write tests that covers all capabilities.

--- a/test_reflectable/test/class_property_test.dart
+++ b/test_reflectable/test/class_property_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses class properties such as `isEnum`, `isOriginalDeclaration`, etc.

--- a/test_reflectable/test/corresponding_setter_test.dart
+++ b/test_reflectable/test/corresponding_setter_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 /// File used to test reflectable code generation.
 /// Uses `correspondingSetterCapability` to get support for setters.

--- a/test_reflectable/test/declarations_test.dart
+++ b/test_reflectable/test/declarations_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.declarations_test;
 

--- a/test_reflectable/test/default_values_lib.dart
+++ b/test_reflectable/test/default_values_lib.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Used from 'default_values_test.dart' in order to test the situation

--- a/test_reflectable/test/default_values_test.dart
+++ b/test_reflectable/test/default_values_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses default values.

--- a/test_reflectable/test/delegate_test.dart
+++ b/test_reflectable/test/delegate_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses `delegate`.

--- a/test_reflectable/test/dynamic_reflected_type_test.dart
+++ b/test_reflectable/test/dynamic_reflected_type_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses `dynamicReflectedType`.

--- a/test_reflectable/test/enum_test.dart
+++ b/test_reflectable/test/enum_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 /// File used to test reflectable code generation.
 /// Based on https://github.com/dart-lang/reflectable/issues/80.

--- a/test_reflectable/test/expanding_generics_test.dart
+++ b/test_reflectable/test/expanding_generics_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Checks that the occurrence of an expanding generic type (where

--- a/test_reflectable/test/export_test.dart
+++ b/test_reflectable/test/export_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Imports the core file of this package and re-exports

--- a/test_reflectable/test/exported_main_lib.dart
+++ b/test_reflectable/test/exported_main_lib.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // This file illustrates a peculiar situation: The `main` function which
 // defines the behavior of the program 'exported_main_test.dart' is not

--- a/test_reflectable/test/exported_main_test.dart
+++ b/test_reflectable/test/exported_main_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // Test that the transformation works with an exported main from another
 // library.

--- a/test_reflectable/test/field_test.dart
+++ b/test_reflectable/test/field_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Accesses the types of instance fields and static fields.

--- a/test_reflectable/test/function_type_annotation_test.dart
+++ b/test_reflectable/test/function_type_annotation_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses a function type in type annotations.

--- a/test_reflectable/test/generic_mixin_test.dart
+++ b/test_reflectable/test/generic_mixin_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses a generic mixin.

--- a/test_reflectable/test/global_quantify_test.dart
+++ b/test_reflectable/test/global_quantify_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.global_quantify_test;
 

--- a/test_reflectable/test/implicit_getter_setter_test.dart
+++ b/test_reflectable/test/implicit_getter_setter_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Explores properties of implicit getters and setters.

--- a/test_reflectable/test/import_reflectable.dart
+++ b/test_reflectable/test/import_reflectable.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Imports the core file of this package.

--- a/test_reflectable/test/inherited_variable_test.dart
+++ b/test_reflectable/test/inherited_variable_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses a getter/setter for a variable which is inherited

--- a/test_reflectable/test/invoke_capabilities_test.dart
+++ b/test_reflectable/test/invoke_capabilities_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.invoke_capabilities_test;
 

--- a/test_reflectable/test/invoke_test.dart
+++ b/test_reflectable/test/invoke_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses `invoke`.

--- a/test_reflectable/test/invoker_operator_test.dart
+++ b/test_reflectable/test/invoker_operator_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses `invoker` on operators.

--- a/test_reflectable/test/invoker_test.dart
+++ b/test_reflectable/test/invoker_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses `invoker` on methods with various argument list shapes.

--- a/test_reflectable/test/libraries_test.dart
+++ b/test_reflectable/test/libraries_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses library mirrors and `invoke` on top level entities.

--- a/test_reflectable/test/library_declarations_test.dart
+++ b/test_reflectable/test/library_declarations_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2019, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Looks up the top-level declarations in a library.

--- a/test_reflectable/test/literal_type_arguments_test.dart
+++ b/test_reflectable/test/literal_type_arguments_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 /// Tests that type arguments given to literal lists and maps are preserved
 /// when such objects are delivered as `metadata`.

--- a/test_reflectable/test/member_capability_test.dart
+++ b/test_reflectable/test/member_capability_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses 'reflect', with a constraint to invocation based on

--- a/test_reflectable/test/meta_reflector_test.dart
+++ b/test_reflectable/test/meta_reflector_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 /// File used to test reflectable code generation.
 /// Creates a `MetaReflector` which may be used to reflect on the set of

--- a/test_reflectable/test/meta_reflectors_definer.dart
+++ b/test_reflectable/test/meta_reflectors_definer.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 /// File used to test reflectable code generation.
 /// Part of the entry point 'meta_reflectors_test.dart'.

--- a/test_reflectable/test/meta_reflectors_domain.dart
+++ b/test_reflectable/test/meta_reflectors_domain.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 /// File used to test reflectable code generation.
 /// Part of the entry point 'meta_reflectors_test.dart'.

--- a/test_reflectable/test/meta_reflectors_domain_definer.dart
+++ b/test_reflectable/test/meta_reflectors_domain_definer.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 /// File used to test reflectable code generation.
 /// Part of the entry point 'meta_reflectors_test.dart'.

--- a/test_reflectable/test/meta_reflectors_meta.dart
+++ b/test_reflectable/test/meta_reflectors_meta.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 /// File used to test reflectable code generation.
 /// Part of the entry point 'meta_reflectors_test.dart'.

--- a/test_reflectable/test/meta_reflectors_test.dart
+++ b/test_reflectable/test/meta_reflectors_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 /// File used to test reflectable code generation.
 /// Creates a `MetaReflector` which may be used to reflect on the set of

--- a/test_reflectable/test/meta_reflectors_user.dart
+++ b/test_reflectable/test/meta_reflectors_user.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Part of the entry point 'reflectors_test.dart'.

--- a/test_reflectable/test/metadata_name_clash_lib.dart
+++ b/test_reflectable/test/metadata_name_clash_lib.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.metadata_name_clash_lib;
 

--- a/test_reflectable/test/metadata_name_clash_test.dart
+++ b/test_reflectable/test/metadata_name_clash_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.metadata_name_clash_test;
 

--- a/test_reflectable/test/metadata_subtype_test.dart
+++ b/test_reflectable/test/metadata_subtype_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 /// Tests that metadata used to select members is recognized when it is a
 /// proper subtype of the metadata type specified in a [..MetaCapability].

--- a/test_reflectable/test/metadata_test.dart
+++ b/test_reflectable/test/metadata_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 /// Tests that metadata is preserved when the metadataCapability is present.
 // TODO(sigurdm) implement: Support for metadata-annotations of arguments.

--- a/test_reflectable/test/mixin_application_static_invoke_test.dart
+++ b/test_reflectable/test/mixin_application_static_invoke_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.mixin_application_static_invoke_test;
 

--- a/test_reflectable/test/mixin_application_static_member_test.dart
+++ b/test_reflectable/test/mixin_application_static_member_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.mixin_application_static_member_test;
 

--- a/test_reflectable/test/mixin_static_const_test.dart
+++ b/test_reflectable/test/mixin_static_const_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.mixin_static_const_test;
 

--- a/test_reflectable/test/mixin_test.dart
+++ b/test_reflectable/test/mixin_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.mixin_test;
 

--- a/test_reflectable/test/multi_field_test.dart
+++ b/test_reflectable/test/multi_field_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses multiple fields declared with a shared type annotation.

--- a/test_reflectable/test/name_clash_lib.dart
+++ b/test_reflectable/test/name_clash_lib.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.name_clash_lib;
 

--- a/test_reflectable/test/name_clash_test.dart
+++ b/test_reflectable/test/name_clash_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.name_clash_test;
 

--- a/test_reflectable/test/new_instance_default_values_test.dart
+++ b/test_reflectable/test/new_instance_default_values_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses default values on optional arguments.

--- a/test_reflectable/test/new_instance_native_test.dart
+++ b/test_reflectable/test/new_instance_native_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 // Based on https://github.com/dart-lang/sdk/issues/18541; ported to fit in
 // reflectable: Changed symbols to strings; added reflector and quantifier;

--- a/test_reflectable/test/new_instance_optional_arguments_test.dart
+++ b/test_reflectable/test/new_instance_optional_arguments_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 // Dealing with sdk issue #19635, 'Mirrors: newInstance on constructor with
 // optional parameters result in crash when running as JavaScript'.

--- a/test_reflectable/test/new_instance_test.dart
+++ b/test_reflectable/test/new_instance_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses `newInstance`.

--- a/test_reflectable/test/no_such_capability_test.dart
+++ b/test_reflectable/test/no_such_capability_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.no_such_capability_test;
 

--- a/test_reflectable/test/no_such_method_test.dart
+++ b/test_reflectable/test/no_such_method_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses a generic mixin.

--- a/test_reflectable/test/no_type_relations_test.dart
+++ b/test_reflectable/test/no_type_relations_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses type relations without a `typeRelations` capability.

--- a/test_reflectable/test/not_loaded_lib.dart
+++ b/test_reflectable/test/not_loaded_lib.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2017, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Tests that `targetLibrary` can be null.

--- a/test_reflectable/test/original_prefix_test.dart
+++ b/test_reflectable/test/original_prefix_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses a declaration from the original main file (this one)

--- a/test_reflectable/test/parameter_mirrors_lib.dart
+++ b/test_reflectable/test/parameter_mirrors_lib.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.parameter_mirrors_lib;
 

--- a/test_reflectable/test/parameter_mirrors_test.dart
+++ b/test_reflectable/test/parameter_mirrors_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.parameter_mirrors_test;
 

--- a/test_reflectable/test/parameter_test.dart
+++ b/test_reflectable/test/parameter_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Accesses method parameters and their properties, such as

--- a/test_reflectable/test/polymer_basic_needs_test.dart
+++ b/test_reflectable/test/polymer_basic_needs_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 // Testing the basic set of features that are needed for polymer.
 

--- a/test_reflectable/test/prefixed_annotation_lib.dart
+++ b/test_reflectable/test/prefixed_annotation_lib.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2018, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.prefixed_annotation_lib;
 

--- a/test_reflectable/test/prefixed_annotation_test.dart
+++ b/test_reflectable/test/prefixed_annotation_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2018, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses an annotation that denotes a reflector via a prefix.

--- a/test_reflectable/test/prefixed_reflector_test.dart
+++ b/test_reflectable/test/prefixed_reflector_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses a reflector which is accessed via a prefixed identifier.

--- a/test_reflectable/test/private_class_library.dart
+++ b/test_reflectable/test/private_class_library.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 /// File used to test reflectable code generation.
 /// Part of the entry point 'private_class_test.dart'.

--- a/test_reflectable/test/private_class_test.dart
+++ b/test_reflectable/test/private_class_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 /// File used to test reflectable code generation.
 /// Uses public features of an instance of a private class in a different

--- a/test_reflectable/test/proxy_test.dart
+++ b/test_reflectable/test/proxy_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Implements a very simple kind of proxy object.

--- a/test_reflectable/test/reflect_test.dart
+++ b/test_reflectable/test/reflect_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses `reflect`.

--- a/test_reflectable/test/reflect_type_test.dart
+++ b/test_reflectable/test/reflect_type_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.reflect_type_test;
 

--- a/test_reflectable/test/reflected_type_test.dart
+++ b/test_reflectable/test/reflected_type_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses `reflectedType` to access a `Type` value for the type annotation

--- a/test_reflectable/test/reflected_type_void_test.dart
+++ b/test_reflectable/test/reflected_type_void_test.dart
@@ -6,6 +6,8 @@
 // File used to test reflectable code generation.
 // Uses `reflectedType` to access a `Type` value reifying `void`.
 
+// ignore_for_file: omit_local_variable_types
+
 library test_reflectable.test.reflect_type_void;
 
 import 'package:reflectable/reflectable.dart';

--- a/test_reflectable/test/reflected_type_void_test.dart
+++ b/test_reflectable/test/reflected_type_void_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2020, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses `reflectedType` to access a `Type` value reifying `void`.

--- a/test_reflectable/test/reflectors_test.dart
+++ b/test_reflectable/test/reflectors_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 /// File used to test reflectable code generation.
 /// Creates an `AllReflectorsMetaReflector` which may be used to reflect on

--- a/test_reflectable/test/serialize_test.dart
+++ b/test_reflectable/test/serialize_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.serialize_test;
 

--- a/test_reflectable/test/static_members_test.dart
+++ b/test_reflectable/test/static_members_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses `staticMembers` to access a static const variable.

--- a/test_reflectable/test/static_type_arguments_test.dart
+++ b/test_reflectable/test/static_type_arguments_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 // Test `reflectedTypeArguments` and `typeArguments` on statically known
 // type annotations.

--- a/test_reflectable/test/subtype_quantify_test.dart
+++ b/test_reflectable/test/subtype_quantify_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.subtype_quantify_test;
 

--- a/test_reflectable/test/subtype_test.dart
+++ b/test_reflectable/test/subtype_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses `isSubtypeOf` and `isAssignableTo`.

--- a/test_reflectable/test/superinterfaces_test.dart
+++ b/test_reflectable/test/superinterfaces_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 library test_reflectable.test.superinterfaces_test;
 

--- a/test_reflectable/test/three_files_dir/three_files_aux.dart
+++ b/test_reflectable/test/three_files_dir/three_files_aux.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File being transformed by the reflectable transformer.
 // Uses 'reflect' across file and directory boundaries.  This is an

--- a/test_reflectable/test/three_files_meta.dart
+++ b/test_reflectable/test/three_files_meta.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses 'reflect' across file boundaries.  Provider of the

--- a/test_reflectable/test/three_files_test.dart
+++ b/test_reflectable/test/three_files_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses 'reflect' across file boundaries.  Main file of program.

--- a/test_reflectable/test/type_relations_test.dart
+++ b/test_reflectable/test/type_relations_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses `typeRelations` capability.

--- a/test_reflectable/test/type_variable_test.dart
+++ b/test_reflectable/test/type_variable_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Uses type variables.

--- a/test_reflectable/test/unused_reflector_test.dart
+++ b/test_reflectable/test/unused_reflector_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Defines a reflector that is never used as a reflector; causes a

--- a/test_reflectable/test/use_annotation.dart
+++ b/test_reflectable/test/use_annotation.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Imports the core file of this package and uses the

--- a/test_reflectable/test/use_prefix_test.dart
+++ b/test_reflectable/test/use_prefix_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
+// @dart=2.9
 
 // File used to test reflectable code generation.
 // Imports the core file of this package and gives it a


### PR DESCRIPTION
Update analyzer dependency to allow all versions until breaking change in 0.41.0. Issue #227 reports that 'lib/main.dart' is skipped during code generation; this PR fixes that. Issue #198 about `InconsistentAnalysisException` re-emerged with analyzer 0.40.5, workaround from https://github.com/google/built_value.dart/issues/941 adopted.

This PR also adds `// @dart=2.9` to tests, because they do not get the language version from the pubspec.yaml.

New patchset uploaded Dec 3rd: Package `build` was updated and analyzer 0.41.0, 0.41.1 are now working. Changed pubspec.yaml and CHANGELOG.md accordingly.