### PR TITLE
Adjust the documentation links given for the 4.0.5 CHANGELOG entry

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -13,10 +13,12 @@
   libraries, and that property also holds with this change.
 
   For documentation about how these URIs are generated, please see
-  https://pub.dev/documentation/build/latest/build/Resolver/assetIdForElement.html .
+  https://pub.dev/documentation/build/latest/build/AssetId/uri.html and
+  https://pub.dev/documentation/build/latest/build/AssetId-class.html .
 
   For documentation about package URIs, please see
-  https://api.dart.dev/stable/2.19.2/dart-isolate/Isolate/packageConfig.html .
+  https://api.dart.dev/stable/2.19.2/dart-isolate/Isolate/packageConfig.html 
+  and, for example, https://pub.dev/packages/package_config .
 
 ## 4.0.4
 


### PR DESCRIPTION
I think it would be useful to adjust the links in the 4.0.5 CHANGELOG entry: I added a link to the DartDoc page for the `uri` getter itself, along with the link to the `AssetId` class. For the `packageConfig` getter, I added a link to the `package_config` package, whose README has a very good overview of what a package config file is in the first place, plus a link to the feature spec. I think it would be helpful to make those adjustments before 4.0.5 is published.
