### PR TITLE
Use nullsafe build, migrate to null safety

### DIFF
--- a/reflectable/lib/reflectable_builder.dart
+++ b/reflectable/lib/reflectable_builder.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2017, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
-// @dart = 2.9
 
 library reflectable.reflectable_builder;
 

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -1259,12 +1259,12 @@ class _ReflectorDomain {
     return result;
   }
 
-  Future<int> _computeOwnerIndex(
+  Future<int?> _computeOwnerIndex(
       ExecutableElement element, int descriptor) async {
     if (element.enclosingElement is ClassElement) {
-      return (await classes).indexOf(element.enclosingElement)!;
+      return (await classes).indexOf(element.enclosingElement);
     } else if (element.enclosingElement is CompilationUnitElement) {
-      return _libraries.indexOf(element.enclosingElement.enclosingElement!)!;
+      return _libraries.indexOf(element.enclosingElement.enclosingElement!);
     }
     await _severe('Unexpected kind of request for owner');
     return 0;
@@ -1628,7 +1628,8 @@ class _ReflectorDomain {
       // getter or setter.
       int descriptor = _declarationDescriptor(element);
       int returnTypeIndex = await _computeReturnTypeIndex(element, descriptor);
-      int ownerIndex = (await _computeOwnerIndex(element, descriptor));
+      int ownerIndex = (await _computeOwnerIndex(element, descriptor)) ??
+          constants.NO_CAPABILITY_INDEX;
       String reflectedTypeArgumentsOfReturnType = 'null';
       if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
         reflectedTypeArgumentsOfReturnType =
@@ -2507,23 +2508,23 @@ class _AnnotationClassFixedPoint extends FixedPoint<ClassElement> {
     // abstract the many redundant elements below, because `yield` cannot
     // occur in a local function.
     for (FieldElement fieldElement in classDomain._declaredFields) {
-      Element fieldType = fieldElement.type.element!;
+      Element? fieldType = fieldElement.type.element;
       if (fieldType is ClassElement) result.add(fieldType);
     }
     for (ParameterElement parameterElement in classDomain._declaredParameters) {
-      Element parameterType = parameterElement.type.element!;
+      Element? parameterType = parameterElement.type.element;
       if (parameterType is ClassElement) result.add(parameterType);
     }
     for (ParameterElement parameterElement in classDomain._instanceParameters) {
-      Element parameterType = parameterElement.type.element!;
+      Element? parameterType = parameterElement.type.element;
       if (parameterType is ClassElement) result.add(parameterType);
     }
     for (ExecutableElement executableElement in classDomain._declaredMethods) {
-      Element returnType = executableElement.returnType.element!;
+      Element? returnType = executableElement.returnType.element;
       if (returnType is ClassElement) result.add(returnType);
     }
     for (ExecutableElement executableElement in classDomain._instanceMembers) {
-      Element returnType = executableElement.returnType.element!;
+      Element? returnType = executableElement.returnType.element;
       if (returnType is ClassElement) result.add(returnType);
     }
     return result;
@@ -5227,8 +5228,7 @@ Future<Uri> _getImportUri(
   }
   // Should not encounter any other source types.
   await _severe('Unable to resolve URI for ${source.runtimeType}');
-  return Uri.parse(
-      'package:${from.package}/${from.path}');
+  return Uri.parse('package:${from.package}/${from.path}');
 }
 
 /// Modelling a mixin application as a [ClassElement].

--- a/reflectable/lib/src/element_capability.dart
+++ b/reflectable/lib/src/element_capability.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2015, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
-// @dart = 2.9
 
 library reflectable.src.element_capability;
 
@@ -200,7 +199,7 @@ abstract class ReflecteeQuantifyCapability implements ReflectCapability {
 const subtypeQuantifyCapability = _SubtypeQuantifyCapability();
 
 class SuperclassQuantifyCapability implements ReflecteeQuantifyCapability {
-  final Element upperBound;
+  final Element? upperBound;
   final bool excludeUpperBound;
   const SuperclassQuantifyCapability(this.upperBound,
       {bool excludeUpperBound = false})

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 3.0.1
+version: 3.0.2
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
@@ -10,9 +10,9 @@ dependencies:
   analyzer: '^1.1.0'
   build: ^2.0.0
   build_resolvers: ^2.0.0
-  build_config: ^0.4.0
-  build_runner: ^1.10.0
-  build_runner_core: ^6.0.0
+  build_config: ^1.0.0
+  build_runner: ^2.0.1
+  build_runner_core: ^7.0.0
   dart_style: ^2.0.0
   glob: ^2.0.0
   logging: ^1.0.0

--- a/test_reflectable/tool/Makefile
+++ b/test_reflectable/tool/Makefile
@@ -25,10 +25,10 @@ t: test
 cb: clean get build
 
 get:
-	( cd ..; pub get )
+	( cd ..; dart pub get )
 
 upgrade:
-	( cd ..; pub upgrade )
+	( cd ..; dart pub upgrade )
 
 check:
 	( cd ..; dartanalyzer $(OPTIONS) {lib,test{,/legacy}}/*.dart )
@@ -37,10 +37,10 @@ measure_output: build
 	@./measure_output --include-js --include-source-tree --include-unminified
 
 build:
-	( cd ..; pub run build_runner build )
+	( cd ..; dart run build_runner build )
 
 test:
-	( cd ..; pub run test )
+	( cd ..; dart run test )
 
 clean:
 	( rm -rf ../.dart_tool )

--- a/test_reflectable/tool/Makefile
+++ b/test_reflectable/tool/Makefile
@@ -40,7 +40,7 @@ build:
 	( cd ..; dart run build_runner build )
 
 test:
-	( cd ..; dart run test )
+	( cd ..; dart test )
 
 clean:
 	( rm -rf ../.dart_tool )


### PR DESCRIPTION
This PR migrates the reflectable code generator to null safety, and it uses the newly arrived null safe versions of build packages, such that reflectable is fully opted in to null safety.

In general, nulls that arise because the program does not pass static analysis are asserted (so there are lots of ways that the code generation will crash with a null error if we run it on a program with errors). We may wish to change this later on, to avoid all those possible crashes.

However, it does not seem useful to replicate a large portion of error messages about Dart errors in any code generator, because it's just a duplicate of something that we already have in a much more complete form in the analyzer and the CFE. 

The best approach would probably be to ask the analyzer on startup whether this program has any errors, and only generate code if not.
