### PR TITLE
Fix enum constructor and stray null

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.8
+
+* Change code generation such that no invocations of generative constructors
+  of enums are generated (such that it works with 'enhanced-enums').
+
 ## 3.0.7
 
 * Change `analysis_options.yaml` such that we get the same linting locally

--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.9
+
+* Correct bug reported as #267. Correct code generation which is reported
+  as an error now that we have enhanced enums.
+
 ## 3.0.8
 
 * Change code generation such that no invocations of generative constructors

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -1682,7 +1682,8 @@ class _ReflectorDomain {
       bool reflectedTypeRequested) async {
     int descriptor = _topLevelVariableDescriptor(element);
     var owner = element.library;
-    var ownerIndex = _libraries.indexOf(owner);
+    var ownerIndex = _libraries.indexOf(owner) ??
+        constants.noCapabilityIndex;
     int classMirrorIndex = await _computeVariableTypeIndex(element, descriptor);
     int? reflectedTypeIndex = reflectedTypeRequested
         ? _typeCodeIndex(element.type, await classes, reflectedTypes,

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -1415,7 +1415,9 @@ class _ReflectorDomain {
     } else {
       List<String> mapEntries = [];
       for (ConstructorElement constructor in classDomain._constructors) {
-        if (constructor.isFactory || !constructor.enclosingElement.isAbstract) {
+        if (constructor.isFactory ||
+            (!constructor.enclosingElement.isAbstract &&
+                !constructor.enclosingElement.isEnum)) {
           String code = await _constructorCode(constructor, importCollector);
           mapEntries.add("r'${constructor.name}': $code");
         }

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 3.0.7
+version: 3.0.8
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 3.0.8
+version: 3.0.9
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.


### PR DESCRIPTION
This PR fixes #267 (where null was generated where an expression of type `int` is required), and a non-reported bug where a constructor invocation could be generated for an `enum` type. It prepares release 3.0.9 as well.