### PR TITLE
Update reflectable to use build_resolver 2.1.0

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 4.0.2
+
+* Change handling of 'dart:...' libraries, to handle new behavior by
+  `build_resolvers` 2.1.0: 'dart:html' wasn't reported before by
+  `resolver.libraries`, but is now included. To preserve existing
+  behavior (and avoid generating code that imports 'dart:html'), this
+  update removes 'dart:html' from the set of libraries that are
+  considered "importable" by generated code.
+
 ## 4.0.1
 
 * Update reflectable to use (and require) analyzer 5.2.0. This is a

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -4867,7 +4867,6 @@ const Set<String> sdkLibraryNames = <String>{
   'convert',
   'core',
   'developer',
-  'html',
   'indexed_db',
   'io',
   'isolate',

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -5661,6 +5661,15 @@ Future<AstNode?> _getDeclarationAst(Element element, Resolver resolver) =>
 /// which will be thrown if we use `library.session` directly.
 Future<ResolvedLibraryResult?> _getResolvedLibrary(
     LibraryElement library, Resolver resolver) async {
+  final freshLibrary =
+      await resolver.libraryFor(await resolver.assetIdForElement(library));
+  final freshSession = freshLibrary.session;
+  var someResult =
+      await freshSession.getResolvedLibraryByElement(freshLibrary);
+  if (someResult is ResolvedLibraryResult) return someResult;
+  else return null;
+
+/*
   // This is expensive, but seems to be necessary. It is using the workaround
   // mentioned in dart-lang/build#2634. If we do not fetch a fresh session
   // then the code generation stops with an `InconsistentAnalysisException`
@@ -5687,4 +5696,5 @@ Future<ResolvedLibraryResult?> _getResolvedLibrary(
       }
     }
   }
+*/
 }

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -3616,9 +3616,8 @@ class BuilderImplementation {
                   .getField('(super)')
                   ?.getField('reflector')
                   ?.type;
-              var reflector = reflectorType is InterfaceType
-                  ? reflectorType.element
-                  : null;
+              var reflector =
+                  reflectorType is InterfaceType ? reflectorType.element : null;
               if (reflector == null) {
                 await _warn(
                     WarningKind.badSuperclass,
@@ -4033,9 +4032,8 @@ class BuilderImplementation {
         return null;
       }
       var metadataFieldType = constantSuperMetadataType.toTypeValue();
-      Object? metadataFieldValue = metadataFieldType is InterfaceType
-          ? metadataFieldType.element
-          : null;
+      Object? metadataFieldValue =
+          metadataFieldType is InterfaceType ? metadataFieldType.element : null;
       if (metadataFieldValue is InterfaceElement) return metadataFieldValue;
       await _warn(
           WarningKind.badMetadata,
@@ -5664,37 +5662,11 @@ Future<ResolvedLibraryResult?> _getResolvedLibrary(
   final freshLibrary =
       await resolver.libraryFor(await resolver.assetIdForElement(library));
   final freshSession = freshLibrary.session;
-  var someResult =
-      await freshSession.getResolvedLibraryByElement(freshLibrary);
-  if (someResult is ResolvedLibraryResult) return someResult;
-  else return null;
-
-/*
-  // This is expensive, but seems to be necessary. It is using the workaround
-  // mentioned in dart-lang/build#2634. If we do not fetch a fresh session
-  // then the code generation stops with an `InconsistentAnalysisException`
-  // if there is more than one entry point. This workaround turned out to be
-  // insufficient with analyzer 0.40.5, and the while loop was proposed as a
-  // workaround to the workaround in
-  //   https://github.com/google/built_value.dart/issues/
-  //   941#issuecomment-731077220.
-  var attempts = 0;
-  while (true) {
-    try {
-      final freshLibrary =
-          await resolver.libraryFor(await resolver.assetIdForElement(library));
-      final freshSession = freshLibrary.session;
-      var someResult =
-          await freshSession.getResolvedLibraryByElement(freshLibrary);
-      if (someResult is ResolvedLibraryResult) return someResult;
-    } catch (_) {
-      ++attempts;
-      if (attempts == 10) {
-        log.severe('Internal error: Analysis session '
-            'did not stabilize after ten attempts!');
-        return null;
-      }
-    }
+  var someResult = await freshSession.getResolvedLibraryByElement(freshLibrary);
+  if (someResult is ResolvedLibraryResult) {
+    return someResult;
+  } else {
+    log.severe('Internal error: Inconsistent analysis session!');
+    return null;
   }
-*/
 }

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 4.0.1
+version: 4.0.2
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.


### PR DESCRIPTION
This PR changes reflectable such that it does not consider 'dart:html' as a library which can be imported by generated code. This used to be the case anyway, but build_resolvers 2.1.0 has added 'dart:html' to `resolver.libraries`, and this causes reflectable to generate code that imports 'dart:html' (and it has no notion about being on a platform where that library does or does not exist). Hence, this change preserves the behavior we have had until now.

The PR removes the workaround which was needed as described in https://github.com/google/reflectable.dart/issues/269. The InconsistentAnalysisException does not seem to occur any longer.

The PR also prepares reflectable for being released as version 4.0.2.
