### PR TITLE
Use new `Resolver.astNodeFor` method to avoid workaround

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.10
+
+* Change code generation to use new `Resolver.astNodeFor` method, eliminating
+  the `InconsistentAnalysisException` workaround in most cases.
+* Prevent unnecessary code generation for inputs named `*.vm_test.*`, 
+  `*.node_test.*`, or `*.browser_test.*`, to reduce code generation time.
+
 ## 2.2.9
 
 * Change `build.yaml` to ensure that 'lib/main.dart' will again be considered

--- a/reflectable/lib/reflectable_builder.dart
+++ b/reflectable/lib/reflectable_builder.dart
@@ -17,6 +17,10 @@ class ReflectableBuilder implements Builder {
 
   @override
   Future<void> build(BuildStep buildStep) async {
+    var targetId = buildStep.inputId.toString();
+    if (targetId.contains('.vm_test.') ||
+      targetId.contains('.node_test.') ||
+      targetId.contains('.browser_test.')) return;
     var inputLibrary = await buildStep.inputLibrary;
     var resolver = buildStep.resolver;
     var inputId = buildStep.inputId;

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 2.2.9
+version: 2.2.10
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.7.0 <3.0.0'
 dependencies:
   analyzer: '>=0.40.3 <=0.41.1'
-  build: ^1.3.0
+  build: ^1.6.0
   build_resolvers: ^1.3.0
   build_config: ^0.4.0
   build_runner: ^1.10.0


### PR DESCRIPTION
Change code generation to use new `Resolver.astNodeFor` method, eliminating the `InconsistentAnalysisException` workaround in most cases, cf. https://github.com/dart-lang/build/pull/2947. Also prevent unnecessary code generation for inputs named `*.vm_test.*`, `*.node_test.*`, or `*.browser_test.*`, to reduce code generation time to about half of the current time.
