### PR TITLE
Add support for generic type arguments in annotations

### DIFF
--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -4877,7 +4877,18 @@ Future<String> _extractMetadataCode(Element element, Resolver resolver,
       if (_isPrivateName(name)) {
         await _severe('Cannot access private name $name', element);
       }
-      metadataParts.add('const $prefix$name($arguments)');
+      if (annotationNode.typeArguments != null) {
+        String typeArguments = annotationNode.typeArguments!.arguments
+            .map((TypeAnnotation typeArgument) {
+              LibraryElement library = typeArgument.type!.element!.library!;
+              String prefix = importCollector._getPrefix(library);
+              return '$prefix$typeArgument';
+            })
+            .join(', ');
+        metadataParts.add('const $prefix$name<$typeArguments>($arguments)');
+      } else {
+        metadataParts.add('const $prefix$name($arguments)');
+      }
     } else {
       // A field reference.
       if (_isPrivateName(annotationNode.name.name)) {


### PR DESCRIPTION
# Overview
Adds support for generic annotations, a feature added in [Dart SDK 2.14](https://github.com/dart-lang/language/blob/master/accepted/2.14/small-features-21Q1/feature-specification.md).

Take this class for example:
```dart
@reflector
class Person {
  @TypeHelper<Soul>(42, "The meaning")
  String? life;
}

class TypeHelper<T> {
  const TypeHelper(int var1, String var2);
}

class Soul { }
```
The annotation would have previously been identified as having the type argument `dynamic`:
```dart
ClassMirror personClassMirror = reflector.reflectType(Person) as ClassMirror;
VariableMirror field = personClassMirror.declarations["life"] as VariableMirror;
var annotation = field.metadata[0];
print(annotation.runtimeType); // TypeHelper<dynamic>
```
It will now be correctly identified as having the type argument `Soul`:
```dart
print(annotation.runtimeType); // TypeHelper<Soul>
```

This is done by appending the type arguments (if any exist) after the annotation name in during the `_extractMetadataCode` function of `builder_implementation.dart`.