### PR TITLE
Update analyzer to 5.0.0

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,7 +1,25 @@
-## 3.0.11
+## 3.1.0
 
-* Update reflectable to use analyzer 4.4.0 (this requires 4.4.0, too, because
-  of a breaking change).
+* Update reflectable to use (and require) analyzer 5.0.0. This is a
+  substantial update, because several analyzer members in the analyzer
+  have been deprecated, and some replacements have different return
+  types.
+* **Breaking change**: The analyzer now reports that the 'mixin' of a
+  'mixin application class' (e.g., `class B = A with M1, M2;`) is the class
+  itself (i.e., `B`), and the last mixin (`M2`) is obtained as
+  `mirror.superclass.mixin`. Previously the same mixin would be obtained with
+  `mirror.mixin`. This is actually a more faithful model than the one used
+  previously, so the new behavior is also used by reflectable. (In particular,
+  if we have `class B2 = A with M1, M2;` then `B == B2` is _not_ true, which
+  implies that the mixin application class works like a regular class
+  declaration with an empty body, e.g., `class B = A with M1, M2;` works like
+  `class B extends A with M1, M2 {}`, where `mirror.superclass.mixin` is
+  the natural way to obtain a mirror of `M2`). This is a breaking change, 
+  but it only affects usages where there is a dependency on the exact 
+  superclass structure, and it seems likely that this is exceedingly rare
+  (we may well traverse all supertypes or all superclasses, but we are not
+  likely to do things like "go to the 5th superclass, find the mixin, and
+  check that it has a `foo` method"). Hence no new major version number.
 
 ## 3.0.10
 

--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.0
+## 4.0.0
 
 * Update reflectable to use (and require) analyzer 5.0.0. This is a
   substantial update, because several analyzer members in the analyzer
@@ -16,10 +16,10 @@
   `class B extends A with M1, M2 {}`, where `mirror.superclass.mixin` is
   the natural way to obtain a mirror of `M2`). This is a breaking change, 
   but it only affects usages where there is a dependency on the exact 
-  superclass structure, and it seems likely that this is exceedingly rare
-  (we may well traverse all supertypes or all superclasses, but we are not
+  superclass structure, and it seems likely that this only happens rarely:
+  we may well traverse all supertypes or all superclasses, but we are not
   likely to do things like "go to the 5th superclass, find the mixin, and
-  check that it has a `foo` method"). Hence no new major version number.
+  check that it has a `foo` method".
 
 ## 3.0.10
 

--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.11
+
+* Update reflectable to use analyzer 4.4.0 (this requires 4.4.0, too, because
+  of a breaking change).
+
 ## 3.0.10
 
 * Perform a minimal migration to use analyzer 4.6.0.

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -4409,7 +4409,7 @@ int _classDescriptor(InterfaceElement element) {
   int result = constants.clazz;
   if (element.isPrivate) result |= constants.privateAttribute;
   if (element.isSynthetic) result |= constants.syntheticAttribute;
-  if (element is MixinElement && element.isAbstract ||
+  if (element is MixinElement ||
       element is ClassElement && element.isAbstract) {
     result |= constants.abstractAttribute;
   }
@@ -5487,7 +5487,7 @@ class MixinApplication implements ClassElement {
   bool get isAbstract {
     var mixin = this.mixin;
     return !isMixinApplication ||
-        mixin is MixinElement && mixin.isAbstract ||
+        mixin is MixinElement ||
         mixin is ClassElement && mixin.isAbstract;
   }
 

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -225,7 +225,7 @@ class Enumerator<T extends Object> {
 /// Hybrid data structure holding [InterfaceElement]s and supporting data.
 /// It holds three different data structures used to describe the set of
 /// classes under transformation. It holds an [Enumerator] named
-/// [classElements] which as a set-like data structure that also enables
+/// [interfaceElements] which as a set-like data structure that also enables
 /// clients to obtain unique indices for each member; it holds a map
 /// [elementToDomain] that maps each [InterfaceElement] to a corresponding
 /// [_ClassDomain]; and it holds a relation [mixinApplicationSupers] that
@@ -238,11 +238,11 @@ class Enumerator<T extends Object> {
 /// together in this class because they must remain consistent and hence all
 /// operations on them should be expressed in one location, namely this class.
 /// Note that this data structure can delegate all read-only operations to
-/// the [classElements], because they will not break consistency, but for every
-/// mutating method we need to maintain the invariants.
+/// the [interfaceElements], because they will not break consistency, but for
+/// every mutating method we need to maintain the invariants.
 class _InterfaceElementEnhancedSet implements Set<InterfaceElement> {
   final _ReflectorDomain reflectorDomain;
-  final Enumerator<InterfaceElement> classElements =
+  final Enumerator<InterfaceElement> interfaceElements =
       Enumerator<InterfaceElement>();
   final Map<InterfaceElement, _ClassDomain> elementToDomain =
       <InterfaceElement, _ClassDomain>{};
@@ -262,7 +262,7 @@ class _InterfaceElementEnhancedSet implements Set<InterfaceElement> {
 
   @override
   Iterable<T> map<T>(T Function(InterfaceElement) f) =>
-      classElements.items.map<T>(f);
+      interfaceElements.items.map<T>(f);
 
   @override
   Set<R> cast<R>() {
@@ -272,7 +272,7 @@ class _InterfaceElementEnhancedSet implements Set<InterfaceElement> {
 
   @override
   Iterable<InterfaceElement> where(bool Function(InterfaceElement) f) {
-    return classElements.items.where(f);
+    return interfaceElements.items.where(f);
   }
 
   @override
@@ -286,61 +286,65 @@ class _InterfaceElementEnhancedSet implements Set<InterfaceElement> {
 
   @override
   Iterable<T> expand<T>(Iterable<T> Function(InterfaceElement) f) {
-    return classElements.items.expand<T>(f);
+    return interfaceElements.items.expand<T>(f);
   }
 
   @override
   void forEach(void Function(InterfaceElement) f) =>
-      classElements.items.forEach(f);
+      interfaceElements.items.forEach(f);
 
   @override
   InterfaceElement reduce(
       InterfaceElement Function(InterfaceElement, InterfaceElement) combine) {
-    return classElements.items.reduce(combine);
+    return interfaceElements.items.reduce(combine);
   }
 
   @override
   T fold<T>(T initialValue, T Function(T, InterfaceElement) combine) {
-    return classElements.items.fold<T>(initialValue, combine);
+    return interfaceElements.items.fold<T>(initialValue, combine);
   }
 
   @override
-  bool every(bool Function(InterfaceElement) f) => classElements.items.every(f);
+  bool every(bool Function(InterfaceElement) f) =>
+      interfaceElements.items.every(f);
 
   @override
-  String join([String separator = '']) => classElements.items.join(separator);
+  String join([String separator = '']) =>
+      interfaceElements.items.join(separator);
 
   @override
-  bool any(bool Function(InterfaceElement) f) => classElements.items.any(f);
+  bool any(bool Function(InterfaceElement) f) => interfaceElements.items.any(f);
 
   @override
   List<InterfaceElement> toList({bool growable = true}) {
-    return classElements.items.toList(growable: growable);
+    return interfaceElements.items.toList(growable: growable);
   }
 
   @override
-  int get length => classElements.items.length;
+  int get length => interfaceElements.items.length;
 
   @override
-  bool get isEmpty => classElements.items.isEmpty;
+  bool get isEmpty => interfaceElements.items.isEmpty;
 
   @override
-  bool get isNotEmpty => classElements.items.isNotEmpty;
+  bool get isNotEmpty => interfaceElements.items.isNotEmpty;
 
   @override
-  Iterable<InterfaceElement> take(int count) => classElements.items.take(count);
+  Iterable<InterfaceElement> take(int count) =>
+      interfaceElements.items.take(count);
 
   @override
   Iterable<InterfaceElement> takeWhile(bool Function(InterfaceElement) test) {
-    return classElements.items.takeWhile(test);
+    return interfaceElements.items.takeWhile(test);
   }
 
   @override
-  Iterable<InterfaceElement> skip(int count) => classElements.items.skip(count);
+  Iterable<InterfaceElement> skip(int count) =>
+      interfaceElements.items.skip(count);
 
   @override
   Iterable<InterfaceElement> skipWhile(bool Function(InterfaceElement) test) {
-    return classElements.items.skipWhile(test);
+    return interfaceElements.items.skipWhile(test);
   }
 
   @override
@@ -351,45 +355,46 @@ class _InterfaceElementEnhancedSet implements Set<InterfaceElement> {
   }
 
   @override
-  InterfaceElement get first => classElements.items.first;
+  InterfaceElement get first => interfaceElements.items.first;
 
   @override
-  InterfaceElement get last => classElements.items.last;
+  InterfaceElement get last => interfaceElements.items.last;
 
   @override
-  InterfaceElement get single => classElements.items.single;
+  InterfaceElement get single => interfaceElements.items.single;
 
   @override
   InterfaceElement firstWhere(bool Function(InterfaceElement) test,
       {InterfaceElement Function()? orElse}) {
-    return classElements.items.firstWhere(test, orElse: orElse);
+    return interfaceElements.items.firstWhere(test, orElse: orElse);
   }
 
   @override
   InterfaceElement lastWhere(bool Function(InterfaceElement) test,
       {InterfaceElement Function()? orElse}) {
-    return classElements.items.lastWhere(test, orElse: orElse);
+    return interfaceElements.items.lastWhere(test, orElse: orElse);
   }
 
   @override
   InterfaceElement singleWhere(bool Function(InterfaceElement) test,
       {InterfaceElement Function()? orElse}) {
-    return classElements.items.singleWhere(test);
+    return interfaceElements.items.singleWhere(test);
   }
 
   @override
-  InterfaceElement elementAt(int index) => classElements.items.elementAt(index);
+  InterfaceElement elementAt(int index) =>
+      interfaceElements.items.elementAt(index);
 
   @override
-  Iterator<InterfaceElement> get iterator => classElements.items.iterator;
+  Iterator<InterfaceElement> get iterator => interfaceElements.items.iterator;
 
   @override
-  bool contains(Object? value) => classElements.items.contains(value);
+  bool contains(Object? value) => interfaceElements.items.contains(value);
 
   @override
   bool add(InterfaceElement value) {
     assert(!_unmodifiable);
-    bool result = classElements.add(value);
+    bool result = interfaceElements.add(value);
     if (result) {
       assert(!elementToDomain.containsKey(value));
       elementToDomain[value] = _createClassDomain(value, reflectorDomain);
@@ -414,8 +419,8 @@ class _InterfaceElementEnhancedSet implements Set<InterfaceElement> {
   @override
   bool remove(Object? value) {
     assert(!_unmodifiable);
-    bool result = classElements._contains(value);
-    classElements._map.remove(value);
+    bool result = interfaceElements._contains(value);
+    interfaceElements._map.remove(value);
     if (result) {
       assert(elementToDomain.containsKey(value));
       elementToDomain.remove(value);
@@ -431,7 +436,7 @@ class _InterfaceElementEnhancedSet implements Set<InterfaceElement> {
 
   @override
   InterfaceElement? lookup(Object? object) {
-    for (InterfaceElement classElement in classElements._map.keys) {
+    for (InterfaceElement classElement in interfaceElements._map.keys) {
       if (object == classElement) return classElement;
     }
     return null;
@@ -449,7 +454,7 @@ class _InterfaceElementEnhancedSet implements Set<InterfaceElement> {
   @override
   void removeWhere(bool Function(InterfaceElement) test) {
     var toRemove = <InterfaceElement>{};
-    for (InterfaceElement classElement in classElements.items) {
+    for (InterfaceElement classElement in interfaceElements.items) {
       if (test(classElement)) toRemove.add(classElement);
     }
     removeAll(toRemove);
@@ -463,28 +468,28 @@ class _InterfaceElementEnhancedSet implements Set<InterfaceElement> {
 
   @override
   bool containsAll(Iterable<Object?> other) {
-    return classElements.items.toSet().containsAll(other);
+    return interfaceElements.items.toSet().containsAll(other);
   }
 
   @override
   Set<InterfaceElement> intersection(Set<Object?> other) {
-    return classElements.items.toSet().intersection(other);
+    return interfaceElements.items.toSet().intersection(other);
   }
 
   @override
   Set<InterfaceElement> union(Set<InterfaceElement> other) {
-    return classElements.items.toSet().union(other);
+    return interfaceElements.items.toSet().union(other);
   }
 
   @override
   Set<InterfaceElement> difference(Set<Object?> other) {
-    return classElements.items.toSet().difference(other);
+    return interfaceElements.items.toSet().difference(other);
   }
 
   @override
   void clear() {
     assert(!_unmodifiable);
-    classElements.clear();
+    interfaceElements.clear();
     elementToDomain.clear();
   }
 
@@ -529,7 +534,7 @@ class _InterfaceElementEnhancedSet implements Set<InterfaceElement> {
   /// Returns the index of the given [classElement] if it is contained
   /// in this [_InterfaceElementEnhancedSet], otherwise [null].
   int? indexOf(Object classElement) {
-    return classElements.indexOf(classElement);
+    return interfaceElements.indexOf(classElement);
   }
 
   Iterable<_ClassDomain> get domains => elementToDomain.values;
@@ -1356,7 +1361,7 @@ class _ReflectorDomain {
       Map<LibraryElement, _LibraryDomain> libraryMap,
       _ImportCollector importCollector,
       Map<FunctionType, int> typedefs) async {
-    int descriptor = _classDescriptor(classDomain._classElement);
+    int descriptor = _classDescriptor(classDomain._interfaceElement);
 
     // Fields go first in [memberMirrors], so they will get the
     // same index as in [fields].
@@ -1417,8 +1422,9 @@ class _ReflectorDomain {
       }));
     }
 
-    InterfaceElement classElement = classDomain._classElement;
-    InterfaceElement? superclass = (await classes).superclassOf(classElement);
+    InterfaceElement interfaceElement = classDomain._interfaceElement;
+    InterfaceElement? superclass =
+        (await classes).superclassOf(interfaceElement);
 
     String superclassIndex = '${constants.noCapabilityIndex}';
     if (_capabilities._impliesTypeRelations) {
@@ -1427,8 +1433,8 @@ class _ReflectorDomain {
       // convention we make it supported and report it in the same way as
       // 'dart:mirrors'. Other superclasses use `noCapabilityIndex` to
       // indicate missing support.
-      superclassIndex = (classElement is! MixinApplication &&
-              _typeForReflectable(classElement).isDartCoreObject)
+      superclassIndex = (interfaceElement is! MixinApplication &&
+              _typeForReflectable(interfaceElement).isDartCoreObject)
           ? 'null'
           : ((await classes).contains(superclass))
               ? '${(await classes).indexOf(superclass!)}'
@@ -1436,7 +1442,7 @@ class _ReflectorDomain {
     }
 
     String constructorsCode;
-    if (classElement is MixinApplication) {
+    if (interfaceElement is MixinApplication) {
       constructorsCode = 'const {}';
     } else {
       List<String> mapEntries = [];
@@ -1455,18 +1461,18 @@ class _ReflectorDomain {
 
     String staticGettersCode = 'const {}';
     String staticSettersCode = 'const {}';
-    if (classElement is! MixinApplication) {
+    if (interfaceElement is! MixinApplication) {
       List<String> staticGettersCodeList = [];
       for (MethodElement method in classDomain._declaredMethods) {
         if (method.isStatic) {
           staticGettersCodeList.add(await _staticGettingClosure(
-              importCollector, classElement, method.name));
+              importCollector, interfaceElement, method.name));
         }
       }
       for (PropertyAccessorElement accessor in classDomain._accessors) {
         if (accessor.isStatic && accessor.isGetter) {
           staticGettersCodeList.add(await _staticGettingClosure(
-              importCollector, classElement, accessor.name));
+              importCollector, interfaceElement, accessor.name));
         }
       }
       staticGettersCode = _formatAsMap(staticGettersCodeList);
@@ -1474,7 +1480,7 @@ class _ReflectorDomain {
       for (PropertyAccessorElement accessor in classDomain._accessors) {
         if (accessor.isStatic && accessor.isSetter) {
           staticSettersCodeList.add(await _staticSettingClosure(
-              importCollector, classElement, accessor.name));
+              importCollector, interfaceElement, accessor.name));
         }
       }
       staticSettersCode = _formatAsMap(staticSettersCodeList);
@@ -1483,15 +1489,16 @@ class _ReflectorDomain {
     int? mixinIndex = constants.noCapabilityIndex;
     if (_capabilities._impliesTypeRelations) {
       var theClasses = await classes;
-      if (classElement is MixinApplication && classElement.isMixinApplication) {
+      if (interfaceElement is MixinApplication &&
+          interfaceElement.isMixinApplication) {
         // Named mixin application (using the syntax `class B = A with M;`).
-        mixinIndex = theClasses.indexOf(classElement.mixins.last.element2);
-      } else if (classElement is MixinApplication) {
+        mixinIndex = theClasses.indexOf(interfaceElement.mixins.last.element2);
+      } else if (interfaceElement is MixinApplication) {
         // Anonymous mixin application.
-        mixinIndex = theClasses.indexOf(classElement.mixin);
+        mixinIndex = theClasses.indexOf(interfaceElement.mixin);
       } else {
         // No mixins, by convention we use the class itself.
-        mixinIndex = theClasses.indexOf(classElement);
+        mixinIndex = theClasses.indexOf(interfaceElement);
       }
       // We may not have support for the given class, in which case we must
       // correct the `null` from `indexOf` to indicate missing capability.
@@ -1499,7 +1506,7 @@ class _ReflectorDomain {
     }
 
     int ownerIndex = _capabilities._supportsLibraries
-        ? libraries.indexOf(libraryMap[classElement.library]!)!
+        ? libraries.indexOf(libraryMap[interfaceElement.library]!)!
         : constants.noCapabilityIndex;
 
     String superinterfaceIndices =
@@ -1507,7 +1514,7 @@ class _ReflectorDomain {
     if (_capabilities._impliesTypeRelations) {
       superinterfaceIndices = _formatAsConstList(
           'int',
-          classElement.interfaces
+          interfaceElement.interfaces
               .map((InterfaceType type) => type.element2)
               .where((await classes).contains)
               .map((await classes).indexOf));
@@ -1516,12 +1523,12 @@ class _ReflectorDomain {
     String classMetadataCode;
     if (_capabilities._supportsMetadata) {
       classMetadataCode = await _extractMetadataCode(
-          classElement, _resolver, importCollector, _generatedLibraryId);
+          interfaceElement, _resolver, importCollector, _generatedLibraryId);
     } else {
       classMetadataCode = 'null';
     }
 
-    int classIndex = (await classes).indexOf(classElement)!;
+    int classIndex = (await classes).indexOf(interfaceElement)!;
 
     String parameterListShapesCode = 'null';
     if (_capabilities._impliesParameterListShapes) {
@@ -1539,9 +1546,9 @@ class _ReflectorDomain {
       }));
     }
 
-    if (classElement.typeParameters.isEmpty) {
+    if (interfaceElement.typeParameters.isEmpty) {
       return "r.NonGenericClassMirrorImpl(r'${classDomain._simpleName}', "
-          "r'${_qualifiedName(classElement)}', $descriptor, $classIndex, "
+          "r'${_qualifiedName(interfaceElement)}', $descriptor, $classIndex, "
           '${await _constConstructionCode(importCollector)}, '
           '$declarationsCode, $instanceMembersCode, $staticMembersCode, '
           '$superclassIndex, $staticGettersCode, $staticSettersCode, '
@@ -1555,16 +1562,17 @@ class _ReflectorDomain {
       // `List<dynamic>`), and not an instance of any of its immediate subtypes,
       // if any. [isCheckCode] is a function which will test that its argument
       // (1) `is` an instance of the fully dynamic instance of the generic
-      // class modeled by [classElement], and (2) that it is not an instance
+      // class modeled by [interfaceElement], and (2) that it is not an instance
       // of the fully dynamic instance of any of the classes that `extends` or
-      // `implements` this [classElement].
+      // `implements` this [interfaceElement].
       List<String> isCheckList = [];
-      if (classElement.isPrivate ||
-          classElement is MixinElement ||
-          (classElement is ClassElement && classElement.isAbstract) ||
-          (classElement is MixinApplication &&
-              !classElement.isMixinApplication) ||
-          !await _isImportable(classElement, _generatedLibraryId, _resolver)) {
+      if (interfaceElement.isPrivate ||
+          interfaceElement is MixinElement ||
+          (interfaceElement is ClassElement && interfaceElement.isAbstract) ||
+          (interfaceElement is MixinApplication &&
+              !interfaceElement.isMixinApplication) ||
+          !await _isImportable(
+              interfaceElement, _generatedLibraryId, _resolver)) {
         // Note that this location is dead code until we get support for
         // anonymous mixin applications using type arguments as generic
         // classes (currently, no classes will pass the tests above). See
@@ -1573,14 +1581,14 @@ class _ReflectorDomain {
         // no object can be an instance of an anonymous mixin application.
         isCheckList.add('(o) => false');
       } else {
-        String prefix = importCollector._getPrefix(classElement.library);
-        isCheckList.add('(o) { return o is $prefix${classElement.name}');
+        String prefix = importCollector._getPrefix(interfaceElement.library);
+        isCheckList.add('(o) { return o is $prefix${interfaceElement.name}');
 
-        // Add 'is checks' to [list], based on [classElement].
+        // Add 'is checks' to [list], based on [interfaceElement].
         Future<void> helper(
-            List<String> list, InterfaceElement classElement) async {
+            List<String> list, InterfaceElement interfaceElement) async {
           Iterable<InterfaceElement> subtypes =
-              _world.subtypes[classElement] ?? <InterfaceElement>[];
+              _world.subtypes[interfaceElement] ?? <InterfaceElement>[];
           for (InterfaceElement subtype in subtypes) {
             if (subtype.isPrivate ||
                 subtype is MixinElement ||
@@ -1595,7 +1603,7 @@ class _ReflectorDomain {
           }
         }
 
-        await helper(isCheckList, classElement);
+        await helper(isCheckList, interfaceElement);
         isCheckList.add('; }');
       }
       String isCheckCode = isCheckList.join();
@@ -1606,20 +1614,20 @@ class _ReflectorDomain {
             typeParameters.indexOf(typeParameter)! + typeParametersOffset;
         typeParameterIndices = _formatAsConstList(
             'int',
-            classElement.typeParameters
+            interfaceElement.typeParameters
                 .where(typeParameters.items.contains)
                 .map(indexOf));
       }
 
       int? dynamicReflectedTypeIndex = _dynamicTypeCodeIndex(
-          _typeForReflectable(classElement),
+          _typeForReflectable(interfaceElement),
           await classes,
           reflectedTypes,
           reflectedTypesOffset,
           typedefs);
 
       return "r.GenericClassMirrorImpl(r'${classDomain._simpleName}', "
-          "r'${_qualifiedName(classElement)}', $descriptor, $classIndex, "
+          "r'${_qualifiedName(interfaceElement)}', $descriptor, $classIndex, "
           '${await _constConstructionCode(importCollector)}, '
           '$declarationsCode, $instanceMembersCode, $staticMembersCode, '
           '$superclassIndex, $staticGettersCode, $staticSettersCode, '
@@ -2385,9 +2393,9 @@ class _SubtypesFixedPoint extends FixedPoint<InterfaceElement> {
   /// Returns all the immediate subtypes of the given [classMirror].
   @override
   Future<Iterable<InterfaceElement>> successors(
-      final InterfaceElement classElement) async {
-    Iterable<InterfaceElement>? classElements = subtypes[classElement];
-    return classElements ?? <InterfaceElement>[];
+      final InterfaceElement interfaceElement) async {
+    Iterable<InterfaceElement>? interfaceElements = subtypes[interfaceElement];
+    return interfaceElements ?? <InterfaceElement>[];
   }
 }
 
@@ -2430,7 +2438,7 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement> {
       result.add(workingSuperclass);
     }
 
-    // Create the chain of mixin applications between [classElement] and the
+    // Create the chain of mixin applications between [interfaceElement] and the
     // next non-mixin-application class that it extends. If [mixinsRequested]
     // then for each mixin application add the class [mixinClass] which was
     // applied as a mixin (it is then considered as yet another superclass).
@@ -2466,24 +2474,24 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement> {
     return result;
   }
 
-  bool _includedByUpwardsClosure(InterfaceElement classElement) {
+  bool _includedByUpwardsClosure(InterfaceElement interfaceElement) {
     bool helper(InterfaceElement interfaceElement, bool direct) {
       bool isSuperclassOfInterfaceElement(InterfaceElement bound) {
         if (interfaceElement == bound) {
           // If `!direct` then the desired subclass relation exists.
-          // If `direct` then the original `classElement` is equal to
+          // If `direct` then the original `interfaceElement` is equal to
           // `bound`, so we must return false if `excludeUpperBound`.
           return !direct || !upwardsClosureBounds[bound]!;
         }
-        var classElementSupertype = interfaceElement.supertype;
-        if (classElementSupertype == null) return false;
-        return helper(classElementSupertype.element2, false);
+        var interfaceElementSupertype = interfaceElement.supertype;
+        if (interfaceElementSupertype == null) return false;
+        return helper(interfaceElementSupertype.element2, false);
       }
 
       return upwardsClosureBounds.keys.any(isSuperclassOfInterfaceElement);
     }
 
-    return upwardsClosureBounds.isEmpty || helper(classElement, true);
+    return upwardsClosureBounds.isEmpty || helper(interfaceElement, true);
   }
 }
 
@@ -2492,10 +2500,10 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement> {
 Set<InterfaceElement> _mixinApplicationsOfClasses(
     Set<InterfaceElement> classes) {
   var mixinApplications = <InterfaceElement>{};
-  for (InterfaceElement classElement in classes) {
+  for (InterfaceElement interfaceElement in classes) {
     // Mixin-applications are handled when they are created.
-    if (classElement is MixinApplication) continue;
-    InterfaceType? supertype = classElement.supertype;
+    if (interfaceElement is MixinApplication) continue;
+    InterfaceType? supertype = interfaceElement.supertype;
     if (supertype == null) continue; // "Superclass of [Object]", ignore.
     var superclass = supertype.element2;
     // Note that we iterate from the most general mixin to more specific ones,
@@ -2504,17 +2512,18 @@ Set<InterfaceElement> _mixinApplicationsOfClasses(
     // new [MixinApplication] created.  We must provide the immediate subclass
     // of each [MixinApplication] when it is a regular class (not a mixin
     // application), otherwise [null], which is done with [subClass].
-    for (var mixin in classElement.mixins) {
+    for (var mixin in interfaceElement.mixins) {
       var mixinClass = mixin.element2;
       InterfaceElement? subClass =
-          mixin == classElement.mixins.last ? classElement : null;
+          mixin == interfaceElement.mixins.last ? interfaceElement : null;
       String? name = subClass == null
           ? null
-          : (classElement is MixinApplication && classElement.isMixinApplication
-              ? classElement.name
+          : (interfaceElement is MixinApplication &&
+                  interfaceElement.isMixinApplication
+              ? interfaceElement.name
               : null);
       InterfaceElement mixinApplication = MixinApplication(
-          name, superclass, mixinClass, classElement.library, subClass);
+          name, superclass, mixinClass, interfaceElement.library, subClass);
       mixinApplications.add(mixinApplication);
       superclass = mixinApplication;
     }
@@ -2543,14 +2552,14 @@ class _AnnotationClassFixedPoint extends FixedPoint<InterfaceElement> {
   /// type annotations of covered variables and parameters of covered methods,
   @override
   Future<Iterable<InterfaceElement>> successors(
-      InterfaceElement classElement) async {
-    if (!await _isImportable(classElement, generatedLibraryId, resolver)) {
+      InterfaceElement interfaceElement) async {
+    if (!await _isImportable(interfaceElement, generatedLibraryId, resolver)) {
       return [];
     }
-    _ClassDomain classDomain = elementToDomain(classElement);
+    _ClassDomain classDomain = elementToDomain(interfaceElement);
 
     // Mixin-applications do not add further methods and fields.
-    if (classDomain._classElement is MixinApplication) return [];
+    if (classDomain._interfaceElement is MixinApplication) return [];
 
     List<InterfaceElement> result = [];
 
@@ -2622,32 +2631,32 @@ String _settingClosure(String setterName) {
 
 // Auxiliary function used by `_generateCode`.
 Future<String> _staticGettingClosure(_ImportCollector importCollector,
-    InterfaceElement classElement, String getterName) async {
-  String className = classElement.name;
-  String prefix = importCollector._getPrefix(classElement.library);
+    InterfaceElement interfaceElement, String getterName) async {
+  String className = interfaceElement.name;
+  String prefix = importCollector._getPrefix(interfaceElement.library);
   // Operators cannot be static.
   if (_isPrivateName(getterName)) {
-    await _severe('Cannot access private name $getterName', classElement);
+    await _severe('Cannot access private name $getterName', interfaceElement);
   }
   if (_isPrivateName(className)) {
-    await _severe('Cannot access private name $className', classElement);
+    await _severe('Cannot access private name $className', interfaceElement);
   }
   return "r'$getterName': () => $prefix$className.$getterName";
 }
 
 // Auxiliary function used by `_generateCode`.
 Future<String> _staticSettingClosure(_ImportCollector importCollector,
-    InterfaceElement classElement, String setterName) async {
+    InterfaceElement interfaceElement, String setterName) async {
   assert(setterName.substring(setterName.length - 1) == '=');
   // The [setterName] includes the '=', remove it.
   String name = setterName.substring(0, setterName.length - 1);
-  String className = classElement.name;
-  String prefix = importCollector._getPrefix(classElement.library);
+  String className = interfaceElement.name;
+  String prefix = importCollector._getPrefix(interfaceElement.library);
   if (_isPrivateName(setterName)) {
-    await _severe('Cannot access private name $setterName', classElement);
+    await _severe('Cannot access private name $setterName', interfaceElement);
   }
   if (_isPrivateName(className)) {
-    await _severe('Cannot access private name $className', classElement);
+    await _severe('Cannot access private name $className', interfaceElement);
   }
   return "r'$setterName': (dynamic value) => $prefix$className.$name = value";
 }
@@ -2717,7 +2726,7 @@ class _LibraryDomain {
       this._reflectorDomain);
 
   /// Returns the declared methods, accessors and constructors in
-  /// [_classElement]. Note that this includes synthetic getters and
+  /// [_interfaceElement]. Note that this includes synthetic getters and
   /// setters, and omits fields; in other words, it provides the
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
@@ -2748,31 +2757,31 @@ class _LibraryDomain {
 /// Information about reflectability for a given class.
 class _ClassDomain {
   /// Element describing the target class.
-  final InterfaceElement _classElement;
+  final InterfaceElement _interfaceElement;
 
-  /// Fields declared by [_classElement] and included for reflection support,
+  /// Fields declared by [_interfaceElement] and included for reflection support,
   /// according to the reflector described by the [_reflectorDomain];
-  /// obtained by filtering `_classElement.fields`.
+  /// obtained by filtering `_interfaceElement.fields`.
   final Iterable<FieldElement> _declaredFields;
 
-  /// Methods which are declared by [_classElement] and included for
+  /// Methods which are declared by [_interfaceElement] and included for
   /// reflection support, according to the reflector described by
-  /// [reflectorDomain]; obtained by filtering `_classElement.methods`.
+  /// [reflectorDomain]; obtained by filtering `_interfaceElement.methods`.
   final Iterable<MethodElement> _declaredMethods;
 
   /// Formal parameters declared by one of the [_declaredMethods].
   final Iterable<ParameterElement> _declaredParameters;
 
-  /// Getters and setters possessed by [_classElement] and included for
+  /// Getters and setters possessed by [_interfaceElement] and included for
   /// reflection support, according to the reflector described by
-  /// [reflectorDomain]; obtained by filtering `_classElement.accessors`.
+  /// [reflectorDomain]; obtained by filtering `_interfaceElement.accessors`.
   /// Note that it includes declared as well as synthetic accessors,
   /// implicitly created as getters/setters for fields.
   final Iterable<PropertyAccessorElement> _accessors;
 
-  /// Constructors declared by [_classElement] and included for reflection
+  /// Constructors declared by [_interfaceElement] and included for reflection
   /// support, according to the reflector described by [_reflectorDomain];
-  /// obtained by filtering `_classElement.constructors`.
+  /// obtained by filtering `_interfaceElement.constructors`.
   final Iterable<ConstructorElement> _constructors;
 
   /// The reflector domain that holds [this] object as one of its
@@ -2780,7 +2789,7 @@ class _ClassDomain {
   final _ReflectorDomain _reflectorDomain;
 
   _ClassDomain(
-      this._classElement,
+      this._interfaceElement,
       this._declaredFields,
       this._declaredMethods,
       this._declaredParameters,
@@ -2791,17 +2800,18 @@ class _ClassDomain {
   String get _simpleName {
     // TODO(eernst) clarify: Decide whether this should be simplified
     // by adding a method implementation to `MixinApplication`.
-    var classElement = _classElement;
-    if (classElement is MixinApplication && classElement.isMixinApplication) {
+    var interfaceElement = _interfaceElement;
+    if (interfaceElement is MixinApplication &&
+        interfaceElement.isMixinApplication) {
       // This is the case `class B = A with M;`.
-      return classElement.name;
-    } else if (classElement is MixinApplication) {
+      return interfaceElement.name;
+    } else if (interfaceElement is MixinApplication) {
       // This is the case `class B extends A with M1, .. Mk {..}`
-      // where `classElement` denotes one of the mixin applications
+      // where `interfaceElement` denotes one of the mixin applications
       // that constitute the superclass chain between `B` and `A`, both
       // excluded.
-      List<InterfaceType> mixins = classElement.mixins;
-      var superclassType = classElement.supertype as InterfaceType;
+      List<InterfaceType> mixins = interfaceElement.mixins;
+      var superclassType = interfaceElement.supertype as InterfaceType;
       var superclassTypeElement = superclassType.element2;
       String superclassName = _qualifiedName(superclassTypeElement);
       StringBuffer name = StringBuffer(superclassName);
@@ -2814,12 +2824,12 @@ class _ClassDomain {
       return name.toString();
     } else {
       // This is a regular class, i.e., we can use its declared name.
-      return classElement.name;
+      return interfaceElement.name;
     }
   }
 
   /// Returns the declared methods, accessors and constructors in
-  /// [_classElement]. Note that this includes synthetic getters and
+  /// [_interfaceElement]. Note that this includes synthetic getters and
   /// setters, and omits fields; in other words, it provides the
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
@@ -2888,7 +2898,7 @@ class _ClassDomain {
       return result;
     }
 
-    return helper(_classElement).values;
+    return helper(_interfaceElement).values;
   }
 
   /// Finds all parameters of instance members.
@@ -2905,7 +2915,7 @@ class _ClassDomain {
   /// Finds all static members.
   Iterable<ExecutableElement> get _staticMembers {
     List<ExecutableElement> result = <ExecutableElement>[];
-    if (_classElement is MixinApplication) return result;
+    if (_interfaceElement is MixinApplication) return result;
 
     void possiblyAddMethod(MethodElement method) {
       if (method.isStatic &&
@@ -2939,14 +2949,14 @@ class _ClassDomain {
       }
     }
 
-    _classElement.methods.forEach(possiblyAddMethod);
-    _classElement.accessors.forEach(possiblyAddAccessor);
+    _interfaceElement.methods.forEach(possiblyAddMethod);
+    _interfaceElement.accessors.forEach(possiblyAddAccessor);
     return result;
   }
 
   @override
   String toString() {
-    return 'ClassDomain($_classElement)';
+    return 'ClassDomain($_interfaceElement)';
   }
 }
 
@@ -3617,7 +3627,7 @@ class BuilderImplementation {
                   continue;
                 }
               }
-              if (metadataFieldValue is ClassElement) {
+              if (metadataFieldValue is InterfaceElement) {
                 globalMetadata
                     .putIfAbsent(metadataFieldValue, () => <InterfaceElement>[])
                     .add(reflector);
@@ -4408,8 +4418,8 @@ int _classDescriptor(InterfaceElement element) {
   int result = constants.clazz;
   if (element.isPrivate) result |= constants.privateAttribute;
   if (element.isSynthetic) result |= constants.syntheticAttribute;
-  if (element is MixinElement ||
-      (element is ClassElement && element.isAbstract)) {
+  if (element is MixinElement && element.isAbstract ||
+      element is ClassElement && element.isAbstract) {
     result |= constants.abstractAttribute;
   }
   if (element is EnumElement) result |= constants.enumAttribute;
@@ -5110,26 +5120,26 @@ typedef CapabilityChecker = bool Function(
     Iterable<ElementAnnotation> metadata,
     Iterable<ElementAnnotation>? getterMetadata);
 
-/// Returns the declared fields in the given [classElement], filtered such
+/// Returns the declared fields in the given [interfaceElement], filtered such
 /// that the returned ones are the ones that are supported by [capabilities].
 Iterable<FieldElement> _extractDeclaredFields(Resolver resolver,
-    InterfaceElement classElement, _Capabilities capabilities) {
-  return classElement.fields.where((FieldElement field) {
+    InterfaceElement interfaceElement, _Capabilities capabilities) {
+  return interfaceElement.fields.where((FieldElement field) {
     if (field.isPrivate) return false;
     CapabilityChecker capabilityChecker = field.isStatic
         ? capabilities.supportsStaticInvoke
         : capabilities.supportsInstanceInvoke;
     return !field.isSynthetic &&
-        capabilityChecker(
-            classElement.library.typeSystem, field.name, field.metadata, null);
+        capabilityChecker(interfaceElement.library.typeSystem, field.name,
+            field.metadata, null);
   });
 }
 
-/// Returns the declared methods in the given [classElement], filtered such
+/// Returns the declared methods in the given [interfaceElement], filtered such
 /// that the returned ones are the ones that are supported by [capabilities].
 Iterable<MethodElement> _extractDeclaredMethods(Resolver resolver,
-    InterfaceElement classElement, _Capabilities capabilities) {
-  return classElement.methods.where((MethodElement method) {
+    InterfaceElement interfaceElement, _Capabilities capabilities) {
+  return interfaceElement.methods.where((MethodElement method) {
     if (method.isPrivate) return false;
     CapabilityChecker capabilityChecker = method.isStatic
         ? capabilities.supportsStaticInvoke
@@ -5192,7 +5202,7 @@ Iterable<PropertyAccessorElement> _extractLibraryAccessors(Resolver resolver,
 }
 
 /// Returns the [PropertyAccessorElement]s which are the accessors
-/// of the given [classElement], including both the declared ones
+/// of the given [interfaceElement], including both the declared ones
 /// and the implicitly generated ones corresponding to fields. This
 /// is the set of accessors that corresponds to the behavioral interface
 /// of the corresponding instances, as opposed to the source code oriented
@@ -5200,8 +5210,8 @@ Iterable<PropertyAccessorElement> _extractLibraryAccessors(Resolver resolver,
 /// here, by filtering out the accessors whose `isSynthetic` is true
 /// and adding the fields.
 Iterable<PropertyAccessorElement> _extractAccessors(Resolver resolver,
-    InterfaceElement classElement, _Capabilities capabilities) {
-  return classElement.accessors.where((PropertyAccessorElement accessor) {
+    InterfaceElement interfaceElement, _Capabilities capabilities) {
+  return interfaceElement.accessors.where((PropertyAccessorElement accessor) {
     if (accessor.isPrivate) return false;
     // TODO(eernst) implement: refactor treatment of `getterMetadata`
     // such that we avoid passing in `null` at all call sites except one,
@@ -5225,14 +5235,14 @@ Iterable<PropertyAccessorElement> _extractAccessors(Resolver resolver,
   });
 }
 
-/// Returns the declared constructors from [classElement], filtered such that
+/// Returns the declared constructors from [interfaceElement], filtered such that
 /// the returned ones are the ones that are supported by [capabilities].
 Iterable<ConstructorElement> _extractDeclaredConstructors(
     Resolver resolver,
     LibraryElement libraryElement,
-    InterfaceElement classElement,
+    InterfaceElement interfaceElement,
     _Capabilities capabilities) {
-  return classElement.constructors.where((ConstructorElement constructor) {
+  return interfaceElement.constructors.where((ConstructorElement constructor) {
     if (constructor.isPrivate) return false;
     return capabilities.supportsNewInstance(constructor.library.typeSystem,
         constructor.name, constructor.metadata, libraryElement, resolver);

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -5478,6 +5478,7 @@ class MixinApplication implements ClassElement {
   @override
   bool get isPrivate => false;
 
+  @deprecated
   @override
   bool get isEnum => false;
 

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -3910,7 +3910,6 @@ class BuilderImplementation {
             allReflectors.add(type);
           }
         }
-        /* !!!TODO!!!
         for (EnumElement type in unit.enums2) {
           for (InterfaceElement reflector
               in await getReflectors(_qualifiedName(type), type.metadata)) {
@@ -3918,7 +3917,6 @@ class BuilderImplementation {
           }
           // An enum is never a reflector class, hence no `_isReflectorClass`.
         }
-        */
         for (FunctionElement function in unit.functions) {
           for (InterfaceElement reflector in await getReflectors(
               _qualifiedFunctionName(function), function.metadata)) {

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -2900,10 +2900,11 @@ class _ClassDomain {
       if (superclassType is InterfaceType) {
         var superclassElement = superclassType.element2;
         helper(superclassElement).forEach(addIfCapable);
-        interfaceElement.mixins.forEach(addTypeIfCapable);
-        interfaceElement.methods.forEach(addIfCapableConcreteInstance);
-        interfaceElement.accessors.forEach(addIfCapableConcreteInstance);
       }
+      interfaceElement.mixins.forEach(addTypeIfCapable);
+      interfaceElement.methods.forEach(addIfCapableConcreteInstance);
+      interfaceElement.accessors.forEach(addIfCapableConcreteInstance);
+
       return cacheResult(result);
     }
 

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -225,21 +225,22 @@ class Enumerator<T extends Object> {
 /// Hybrid data structure holding [InterfaceElement]s and supporting data.
 /// It holds three different data structures used to describe the set of
 /// classes under transformation. It holds an [Enumerator] named
-/// [interfaceElements] which as a set-like data structure that also enables
+/// [interfaceElements] which is a set-like data structure that also enables
 /// clients to obtain unique indices for each member; it holds a map
 /// [elementToDomain] that maps each [InterfaceElement] to a corresponding
 /// [_ClassDomain]; and it holds a relation [mixinApplicationSupers] that
-/// maps each [InterfaceElement] which is a direct subclass of a mixin application
-/// to its superclass. The latter is needed because the analyzer representation
-/// of mixins and mixin applications makes it difficult to find a superclass
-/// which is a mixin application (`InterfaceElement.supertype` is the _syntactic_
-/// superclass, that is, for `class C extends B with M..` it is `B`, not the
-/// mixin application `B with M`). The three data structures are bundled
-/// together in this class because they must remain consistent and hence all
-/// operations on them should be expressed in one location, namely this class.
-/// Note that this data structure can delegate all read-only operations to
-/// the [interfaceElements], because they will not break consistency, but for
-/// every mutating method we need to maintain the invariants.
+/// maps each [InterfaceElement] which is a direct subclass of a mixin
+/// application to its superclass. The latter is needed because the analyzer
+/// representation of mixins and mixin applications makes it difficult to find
+/// a superclass which is a mixin application (`InterfaceElement.supertype` is
+/// the _syntactic_ superclass, that is, for `class C extends B with M..` it
+/// is `B`, not the mixin application `B with M`). The three data structures
+/// are bundled together in this class because they must remain consistent and
+/// hence all operations on them should be expressed in one location, namely
+/// this class. Note that this data structure can delegate all read-only
+/// operations to the [interfaceElements], because they will not break
+/// consistency, but for every mutating method we need to maintain the
+/// invariants.
 class _InterfaceElementEnhancedSet implements Set<InterfaceElement> {
   final _ReflectorDomain reflectorDomain;
   final Enumerator<InterfaceElement> interfaceElements =

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -5476,17 +5476,18 @@ class MixinApplication implements ClassElement {
   @override
   int get nameOffset => -1;
 
-  @override
-  bool get isAbstract {
-    if (!isMixinApplication) return true;
-    var mixin = this.mixin;
-    return mixin is MixinElement || (mixin is ClassElement && mixin.isAbstract);
-  }
-
   /// Returns true iff this class was declared using the syntax
   /// `class B = A with M;`, i.e., if it is an explicitly named mixin
   /// application.
   bool get isMixinApplication => declaredName != null;
+
+  @override
+  bool get isAbstract {
+    var mixin = this.mixin;
+    return !isMixinApplication ||
+        mixin is MixinElement && mixin.isAbstract ||
+        mixin is ClassElement && mixin.isAbstract;
+  }
 
   // This seems to be the defined behaviour according to dart:mirrors.
   @override

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -3632,26 +3632,9 @@ class BuilderImplementation {
                   continue;
                 }
               }
-              if (metadataFieldValue is InterfaceElement) {
-                globalMetadata
-                    .putIfAbsent(metadataFieldValue, () => <InterfaceElement>[])
-                    .add(reflector);
-              } else {
-                // TODO(eernst): We don't support non-class `Type` values.
-                // However, it might be (weirdly) useful to allow `dynamic` in
-                // order to cover _everything_ that has an annotation at all,
-                // and maybe other things like function types as metadata.
-                var metadataType = constantValue.getField('metadataType');
-                var metadataTypeType = metadataType?.type;
-                if (metadataTypeType is InterfaceType) {
-                  var typeName = metadataTypeType.element2.name;
-                  var message =
-                      'The metadata must be a class type. Found $typeName.';
-                  await _warn(
-                      WarningKind.badMetadata, message, metadatumElement);
-                }
-                continue;
-              }
+              globalMetadata
+                  .putIfAbsent(metadataFieldValue, () => <InterfaceElement>[])
+                  .add(reflector);
             }
           }
         }
@@ -5492,6 +5475,7 @@ class MixinApplication implements ClassElement {
   /// Returns true iff this class was declared using the syntax
   /// `class B = A with M;`, i.e., if it is an explicitly named mixin
   /// application.
+  @override
   bool get isMixinApplication => declaredName != null;
 
   @override

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -2880,10 +2880,17 @@ class _ClassDomain {
         }
       }
 
+      Map<String, ExecutableElement> cacheResult(
+          Map<String, ExecutableElement> result) {
+        result = Map.unmodifiable(result);
+        _reflectorDomain._instanceMemberCache[interfaceElement] = result;
+        return result;
+      }
+
       if (interfaceElement is MixinApplication) {
         helper(interfaceElement.superclass).forEach(addIfCapable);
         helper(interfaceElement.mixin).forEach(addIfCapable);
-        return result;
+        return cacheResult(result);
       }
       var superclassType = interfaceElement.supertype;
       if (superclassType is InterfaceType) {
@@ -2893,9 +2900,7 @@ class _ClassDomain {
         interfaceElement.methods.forEach(addIfCapableConcreteInstance);
         interfaceElement.accessors.forEach(addIfCapableConcreteInstance);
       }
-      _reflectorDomain._instanceMemberCache[interfaceElement] =
-          Map.unmodifiable(result);
-      return result;
+      return cacheResult(result);
     }
 
     return helper(_interfaceElement).values;

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -1443,6 +1443,10 @@ class _ReflectorDomain {
 
     String constructorsCode;
     if (interfaceElement is MixinApplication) {
+      // There may be any number of constructors, but they are implicitly
+      // induced forwarding constructors, so it won't help anybody to be
+      // able to get to them. Also, we can't invoke them because the mixin
+      // application is an abstract class.
       constructorsCode = 'const {}';
     } else {
       List<String> mapEntries = [];

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -4445,13 +4445,13 @@ int _topLevelVariableDescriptor(TopLevelVariableElement element) {
       result |= constants.classTypeAttribute;
     }
     result |= constants.topLevelAttribute;
-    LibraryElement library = element.library;
-    if (library.typeSystem.isNullable(declaredType)) {
-      result |= constants.nullableAttribute;
-    }
-    if (library.typeSystem.isNonNullable(declaredType)) {
-      result |= constants.nonNullableAttribute;
-    }
+  }
+  LibraryElement library = element.library;
+  if (library.typeSystem.isNullable(declaredType)) {
+    result |= constants.nullableAttribute;
+  }
+  if (library.typeSystem.isNonNullable(declaredType)) {
+    result |= constants.nonNullableAttribute;
   }
   return result;
 }
@@ -4484,13 +4484,13 @@ int _fieldDescriptor(FieldElement element) {
         result |= constants.genericTypeAttribute;
       }
     }
-    LibraryElement library = element.library;
-    if (library.typeSystem.isNullable(declaredType)) {
-      result |= constants.nullableAttribute;
-    }
-    if (library.typeSystem.isNonNullable(declaredType)) {
-      result |= constants.nonNullableAttribute;
-    }
+  }
+  LibraryElement library = element.library;
+  if (library.typeSystem.isNullable(declaredType)) {
+    result |= constants.nullableAttribute;
+  }
+  if (library.typeSystem.isNonNullable(declaredType)) {
+    result |= constants.nonNullableAttribute;
   }
   return result;
 }
@@ -4520,14 +4520,14 @@ int _parameterDescriptor(ParameterElement element) {
         result |= constants.genericTypeAttribute;
       }
     }
-    LibraryElement? library = element.library;
-    if (library != null) {
-      if (library.typeSystem.isNullable(declaredType)) {
-        result |= constants.nullableAttribute;
-      }
-      if (library.typeSystem.isNonNullable(declaredType)) {
-        result |= constants.nonNullableAttribute;
-      }
+  }
+  LibraryElement? library = element.library;
+  if (library != null) {
+    if (library.typeSystem.isNullable(declaredType)) {
+      result |= constants.nullableAttribute;
+    }
+    if (library.typeSystem.isNonNullable(declaredType)) {
+      result |= constants.nonNullableAttribute;
     }
   }
   return result;

--- a/reflectable/lib/src/element_capability.dart
+++ b/reflectable/lib/src/element_capability.dart
@@ -35,7 +35,7 @@ abstract class NamePatternCapability implements ApiReflectCapability {
 }
 
 abstract class MetadataQuantifiedCapability implements ApiReflectCapability {
-  final ClassElement metadataType;
+  final InterfaceElement metadataType;
   const MetadataQuantifiedCapability(this.metadataType);
 }
 
@@ -46,7 +46,7 @@ class InstanceInvokeCapability extends NamePatternCapability {
 const instanceInvokeCapability = InstanceInvokeCapability('');
 
 class InstanceInvokeMetaCapability extends MetadataQuantifiedCapability {
-  const InstanceInvokeMetaCapability(ClassElement metadataType)
+  const InstanceInvokeMetaCapability(InterfaceElement metadataType)
       : super(metadataType);
 }
 
@@ -59,7 +59,7 @@ const staticInvokeCapability = StaticInvokeCapability('');
 
 class StaticInvokeMetaCapability extends MetadataQuantifiedCapability
     implements TypeCapability {
-  const StaticInvokeMetaCapability(ClassElement metadataType)
+  const StaticInvokeMetaCapability(InterfaceElement metadataType)
       : super(metadataType);
 }
 
@@ -68,7 +68,7 @@ class TopLevelInvokeCapability extends NamePatternCapability {
 }
 
 class TopLevelInvokeMetaCapability extends MetadataQuantifiedCapability {
-  const TopLevelInvokeMetaCapability(ClassElement metadataType)
+  const TopLevelInvokeMetaCapability(InterfaceElement metadataType)
       : super(metadataType);
 }
 
@@ -81,7 +81,7 @@ const newInstanceCapability = NewInstanceCapability('');
 
 class NewInstanceMetaCapability extends MetadataQuantifiedCapability
     implements TypeCapability {
-  const NewInstanceMetaCapability(ClassElement metadataType)
+  const NewInstanceMetaCapability(InterfaceElement metadataType)
       : super(metadataType);
 }
 
@@ -172,7 +172,8 @@ class InvokingMetaCapability extends MetadataQuantifiedCapability
         InstanceInvokeMetaCapability,
         StaticInvokeMetaCapability,
         NewInstanceMetaCapability {
-  const InvokingMetaCapability(ClassElement metadataType) : super(metadataType);
+  const InvokingMetaCapability(InterfaceElement metadataType)
+      : super(metadataType);
 }
 
 class TypingCapability

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  analyzer: ^4.6.0
+  analyzer: ^5.0.0
   build: ^2.0.0
   build_resolvers: ^2.0.0
   build_config: ^1.0.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,11 +1,11 @@
 name: reflectable
-version: 3.1.0
+version: 4.0.0
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
 homepage: https://github.com/google/reflectable.dart
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 dependencies:
   analyzer: ^5.0.0
   build: ^2.0.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 3.0.10
+version: 3.1.0
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.

--- a/reflectable/tool/publish
+++ b/reflectable/tool/publish
@@ -68,7 +68,9 @@ echo "Using tag value '$TAG_VALUE'."
 echo -n "Check entry in CHANGELOG.md and version in pubspec.yaml: $VERSION"
 read
 
-echo ">>>>>> Check `dart format`: no effect, `dart analyze`: no issues"
+echo ">>>>>> Check 'dart format .': no effect, 'dart analyze .': no issues"
+dart format .
+dart analyze .
 echo ">>>>>> Ensure that github master is the version to publish"
 read
 

--- a/test_reflectable/test/legacy/meta_reflector_test.dart
+++ b/test_reflectable/test/legacy/meta_reflector_test.dart
@@ -175,8 +175,9 @@ void testReflector(Reflectable reflector, String desc) {
     expect(cMirror.superclass.superclass.mixin, m2Mirror);
     expect(cMirror.superclass.mixin, m3Mirror);
     expect(cMirror.superclass.superclass.superclass, bMirror);
-    expect(dMirror.mixin, m1Mirror);
-    expect(dMirror.superclass.mixin, aMirror);
+    expect(dMirror.mixin, dMirror);
+    expect(dMirror.superclass.mixin, m1Mirror);
+    expect(dMirror.superclass.superclass.mixin, aMirror);
     expect(bMirror.superclass.declarations['foo'].owner, m1Mirror);
     expect(bMirror.superclass.declarations['field'].owner, m1Mirror);
     expect(bMirror.superclass.declarations['staticBar'], null);
@@ -233,7 +234,7 @@ void main() {
     ClassMirror m3Mirror = reflector2.reflectType(M3);
     expect(bMirror.mixin, bMirror);
     expect(cMirror.mixin, cMirror);
-    expect(dMirror.mixin, m1Mirror);
+    expect(dMirror.mixin, dMirror);
     expect(m1Mirror.mixin, m1Mirror);
     // Test that metadata is preserved.
     expect(m1Mirror.metadata, contains(const P()));
@@ -248,7 +249,8 @@ void main() {
     expect(cMirror.superclass.superclass.mixin, m2Mirror);
     expect(cMirror.superclass.mixin, m3Mirror);
     expect(cMirror.superclass.superclass.superclass, bMirror);
-    expect(() => dMirror.superclass, throwsANoSuchCapabilityException);
+    expect(
+        () => dMirror.superclass.superclass, throwsANoSuchCapabilityException);
   });
 
   test('MetaReflector, select by capability', () {
@@ -273,7 +275,7 @@ void main() {
     expect(cMirror.superclass.mixin, m3Mirror);
     expect(cMirror.superclass.superclass.mixin, m2Mirror);
     expect(cMirror.superclass.superclass.superclass, bMirror);
-    expect(dMirror.mixin, m1Mirror);
-    expect(dMirror.superclass, aMirror);
+    expect(dMirror.superclass.mixin, m1Mirror);
+    expect(dMirror.superclass.superclass, aMirror);
   });
 }

--- a/test_reflectable/test/legacy/meta_reflectors_user.dart
+++ b/test_reflectable/test/legacy/meta_reflectors_user.dart
@@ -39,8 +39,9 @@ void testReflector(Reflectable reflector, String desc) {
     expect(cMirror.superclass.superclass.mixin, m2Mirror);
     expect(cMirror.superclass.mixin, m3Mirror);
     expect(cMirror.superclass.superclass.superclass, bMirror);
-    expect(dMirror.mixin, m1Mirror);
-    expect(dMirror.superclass.mixin, aMirror);
+    expect(dMirror.mixin, dMirror);
+    expect(dMirror.superclass.mixin, m1Mirror);
+    expect(dMirror.superclass.superclass.mixin, aMirror);
     expect(bMirror.superclass.declarations['foo'].owner, m1Mirror);
     expect(bMirror.superclass.declarations['field'].owner, m1Mirror);
     expect(bMirror.superclass.declarations['staticBar'], null);
@@ -95,7 +96,7 @@ void runTests() {
     ClassMirror m3Mirror = reflector2.reflectType(M3);
     expect(bMirror.mixin, bMirror);
     expect(cMirror.mixin, cMirror);
-    expect(dMirror.mixin, m1Mirror);
+    expect(dMirror.mixin, dMirror);
     expect(m1Mirror.mixin, m1Mirror);
     // Test that metadata is preserved.
     expect(m1Mirror.metadata, contains(const P()));
@@ -110,7 +111,8 @@ void runTests() {
     expect(cMirror.superclass.superclass.mixin, m2Mirror);
     expect(cMirror.superclass.mixin, m3Mirror);
     expect(cMirror.superclass.superclass.superclass, bMirror);
-    expect(() => dMirror.superclass, throwsANoSuchCapabilityException);
+    expect(
+        () => dMirror.superclass.superclass, throwsANoSuchCapabilityException);
   });
 
   test('MetaReflector, select by capability', () {
@@ -135,7 +137,8 @@ void runTests() {
     expect(cMirror.superclass.mixin, m3Mirror);
     expect(cMirror.superclass.superclass.mixin, m2Mirror);
     expect(cMirror.superclass.superclass.superclass, bMirror);
-    expect(dMirror.mixin, m1Mirror);
-    expect(dMirror.superclass, aMirror);
+    expect(dMirror.mixin, dMirror);
+    expect(dMirror.superclass.mixin, m1Mirror);
+    expect(dMirror.superclass.superclass, aMirror);
   });
 }

--- a/test_reflectable/test/legacy/mixin_test.dart
+++ b/test_reflectable/test/legacy/mixin_test.dart
@@ -130,8 +130,9 @@ void testReflector(Reflectable reflector, String desc) {
     expect(cMirror.superclass.superclass.mixin, m2Mirror);
     expect(cMirror.superclass.mixin, m3Mirror);
     expect(cMirror.superclass.superclass.superclass, bMirror);
-    expect(dMirror.mixin, m1Mirror);
-    expect(dMirror.superclass.mixin, aMirror);
+    expect(dMirror.mixin, dMirror);
+    expect(dMirror.superclass.mixin, m1Mirror);
+    expect(dMirror.superclass.superclass.mixin, aMirror);
     expect(bMirror.superclass.declarations['foo'].owner, m1Mirror);
     expect(bMirror.superclass.declarations['field'].owner, m1Mirror);
     expect(bMirror.superclass.declarations['staticBar'], null);
@@ -160,7 +161,7 @@ void main() {
     ClassMirror m3Mirror = reflector2.reflectType(M3);
     expect(bMirror.mixin, bMirror);
     expect(cMirror.mixin, cMirror);
-    expect(dMirror.mixin, m1Mirror);
+    expect(dMirror.mixin, dMirror);
     expect(m1Mirror.mixin, m1Mirror);
     // Test that metadata is preserved.
     expect(m1Mirror.metadata, contains(const P()));
@@ -175,7 +176,8 @@ void main() {
     expect(cMirror.superclass.superclass.mixin, m2Mirror);
     expect(cMirror.superclass.mixin, m3Mirror);
     expect(cMirror.superclass.superclass.superclass, bMirror);
-    expect(() => dMirror.superclass, throwsANoSuchCapabilityException);
+    expect(
+        () => dMirror.superclass.superclass, throwsANoSuchCapabilityException);
   });
   test('Mixin, superclasses included up to bound', () {
     var reflector = const ReflectorUpwardsClosedToA();
@@ -194,8 +196,8 @@ void main() {
     expect(cMirror.superclass.mixin, m3Mirror);
     expect(cMirror.superclass.superclass.mixin, m2Mirror);
     expect(cMirror.superclass.superclass.superclass, bMirror);
-    expect(dMirror.mixin, m1Mirror);
-    expect(dMirror.superclass, aMirror);
+    expect(dMirror.superclass.mixin, m1Mirror);
+    expect(dMirror.superclass.superclass, aMirror);
   });
   test('Mixin, superclasses included up to but not including bound', () {
     var reflector = const ReflectorUpwardsClosedUntilA();
@@ -215,8 +217,10 @@ void main() {
     expect(cMirror.superclass.superclass.superclass.superclass != null, true);
     expect(() => cMirror.superclass.superclass.superclass.superclass.superclass,
         throwsANoSuchCapabilityException);
-    expect(dMirror.mixin, m1Mirror);
-    expect(() => dMirror.superclass, throwsANoSuchCapabilityException);
+    expect(dMirror.mixin, dMirror);
+    expect(dMirror.superclass.mixin, m1Mirror);
+    expect(
+        () => dMirror.superclass.superclass, throwsANoSuchCapabilityException);
   });
   test('Mixin, naming', () {
     var reflector2 = const Reflector2();

--- a/test_reflectable/test/meta_reflector_test.dart
+++ b/test_reflectable/test/meta_reflector_test.dart
@@ -174,8 +174,9 @@ void testReflector(Reflectable reflector, String desc) {
     expect(cMirror.superclass!.superclass!.mixin, m2Mirror);
     expect(cMirror.superclass!.mixin, m3Mirror);
     expect(cMirror.superclass!.superclass!.superclass, bMirror);
-    expect(dMirror.mixin, m1Mirror);
-    expect(dMirror.superclass!.mixin, aMirror);
+    expect(dMirror.mixin, dMirror);
+    expect(dMirror.superclass!.mixin, m1Mirror);
+    expect(dMirror.superclass!.superclass!.mixin, aMirror);
     expect(bMirror.superclass!.declarations['foo']!.owner, m1Mirror);
     expect(bMirror.superclass!.declarations['field']!.owner, m1Mirror);
     expect(bMirror.superclass!.declarations['staticBar'], null);
@@ -232,7 +233,7 @@ void main() {
     var m3Mirror = reflector2.reflectType(M3) as ClassMirror;
     expect(bMirror.mixin, bMirror);
     expect(cMirror.mixin, cMirror);
-    expect(dMirror.mixin, m1Mirror);
+    expect(dMirror.mixin, dMirror);
     expect(m1Mirror.mixin, m1Mirror);
     // Test that metadata is preserved.
     expect(m1Mirror.metadata, contains(const P()));
@@ -247,7 +248,8 @@ void main() {
     expect(cMirror.superclass!.superclass!.mixin, m2Mirror);
     expect(cMirror.superclass!.mixin, m3Mirror);
     expect(cMirror.superclass!.superclass!.superclass, bMirror);
-    expect(() => dMirror.superclass, throwsANoSuchCapabilityException);
+    expect(
+        () => dMirror.superclass!.superclass, throwsANoSuchCapabilityException);
   });
 
   test('MetaReflector, select by capability', () {
@@ -272,7 +274,8 @@ void main() {
     expect(cMirror.superclass!.mixin, m3Mirror);
     expect(cMirror.superclass!.superclass!.mixin, m2Mirror);
     expect(cMirror.superclass!.superclass!.superclass, bMirror);
-    expect(dMirror.mixin, m1Mirror);
-    expect(dMirror.superclass, aMirror);
+    expect(dMirror.mixin, dMirror);
+    expect(dMirror.superclass!.mixin, m1Mirror);
+    expect(dMirror.superclass!.superclass, aMirror);
   });
 }

--- a/test_reflectable/test/meta_reflectors_user.dart
+++ b/test_reflectable/test/meta_reflectors_user.dart
@@ -38,8 +38,9 @@ void testReflector(Reflectable reflector, String desc) {
     expect(cMirror.superclass!.superclass!.mixin, m2Mirror);
     expect(cMirror.superclass!.mixin, m3Mirror);
     expect(cMirror.superclass!.superclass!.superclass, bMirror);
-    expect(dMirror.mixin, m1Mirror);
-    expect(dMirror.superclass!.mixin, aMirror);
+    expect(dMirror.mixin, dMirror);
+    expect(dMirror.superclass!.mixin, m1Mirror);
+    expect(dMirror.superclass!.superclass!.mixin, aMirror);
     expect(bMirror.superclass!.declarations['foo']!.owner, m1Mirror);
     expect(bMirror.superclass!.declarations['field']!.owner, m1Mirror);
     expect(bMirror.superclass!.declarations['staticBar'], null);
@@ -94,7 +95,7 @@ void runTests() {
     var m3Mirror = reflector2.reflectType(M3) as ClassMirror;
     expect(bMirror.mixin, bMirror);
     expect(cMirror.mixin, cMirror);
-    expect(dMirror.mixin, m1Mirror);
+    expect(dMirror.mixin, dMirror);
     expect(m1Mirror.mixin, m1Mirror);
     // Test that metadata is preserved.
     expect(m1Mirror.metadata, contains(const P()));
@@ -109,7 +110,8 @@ void runTests() {
     expect(cMirror.superclass!.superclass!.mixin, m2Mirror);
     expect(cMirror.superclass!.mixin, m3Mirror);
     expect(cMirror.superclass!.superclass!.superclass, bMirror);
-    expect(() => dMirror.superclass, throwsANoSuchCapabilityException);
+    expect(
+        () => dMirror.superclass!.superclass, throwsANoSuchCapabilityException);
   });
 
   test('MetaReflector, select by capability', () {
@@ -134,7 +136,8 @@ void runTests() {
     expect(cMirror.superclass!.mixin, m3Mirror);
     expect(cMirror.superclass!.superclass!.mixin, m2Mirror);
     expect(cMirror.superclass!.superclass!.superclass, bMirror);
-    expect(dMirror.mixin, m1Mirror);
-    expect(dMirror.superclass, aMirror);
+    expect(dMirror.mixin, dMirror);
+    expect(dMirror.superclass!.mixin, m1Mirror);
+    expect(dMirror.superclass!.superclass, aMirror);
   });
 }

--- a/test_reflectable/test/mixin_test.dart
+++ b/test_reflectable/test/mixin_test.dart
@@ -129,8 +129,9 @@ void testReflector(Reflectable reflector, String desc) {
     expect(cMirror.superclass!.superclass!.mixin, m2Mirror);
     expect(cMirror.superclass!.mixin, m3Mirror);
     expect(cMirror.superclass!.superclass!.superclass, bMirror);
-    expect(dMirror.mixin, m1Mirror);
-    expect(dMirror.superclass!.mixin, aMirror);
+    expect(dMirror.mixin, dMirror);
+    expect(dMirror.superclass!.mixin, m1Mirror);
+    expect(dMirror.superclass!.superclass!.mixin, aMirror);
     expect(bMirror.superclass!.declarations['foo']!.owner, m1Mirror);
     expect(bMirror.superclass!.declarations['field']!.owner, m1Mirror);
     expect(bMirror.superclass!.declarations['staticBar'], null);
@@ -159,7 +160,7 @@ void main() {
     var m3Mirror = reflector2.reflectType(M3) as ClassMirror;
     expect(bMirror.mixin, bMirror);
     expect(cMirror.mixin, cMirror);
-    expect(dMirror.mixin, m1Mirror);
+    expect(dMirror.mixin, dMirror);
     expect(m1Mirror.mixin, m1Mirror);
     // Test that metadata is preserved.
     expect(m1Mirror.metadata, contains(const P()));
@@ -174,7 +175,8 @@ void main() {
     expect(cMirror.superclass!.superclass!.mixin, m2Mirror);
     expect(cMirror.superclass!.mixin, m3Mirror);
     expect(cMirror.superclass!.superclass!.superclass, bMirror);
-    expect(() => dMirror.superclass, throwsANoSuchCapabilityException);
+    expect(
+        () => dMirror.superclass!.superclass, throwsANoSuchCapabilityException);
   });
   test('Mixin, superclasses included up to bound', () {
     var reflector = const ReflectorUpwardsClosedToA();
@@ -193,8 +195,9 @@ void main() {
     expect(cMirror.superclass!.mixin, m3Mirror);
     expect(cMirror.superclass!.superclass!.mixin, m2Mirror);
     expect(cMirror.superclass!.superclass!.superclass, bMirror);
-    expect(dMirror.mixin, m1Mirror);
-    expect(dMirror.superclass, aMirror);
+    expect(dMirror.mixin, dMirror);
+    expect(dMirror.superclass!.mixin, m1Mirror);
+    expect(dMirror.superclass!.superclass, aMirror);
   });
   test('Mixin, superclasses included up to but not including bound', () {
     var reflector = const ReflectorUpwardsClosedUntilA();
@@ -217,8 +220,10 @@ void main() {
         () =>
             cMirror.superclass!.superclass!.superclass!.superclass!.superclass,
         throwsANoSuchCapabilityException);
-    expect(dMirror.mixin, m1Mirror);
-    expect(() => dMirror.superclass, throwsANoSuchCapabilityException);
+    expect(dMirror.mixin, dMirror);
+    expect(dMirror.superclass!.mixin, m1Mirror);
+    expect(
+        () => dMirror.superclass!.superclass, throwsANoSuchCapabilityException);
   });
   test('Mixin, naming', () {
     var reflector2 = const Reflector2();


### PR DESCRIPTION
The analyzer changed in several ways, and this migration gave rise to many changes. In particular, mixins and enums are no longer represented as `ClassElement`s with an `isEnum` and an `isMixin`, and this causes many changes to types and type tests.


