### PR TITLE
Fix a null error; update dependencies

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.3
+
+* Update dependencies: analyzer: ^2.0.0
+* Fix issue #253.
+
 ## 3.0.2
 
 * Migrate the code generator. The reflectable package is hereby fully migrated

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -123,7 +123,7 @@ class ReflectionWorld {
       }
 
       for (CompilationUnitElement unit in library.units) {
-        unit.types.forEach(addClassElement);
+        unit.classes.forEach(addClassElement);
         unit.enums.forEach(addClassElement);
       }
     }
@@ -3325,7 +3325,7 @@ class BuilderImplementation {
   Future<ClassElement?> _findReflectableClassElement(
       LibraryElement reflectableLibrary) async {
     for (CompilationUnitElement unit in reflectableLibrary.units) {
-      for (ClassElement type in unit.types) {
+      for (ClassElement type in unit.classes) {
         if (type.name == reflectable_class_constants.name &&
             _equalsClassReflectable(type)) {
           return type;
@@ -3806,7 +3806,7 @@ class BuilderImplementation {
       }
 
       for (CompilationUnitElement unit in library.units) {
-        for (ClassElement type in unit.types) {
+        for (ClassElement type in unit.classes) {
           for (ClassElement reflector
               in await getReflectors(_qualifiedName(type), type.metadata)) {
             await addClassDomain(type, reflector);
@@ -3891,7 +3891,7 @@ class BuilderImplementation {
       return ec.invokingCapability; // Error default.
     }
 
-    ParameterizedType dartType = constant.type!;
+    DartType dartType = constant.type!;
     // We insist that the type must be a class, and we insist that it must
     // be in the given `capabilityLibrary` (because we could never know
     // how to interpret the meaning of a user-written capability class, so
@@ -4228,8 +4228,7 @@ void initializeReflectable() {
     _libraries = visibleLibraries;
 
     for (LibraryElement library in _libraries) {
-      var libraryName = library.name;
-      if (libraryName != null) _librariesByName[libraryName] = library;
+      _librariesByName[library.name] = library;
     }
     LibraryElement? reflectableLibrary =
         _librariesByName['reflectable.reflectable'];
@@ -4789,7 +4788,7 @@ NodeList<Annotation>? _getOtherMetadata(AstNode? node, Element element) {
 
 /// Returns a String with the code used to build the metadata of [element].
 ///
-/// Also adds any neccessary imports to [importCollector].
+/// Also adds any necessary imports to [importCollector].
 Future<String> _extractMetadataCode(Element element, Resolver resolver,
     _ImportCollector importCollector, AssetId dataId) async {
   // Synthetic accessors do not have metadata. Only their associated fields.
@@ -5474,8 +5473,8 @@ Future<String> _formatDiagnosticMessage(
       !_isPlatformLibrary(targetLibrary)) {
     final resolvedLibrary = await _getResolvedLibrary(targetLibrary, resolver);
     if (resolvedLibrary != null) {
-      final targetDeclaration = resolvedLibrary.getElementDeclaration(target!)!;
-      final unit = targetDeclaration.resolvedUnit?.unit;
+      final targetDeclaration = resolvedLibrary.getElementDeclaration(target!);
+      final unit = targetDeclaration?.resolvedUnit?.unit;
       final location = unit?.lineInfo?.getLocation(nameOffset);
       if (location != null) {
         locationString = '${location.lineNumber}:${location.columnNumber}';

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 3.0.2
+version: 3.0.3
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  analyzer: '^1.1.0'
+  analyzer: ^2.0.0
   build: ^2.0.0
   build_resolvers: ^2.0.0
   build_config: ^1.0.0

--- a/test_reflectable/test/parameter_mirrors_test.dart
+++ b/test_reflectable/test/parameter_mirrors_test.dart
@@ -128,7 +128,7 @@ void main() {
     expect(constructorParameters[0].hasDefaultValue, true);
     expect(constructorParameters[0].defaultValue, 42);
     expect(constructorParameters[0].isConst, false);
-    expect(constructorParameters[0].isFinal, false);
+    expect(constructorParameters[0].isFinal, true);
     expect(constructorParameters[0].isStatic, false);
     expect(constructorParameters[0].isOptional, true);
     expect(constructorParameters[0].isTopLevel, false);


### PR DESCRIPTION
Remove a `!` and handle the null which may actually occur (fixing #253). Change the analyzer dependency to ^2.0.0, and perform a handful of changes that follow from this.

One test was changed (presumably a bug was fixed in the analyzer): An initializing formal parameter is now reported to be final, and a test expectation has been changed to reflect this new behavior.
