### PR TITLE
Update CHANGELOG.md and pubspec.yaml to release as 3.0.10

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.10
+
+* Perform a minimal migration to use analyzer 4.6.0.
+
 ## 3.0.9
 
 * Add support for checking whether a `TypeMirror` is reflecting on a

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 3.0.9
+version: 3.0.10
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.


### PR DESCRIPTION
https://github.com/google/reflectable.dart/pull/287 was contributed by @ashutosh2014, updating reflectable to work with analyzer 4.6.0. On top of that, this PR prepares reflectable for release as version 3.0.10.