### PR TITLE
Issue 255

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.4
 
-* Improve diagnostics for top-level variable, cf. issue 255.
+* Fix the bug reported as #255.
 
 ## 3.0.3
 

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -1264,7 +1264,7 @@ class _ReflectorDomain {
     if (element.enclosingElement is ClassElement) {
       return (await classes).indexOf(element.enclosingElement);
     } else if (element.enclosingElement is CompilationUnitElement) {
-      return _libraries.indexOf(element.enclosingElement.enclosingElement!);
+      return _libraries.indexOf(element.library);
     }
     await _severe('Unexpected kind of request for owner');
     return 0;
@@ -1678,18 +1678,9 @@ class _ReflectorDomain {
       Map<FunctionType, int> typedefs,
       bool reflectedTypeRequested) async {
     int descriptor = _topLevelVariableDescriptor(element);
-    var owner = element.enclosingElement?.enclosingElement;
-    if (owner == null) {
-      await _severe(
-        'Encountered a top-level variable ${element.name} '
-        'which has no enclosing library', element);
-    }
+    var owner = element.library;
     var ownerIndex = owner != null ? _libraries.indexOf(owner) : null;
-    if (ownerIndex == null) {
-      await _severe(
-        'Encountered a top-level variable ${element.name} whose enclosing '
-        'library is not available', owner);
-    }
+    if (ownerIndex == null) ownerIndex = constants.NO_CAPABILITY_INDEX;
     int classMirrorIndex = await _computeVariableTypeIndex(element, descriptor);
     int? reflectedTypeIndex = reflectedTypeRequested
         ? _typeCodeIndex(element.type, await classes, reflectedTypes,

--- a/test_reflectable/test/issue_255_test.dart
+++ b/test_reflectable/test/issue_255_test.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Tests a situation where a top level variable needs to have `ownerIndex`
+// `NO_CAPABILITY_INDEX` (because there is no support for accessing the
+// corresponding library mirror). This used to cause a null error.
+
+import 'package:reflectable/reflectable.dart';
+import 'scratch_test.reflectable.dart';
+
+@c
+class C extends Reflectable {
+  const C() : super(topLevelInvokeCapability);
+}
+
+const c = C();
+
+void main() {
+  initializeReflectable();
+}

--- a/test_reflectable/test/issue_255_test.dart
+++ b/test_reflectable/test/issue_255_test.dart
@@ -7,7 +7,7 @@
 // corresponding library mirror). This used to cause a null error.
 
 import 'package:reflectable/reflectable.dart';
-import 'scratch_test.reflectable.dart';
+import 'issue_255_test.reflectable.dart';
 
 @c
 class C extends Reflectable {


### PR DESCRIPTION
Continuation of #256: The issue in #255 is most likely caused by having a top level variable which is located in a library for which there is no reflection support (so we can't create a `LibraryMirror` on that library). It used to be handled by making the `ownerIndex` of said variable null, but this PR changes it to use `NO_CAPABILITY_INDEX` (-1), as we do with other elements that aren't supported by the given capabilities.