### PR TITLE
Remove pre-release deps (those packages do have a stable release now)

### DIFF
--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -17,8 +17,8 @@ dependencies:
   glob: ^2.0.0
   logging: ^1.0.0
   package_config: ^2.0.0
-  path: ^1.8.0-nullsafety
-  source_span: ^1.8.0-nullsafety
+  path: ^1.8.0
+  source_span: ^1.8.1
 dev_dependencies:
   build_test: ^2.0.0
   pedantic: ^1.10.0-nullsafety


### PR DESCRIPTION
Change pubspec.yaml to avoid depending on any versions of the form `*-nullsafety` (those packages do have a regular version with null safety now, and `pub publish` complains).