### PR TITLE
Update dependencies

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.5
+
+* Update reflectable to require analyzer ^3.0.0 (currently using 3.1.0),
+  and to replace the package `pedantic` by the package `lints`.
+
 ## 3.0.4
 
 * Fix the bug reported as #255.

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -1945,7 +1945,7 @@ class _ReflectorDomain {
     } else if (dartType is VoidType) {
       return 'void';
     } else if (dartType is FunctionType) {
-      final Element? dartTypeElement = dartType.aliasElement;
+      final Element? dartTypeElement = dartType.alias?.element;
       if (dartTypeElement is TypeAliasElement) {
         String prefix = importCollector._getPrefix(dartTypeElement.library);
         return '$prefix${dartTypeElement.name}';
@@ -2068,7 +2068,7 @@ class _ReflectorDomain {
       // A function type is inherently not private, so we ignore privacy.
       // Note that some function types are _claimed_ to be private in analyzer
       // 0.36.4, so it is a bug to test for it.
-      final Element? dartTypeElement = dartType.aliasElement;
+      final Element? dartTypeElement = dartType.alias?.element;
       if (dartTypeElement is TypeAliasElement) {
         String prefix = importCollector._getPrefix(dartTypeElement.library);
         return '$prefix${dartTypeElement.name}';
@@ -4733,12 +4733,12 @@ const Set<String> sdkLibraryNames = <String>{
 // Helper for _extractMetadataCode.
 CompilationUnit? _definingCompilationUnit(
     ResolvedLibraryResult resolvedLibrary) {
-  var definingUnit = resolvedLibrary.element?.definingCompilationUnit;
+  var definingUnit = resolvedLibrary.element.definingCompilationUnit;
   var units = resolvedLibrary.units;
   if (units != null) {
     for (var unit in units) {
-      if (unit.unit?.declaredElement == definingUnit) {
-        return unit.unit!;
+      if (unit.unit.declaredElement == definingUnit) {
+        return unit.unit;
       }
     }
   }
@@ -5523,7 +5523,7 @@ Future<ResolvedLibraryResult?> _getResolvedLibrary(
           await resolver.libraryFor(await resolver.assetIdForElement(library));
       final freshSession = freshLibrary.session;
       var someResult =
-          await freshSession.getResolvedLibraryByElement2(freshLibrary);
+          await freshSession.getResolvedLibraryByElement(freshLibrary);
       if (someResult is ResolvedLibraryResult) return someResult;
     } catch (_) {
       ++attempts;

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 3.0.4
+version: 3.0.5
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  analyzer: ^2.0.0
+  analyzer: ^3.0.0
   build: ^2.0.0
   build_resolvers: ^2.0.0
   build_config: ^1.0.0
@@ -21,5 +21,5 @@ dependencies:
   source_span: ^1.8.1
 dev_dependencies:
   build_test: ^2.0.0
-  pedantic: ^1.10.0-nullsafety
+  lints: ^1.0.0
   test: ^1.16.0-nullsafety

--- a/test_reflectable/pubspec.yaml
+++ b/test_reflectable/pubspec.yaml
@@ -16,5 +16,5 @@ dependencies:
 dev_dependencies:
   analyzer: any
   build_test: any
-  pedantic: any
+  lints: any
   test: ^1.16.0-nullsafety

--- a/test_reflectable/test/corresponding_setter_test.dart
+++ b/test_reflectable/test/corresponding_setter_test.dart
@@ -10,7 +10,6 @@ library test_reflectable.test.corresponding_setter_test;
 
 import 'package:test/test.dart';
 import 'package:reflectable/reflectable.dart';
-import 'package:reflectable/capability.dart';
 import 'corresponding_setter_test.reflectable.dart';
 
 // ignore_for_file: omit_local_variable_types

--- a/test_reflectable/test/legacy/corresponding_setter_test.dart
+++ b/test_reflectable/test/legacy/corresponding_setter_test.dart
@@ -11,7 +11,6 @@ library test_reflectable.test.corresponding_setter_test;
 
 import 'package:test/test.dart';
 import 'package:reflectable/reflectable.dart';
-import 'package:reflectable/capability.dart';
 import 'corresponding_setter_test.reflectable.dart';
 
 // ignore_for_file: omit_local_variable_types


### PR DESCRIPTION
This PR updates reflectable to use analyzer 3.1.0 (requiring 3.0.0, also working with 3.1.0) and it switches from `pedantic` (which is now deprecated) to the recommended replacement `lints`. A few methods have been removed, but there were deprecation messages indicating which method names to use instead.