### PR TITLE
Upgrade reflectable to use new version of analyzer

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.6
+
+* Update dependencies to use analyzer 6.3.0.
+
 ## 4.0.5
 
 * Remove legacy tests (they cannot be executed when using a version of Dart

--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.0.6
 
-* Update dependencies to use analyzer 6.3.0.
+* Update dependencies to use analyzer 6.4.0.
 
 ## 4.0.5
 

--- a/reflectable/example/example.dart
+++ b/reflectable/example/example.dart
@@ -3,7 +3,7 @@
 // the LICENSE file.
 
 // Try out some reflective invocations.
-// Build with `cd ..; dart pub run build_runner build example`.
+// Build with `cd ..; dart run build_runner build example`.
 
 import 'package:reflectable/reflectable.dart';
 import 'example.reflectable.dart';

--- a/reflectable/example/example.dart
+++ b/reflectable/example/example.dart
@@ -3,7 +3,7 @@
 // the LICENSE file.
 
 // Try out some reflective invocations.
-// Build with `cd ..; pub run build_runner build example`.
+// Build with `cd ..; dart pub run build_runner build example`.
 
 import 'package:reflectable/reflectable.dart';
 import 'example.reflectable.dart';

--- a/reflectable/lib/capability.dart
+++ b/reflectable/lib/capability.dart
@@ -90,7 +90,7 @@ abstract class MetadataQuantifiedCapability implements ApiReflectCapability {
 /// getters, and setters) matching [namePattern] interpreted as a regular
 /// expression.
 class InstanceInvokeCapability extends NamePatternCapability {
-  const InstanceInvokeCapability(String namePattern) : super(namePattern);
+  const InstanceInvokeCapability(super.namePattern);
 }
 
 /// Short hand for `InstanceInvokeCapability('')`, meaning the capability to
@@ -101,7 +101,7 @@ const instanceInvokeCapability = InstanceInvokeCapability('');
 /// getters, and setters) annotated with instances of [metadataType] or a
 /// subtype thereof.
 class InstanceInvokeMetaCapability extends MetadataQuantifiedCapability {
-  const InstanceInvokeMetaCapability(Type metadataType) : super(metadataType);
+  const InstanceInvokeMetaCapability(super.metadataType);
 }
 
 /// Gives support for reflective invocation of static members (static methods,
@@ -109,7 +109,7 @@ class InstanceInvokeMetaCapability extends MetadataQuantifiedCapability {
 /// expression.
 class StaticInvokeCapability extends NamePatternCapability
     implements TypeCapability {
-  const StaticInvokeCapability(String namePattern) : super(namePattern);
+  const StaticInvokeCapability(super.namePattern);
 }
 
 /// Short hand for `StaticInvokeCapability('')`, meaning the capability to
@@ -121,14 +121,14 @@ const staticInvokeCapability = StaticInvokeCapability('');
 /// or a subtype thereof.
 class StaticInvokeMetaCapability extends MetadataQuantifiedCapability
     implements TypeCapability {
-  const StaticInvokeMetaCapability(Type metadata) : super(metadata);
+  const StaticInvokeMetaCapability(super.metadata);
 }
 
 /// Gives support for reflective invocation of top-level members (top-level
 /// methods, getters, and setters) matching [namePattern] interpreted as a
 /// regular expression.
 class TopLevelInvokeCapability extends NamePatternCapability {
-  const TopLevelInvokeCapability(String namePattern) : super(namePattern);
+  const TopLevelInvokeCapability(super.namePattern);
 }
 
 /// Short hand for `TopLevelInvokeCapability('')`, meaning the capability to
@@ -139,7 +139,7 @@ const topLevelInvokeCapability = TopLevelInvokeCapability('');
 /// methods, getters, and setters) that are annotated with instances of
 /// [metadataType].
 class TopLevelInvokeMetaCapability extends MetadataQuantifiedCapability {
-  const TopLevelInvokeMetaCapability(Type metadataType) : super(metadataType);
+  const TopLevelInvokeMetaCapability(super.metadataType);
 }
 
 /// Gives support for reflective invocation of constructors (of all kinds)
@@ -151,7 +151,7 @@ class TopLevelInvokeMetaCapability extends MetadataQuantifiedCapability {
 /// to perform a `newInstance` operation without class mirrors.
 class NewInstanceCapability extends NamePatternCapability
     implements TypeCapability {
-  const NewInstanceCapability(String namePattern) : super(namePattern);
+  const NewInstanceCapability(super.namePattern);
 }
 
 /// Short hand for `const NewInstanceCapability('')`, meaning the capability to
@@ -163,7 +163,7 @@ const newInstanceCapability = NewInstanceCapability('');
 /// or a subtype thereof.
 class NewInstanceMetaCapability extends MetadataQuantifiedCapability
     implements TypeCapability {
-  const NewInstanceMetaCapability(Type metadataType) : super(metadataType);
+  const NewInstanceMetaCapability(super.metadataType);
 }
 
 /// Gives support for reflective access to metadata associated with a
@@ -264,7 +264,7 @@ class InvokingCapability extends NamePatternCapability
         InstanceInvokeCapability,
         StaticInvokeCapability,
         NewInstanceCapability {
-  const InvokingCapability(String namePattern) : super(namePattern);
+  const InvokingCapability(super.namePattern);
 }
 
 /// Short hand for `InvokingCapability('')`.
@@ -279,7 +279,7 @@ class InvokingMetaCapability extends MetadataQuantifiedCapability
         InstanceInvokeMetaCapability,
         StaticInvokeMetaCapability,
         NewInstanceMetaCapability {
-  const InvokingMetaCapability(Type metadataType) : super(metadataType);
+  const InvokingMetaCapability(super.metadataType);
 }
 
 /// Gives the capabilities of [TypeCapability], [metadataCapability],

--- a/reflectable/lib/reflectable.dart
+++ b/reflectable/lib/reflectable.dart
@@ -126,8 +126,7 @@ abstract class Reflectable extends implementation.ReflectableImpl
       super.cap8,
       super.cap9]);
 
-  const Reflectable.fromList(super.capabilities)
-      : super.fromList();
+  const Reflectable.fromList(super.capabilities) : super.fromList();
 
   /// Returns the canonicalized instance of the given reflector [type].
   ///

--- a/reflectable/lib/reflectable.dart
+++ b/reflectable/lib/reflectable.dart
@@ -115,20 +115,19 @@ abstract class Reflectable extends implementation.ReflectableImpl
   /// Const constructor, to enable usage as metadata, allowing for varargs
   /// style invocation with up to ten arguments.
   const Reflectable(
-      [ReflectCapability? cap0,
-      ReflectCapability? cap1,
-      ReflectCapability? cap2,
-      ReflectCapability? cap3,
-      ReflectCapability? cap4,
-      ReflectCapability? cap5,
-      ReflectCapability? cap6,
-      ReflectCapability? cap7,
-      ReflectCapability? cap8,
-      ReflectCapability? cap9])
-      : super(cap0, cap1, cap2, cap3, cap4, cap5, cap6, cap7, cap8, cap9);
+      [super.cap0,
+      super.cap1,
+      super.cap2,
+      super.cap3,
+      super.cap4,
+      super.cap5,
+      super.cap6,
+      super.cap7,
+      super.cap8,
+      super.cap9]);
 
-  const Reflectable.fromList(List<ReflectCapability> capabilities)
-      : super.fromList(capabilities);
+  const Reflectable.fromList(super.capabilities)
+      : super.fromList();
 
   /// Returns the canonicalized instance of the given reflector [type].
   ///

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -5580,12 +5580,8 @@ bool _isPrivateName(String name) {
 }
 
 DartObject? _evaluateConstant(LibraryElement library, Expression expression) {
-  print('>>> $expression'); // DEBUG
   if (expression is SimpleIdentifier) {
-    print('>>> is SimpleIdentifier'); // DEBUG
     var declaration = expression.staticElement?.declaration;
-    print(
-        '>>> staticElement: ${expression.staticElement}, ${expression.staticElement.runtimeType}'); // DEBUG
     if (declaration is PropertyAccessorElement) {
       Element variable = declaration.variable;
       if (variable is ConstVariableElement) {

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -5590,16 +5590,18 @@ DartObject? _evaluateConstant(LibraryElement library, Expression expression) {
   // !!!TODO!!! Analyzing without errors until this point.
   var currentUnit = expression.parent;
   int levels = 0;
-  while (currentUnit != null && currentUnit is! CompilationUnit && ++levels < 100) {
+  while (currentUnit != null &&
+      currentUnit is! CompilationUnit &&
+      ++levels < 100) {
     currentUnit = currentUnit.parent;
   }
   if (currentUnit is! CompilationUnit) {
     // TODO(eernst): Change all call sites to async, then report error
     // using `severe` as usual (but this shouldn't happen anyway).
     throw StateError(
-      "Expression `$expression` has no enclosing compilation unit!");
-  }  
-  
+        "Expression `$expression` has no enclosing compilation unit!");
+  }
+
   var unitElement = currentUnit.declaredElement!;
   var source = unitElement.source;
   var libraryElement = unitElement.library as LibraryElementImpl;
@@ -5633,7 +5635,7 @@ DartObject? _evaluateConstant(LibraryElement library, Expression expression) {
     libraryElement,
     errorReporter,
   );
-  
+
   var constant = visitor.evaluateAndReportInvalidConstant(expression);
   var dartObject = constant is DartObjectImpl ? constant : null;
 
@@ -5644,23 +5646,6 @@ DartObject? _evaluateConstant(LibraryElement library, Expression expression) {
   }
 
   return dartObject;
-
-  /*
-  switch (expression) {
-    case (SimpleIdentifier() || PrefixedIdentifier()) && Identifier id:
-      var declaration = id.staticElement?.declaration;
-      if (declaration is PropertyAccessorElement) {
-        Element variable = declaration.variable;
-        if (variable is ConstVariableElement) {
-          return variable.computeConstantValue();
-        }
-      }
-    case InstanceCreationExpression(isConst: true):
-      // !!!TODO!!!: Can't `return expression.computeConstantValue();`
-      return null;
-  }
-  return null;
-  */
 }
 
 /// Returns the result of evaluating [elementAnnotation].

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -5584,7 +5584,8 @@ bool _isPrivateName(String name) {
   return name.startsWith('_') || name.contains('._');
 }
 
-Future<DartObject?> _evaluateConstant(LibraryElement library, Expression expression) async {
+Future<DartObject?> _evaluateConstant(
+    LibraryElement library, Expression expression) async {
   var currentUnit = expression.parent;
   int levels = 0;
   while (currentUnit != null &&
@@ -5594,7 +5595,7 @@ Future<DartObject?> _evaluateConstant(LibraryElement library, Expression express
   }
   if (currentUnit is! CompilationUnit) {
     await _severe('Expression `$expression` '
-      'has no enclosing compilation unit.');
+        'has no enclosing compilation unit.');
     return null;
   }
 

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -5595,6 +5595,7 @@ Future<DartObject?> _evaluateConstant(LibraryElement library, Expression express
   if (currentUnit is! CompilationUnit) {
     await _severe('Expression `$expression` '
       'has no enclosing compilation unit.');
+    return null;
   }
 
   var unitElement = currentUnit.declaredElement!;
@@ -5635,11 +5636,11 @@ Future<DartObject?> _evaluateConstant(LibraryElement library, Expression express
   var dartObject = constant is DartObjectImpl ? constant : null;
 
   if (errorListener.errors.isNotEmpty) {
-    StringBuffer message = 'Constant `$expression` has errors:\n';
+    var message = StringBuffer('Constant `$expression` has errors:\n');
     for (var error in errorListener.errors) {
       message.writeln(error);
     }
-    _severe(message);
+    _severe(message.toString());
   }
 
   return dartObject;

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -4295,12 +4295,10 @@ ${imports.join('\n')}
 // ignore_for_file: prefer_adjacent_string_concatenation
 // ignore_for_file: prefer_collection_literals
 // ignore_for_file: unnecessary_const
+// ignore_for_file: unused_import
 
-// ignore:unused_import
 import 'package:reflectable/mirrors.dart' as m;
-// ignore:unused_import
 import 'package:reflectable/src/reflectable_builder_based.dart' as r;
-// ignore:unused_import
 import 'package:reflectable/reflectable.dart' as r show Reflectable;
 
 $code

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -3969,6 +3969,7 @@ class BuilderImplementation {
       LibraryElement containingLibrary,
       Element messageTarget) async {
     Object? evaluated = _evaluateConstant(containingLibrary, expression);
+    print(evaluated.runtimeType); // DEBUG
 
     if (evaluated is! DartObject) {
       await _severe(

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -3572,11 +3572,6 @@ class BuilderImplementation {
             if (value != null) {
               String? pattern =
                   value.getField('classNamePattern')?.toStringValue();
-              if (pattern == null) {
-                await _warn(WarningKind.badNamePattern,
-                    'The classNamePattern must be a string', metadatumElement);
-                continue;
-              }
               var valueType =
                   value.getField('(super)')?.getField('reflector')?.type;
               var reflector =

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -3968,7 +3968,7 @@ class BuilderImplementation {
       Expression expression,
       LibraryElement containingLibrary,
       Element messageTarget) async {
-    Object? evaluated = _evaluateConstant(containingLibrary, expression);
+    Object? evaluated = await _evaluateConstant(containingLibrary, expression);
     print(evaluated.runtimeType); // DEBUG
 
     if (evaluated is! DartObject) {

--- a/reflectable/lib/src/element_capability.dart
+++ b/reflectable/lib/src/element_capability.dart
@@ -40,49 +40,45 @@ abstract class MetadataQuantifiedCapability implements ApiReflectCapability {
 }
 
 class InstanceInvokeCapability extends NamePatternCapability {
-  const InstanceInvokeCapability(String namePattern) : super(namePattern);
+  const InstanceInvokeCapability(super.namePattern);
 }
 
 const instanceInvokeCapability = InstanceInvokeCapability('');
 
 class InstanceInvokeMetaCapability extends MetadataQuantifiedCapability {
-  const InstanceInvokeMetaCapability(InterfaceElement metadataType)
-      : super(metadataType);
+  const InstanceInvokeMetaCapability(super.metadataType);
 }
 
 class StaticInvokeCapability extends NamePatternCapability
     implements TypeCapability {
-  const StaticInvokeCapability(String namePattern) : super(namePattern);
+  const StaticInvokeCapability(super.namePattern);
 }
 
 const staticInvokeCapability = StaticInvokeCapability('');
 
 class StaticInvokeMetaCapability extends MetadataQuantifiedCapability
     implements TypeCapability {
-  const StaticInvokeMetaCapability(InterfaceElement metadataType)
-      : super(metadataType);
+  const StaticInvokeMetaCapability(super.metadataType);
 }
 
 class TopLevelInvokeCapability extends NamePatternCapability {
-  const TopLevelInvokeCapability(String namePattern) : super(namePattern);
+  const TopLevelInvokeCapability(super.namePattern);
 }
 
 class TopLevelInvokeMetaCapability extends MetadataQuantifiedCapability {
-  const TopLevelInvokeMetaCapability(InterfaceElement metadataType)
-      : super(metadataType);
+  const TopLevelInvokeMetaCapability(super.metadataType);
 }
 
 class NewInstanceCapability extends NamePatternCapability
     implements TypeCapability {
-  const NewInstanceCapability(String namePattern) : super(namePattern);
+  const NewInstanceCapability(super.namePattern);
 }
 
 const newInstanceCapability = NewInstanceCapability('');
 
 class NewInstanceMetaCapability extends MetadataQuantifiedCapability
     implements TypeCapability {
-  const NewInstanceMetaCapability(InterfaceElement metadataType)
-      : super(metadataType);
+  const NewInstanceMetaCapability(super.metadataType);
 }
 
 /// To be eliminated when `NameCapability` in 'capability.dart' is eliminated.
@@ -162,7 +158,7 @@ class InvokingCapability extends NamePatternCapability
         InstanceInvokeCapability,
         StaticInvokeCapability,
         NewInstanceCapability {
-  const InvokingCapability(String namePattern) : super(namePattern);
+  const InvokingCapability(super.namePattern);
 }
 
 const invokingCapability = InvokingCapability('');
@@ -172,8 +168,7 @@ class InvokingMetaCapability extends MetadataQuantifiedCapability
         InstanceInvokeMetaCapability,
         StaticInvokeMetaCapability,
         NewInstanceMetaCapability {
-  const InvokingMetaCapability(InterfaceElement metadataType)
-      : super(metadataType);
+  const InvokingMetaCapability(super.metadataType);
 }
 
 class TypingCapability

--- a/reflectable/lib/src/reflectable_builder_based.dart
+++ b/reflectable/lib/src/reflectable_builder_based.dart
@@ -880,41 +880,23 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
 
 class NonGenericClassMirrorImpl extends ClassMirrorBase {
   NonGenericClassMirrorImpl(
-      String simpleName,
-      String qualifiedName,
-      int descriptor,
-      int classIndex,
-      ReflectableImpl reflector,
-      List<int> declarationIndices,
-      List<int>? instanceMemberIndices,
-      List<int>? staticMemberIndices,
-      int? superclassIndex,
-      Map<String, StaticGetter> getters,
-      Map<String, StaticSetter> setters,
-      Map<String, Function> constructors,
-      int ownerIndex,
-      int mixinIndex,
-      List<int> superinterfaceIndices,
-      List<Object>? metadata,
-      Map<String, int>? parameterListShapes)
-      : super(
-            simpleName,
-            qualifiedName,
-            descriptor,
-            classIndex,
-            reflector,
-            declarationIndices,
-            instanceMemberIndices,
-            staticMemberIndices,
-            superclassIndex,
-            getters,
-            setters,
-            constructors,
-            ownerIndex,
-            mixinIndex,
-            superinterfaceIndices,
-            metadata,
-            parameterListShapes);
+      super.simpleName,
+      super.qualifiedName,
+      super.descriptor,
+      super.classIndex,
+      super.reflector,
+      super.declarationIndices,
+      super.instanceMemberIndices,
+      super.staticMemberIndices,
+      super.superclassIndex,
+      super.getters,
+      super.setters,
+      super.constructors,
+      super.ownerIndex,
+      super.mixinIndex,
+      super.superinterfaceIndices,
+      super.metadata,
+      super.parameterListShapes);
 
   @override
   List<TypeMirror> get typeArguments {
@@ -1000,44 +982,26 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   final int _dynamicReflectedTypeIndex;
 
   GenericClassMirrorImpl(
-      String simpleName,
-      String qualifiedName,
-      int descriptor,
-      int classIndex,
-      ReflectableImpl reflector,
-      List<int> declarationIndices,
-      List<int>? instanceMemberIndices,
-      List<int>? staticMemberIndices,
-      int superclassIndex,
-      Map<String, StaticGetter> getters,
-      Map<String, StaticSetter> setters,
-      Map<String, Function> constructors,
-      int ownerIndex,
-      int mixinIndex,
-      List<int> superinterfaceIndices,
-      List<Object>? metadata,
-      Map<String, int>? parameterListShapes,
+      super.simpleName,
+      super.qualifiedName,
+      super.descriptor,
+      super.classIndex,
+      super.reflector,
+      super.declarationIndices,
+      super.instanceMemberIndices,
+      super.staticMemberIndices,
+      int super.superclassIndex,
+      super.getters,
+      super.setters,
+      super.constructors,
+      super.ownerIndex,
+      super.mixinIndex,
+      super.superinterfaceIndices,
+      super.metadata,
+      super.parameterListShapes,
       this._isGenericRuntimeTypeOf,
       this._typeVariableIndices,
-      this._dynamicReflectedTypeIndex)
-      : super(
-            simpleName,
-            qualifiedName,
-            descriptor,
-            classIndex,
-            reflector,
-            declarationIndices,
-            instanceMemberIndices,
-            staticMemberIndices,
-            superclassIndex,
-            getters,
-            setters,
-            constructors,
-            ownerIndex,
-            mixinIndex,
-            superinterfaceIndices,
-            metadata,
-            parameterListShapes);
+      this._dynamicReflectedTypeIndex);
 
   @override
   List<TypeMirror> get typeArguments {
@@ -1148,44 +1112,26 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
   final List<int>? _reflectedTypeArgumentIndices;
 
   InstantiatedGenericClassMirrorImpl(
-      String simpleName,
-      String qualifiedName,
-      int descriptor,
-      int classIndex,
-      ReflectableImpl reflector,
-      List<int> declarationIndices,
-      List<int>? instanceMemberIndices,
-      List<int>? staticMemberIndices,
-      int? superclassIndex,
-      Map<String, StaticGetter> getters,
-      Map<String, StaticSetter> setters,
-      Map<String, Function> constructors,
-      int ownerIndex,
-      int mixinIndex,
-      List<int> superinterfaceIndices,
-      List<Object>? metadata,
-      Map<String, int>? parameterListShapes,
+      super.simpleName,
+      super.qualifiedName,
+      super.descriptor,
+      super.classIndex,
+      super.reflector,
+      super.declarationIndices,
+      super.instanceMemberIndices,
+      super.staticMemberIndices,
+      super.superclassIndex,
+      super.getters,
+      super.setters,
+      super.constructors,
+      super.ownerIndex,
+      super.mixinIndex,
+      super.superinterfaceIndices,
+      super.metadata,
+      super.parameterListShapes,
       this._originalDeclaration,
       this._reflectedType,
-      this._reflectedTypeArgumentIndices)
-      : super(
-            simpleName,
-            qualifiedName,
-            descriptor,
-            classIndex,
-            reflector,
-            declarationIndices,
-            instanceMemberIndices,
-            staticMemberIndices,
-            superclassIndex,
-            getters,
-            setters,
-            constructors,
-            ownerIndex,
-            mixinIndex,
-            superinterfaceIndices,
-            metadata,
-            parameterListShapes);
+      this._reflectedTypeArgumentIndices);
 
   @override
   List<TypeMirror> get typeArguments {
@@ -2086,8 +2032,7 @@ abstract class ImplicitAccessorMirrorImpl extends _DataCaching
 
 class ImplicitGetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   ImplicitGetterMirrorImpl(
-      ReflectableImpl reflector, int variableMirrorIndex, int selfIndex)
-      : super(reflector, variableMirrorIndex, selfIndex);
+      super.reflector, super.variableMirrorIndex, super.selfIndex);
 
   @override
   bool get isGetter => true;
@@ -2116,8 +2061,7 @@ class ImplicitGetterMirrorImpl extends ImplicitAccessorMirrorImpl {
 
 class ImplicitSetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   ImplicitSetterMirrorImpl(
-      ReflectableImpl reflector, int variableMirrorIndex, int selfIndex)
-      : super(reflector, variableMirrorIndex, selfIndex);
+      super.reflector, super.variableMirrorIndex, super.selfIndex);
 
   @override
   bool get isGetter => false;
@@ -2363,25 +2307,15 @@ class VariableMirrorImpl extends VariableMirrorBase {
   bool get isConst => (_descriptor & constants.constAttribute != 0);
 
   VariableMirrorImpl(
-      String name,
-      int descriptor,
-      int ownerIndex,
-      ReflectableImpl reflectable,
-      int classMirrorIndex,
-      int reflectedTypeIndex,
-      int dynamicReflectedTypeIndex,
-      List<int>? reflectedTypeArguments,
-      List<Object>? metadata)
-      : super(
-            name,
-            descriptor,
-            ownerIndex,
-            reflectable,
-            classMirrorIndex,
-            reflectedTypeIndex,
-            dynamicReflectedTypeIndex,
-            reflectedTypeArguments,
-            metadata);
+      super.name,
+      super.descriptor,
+      super.ownerIndex,
+      super.reflectable,
+      super.classMirrorIndex,
+      super.reflectedTypeIndex,
+      super.dynamicReflectedTypeIndex,
+      super.reflectedTypeArguments,
+      super.metadata);
 
   // Note that the corresponding implementation of [hashCode] is inherited from
   // [VariableMirrorBase].
@@ -2437,27 +2371,17 @@ class ParameterMirrorImpl extends VariableMirrorBase
   MethodMirror get owner => _data.memberMirrors![_ownerIndex] as MethodMirror;
 
   ParameterMirrorImpl(
-      String name,
-      int descriptor,
-      int ownerIndex,
-      ReflectableImpl reflectable,
-      int classMirrorIndex,
-      int reflectedTypeIndex,
-      int dynamicReflectedTypeIndex,
-      List<int>? reflectedTypeArguments,
-      List<Object>? metadata,
+      super.name,
+      super.descriptor,
+      super.ownerIndex,
+      super.reflectable,
+      super.classMirrorIndex,
+      super.reflectedTypeIndex,
+      super.dynamicReflectedTypeIndex,
+      super.reflectedTypeArguments,
+      super.metadata,
       this._defaultValue,
-      this._nameSymbol)
-      : super(
-            name,
-            descriptor,
-            ownerIndex,
-            reflectable,
-            classMirrorIndex,
-            reflectedTypeIndex,
-            dynamicReflectedTypeIndex,
-            reflectedTypeArguments,
-            metadata);
+      this._nameSymbol);
 
   // Note that the corresponding implementation of [hashCode] is inherited from
   // [VariableMirrorBase].
@@ -2611,20 +2535,19 @@ abstract class ReflectableImpl extends ReflectableBase
   /// Const constructor, to enable usage as metadata, allowing for varargs
   /// style invocation with up to ten arguments.
   const ReflectableImpl(
-      [ReflectCapability? cap0,
-      ReflectCapability? cap1,
-      ReflectCapability? cap2,
-      ReflectCapability? cap3,
-      ReflectCapability? cap4,
-      ReflectCapability? cap5,
-      ReflectCapability? cap6,
-      ReflectCapability? cap7,
-      ReflectCapability? cap8,
-      ReflectCapability? cap9])
-      : super(cap0, cap1, cap2, cap3, cap4, cap5, cap6, cap7, cap8, cap9);
+      [super.cap0,
+      super.cap1,
+      super.cap2,
+      super.cap3,
+      super.cap4,
+      super.cap5,
+      super.cap6,
+      super.cap7,
+      super.cap8,
+      super.cap9]);
 
-  const ReflectableImpl.fromList(List<ReflectCapability> capabilities)
-      : super.fromList(capabilities);
+  const ReflectableImpl.fromList(List<ReflectCapability> super.capabilities)
+      : super.fromList();
 
   @override
   bool canReflect(Object reflectee) {

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   glob: ^2.1.0
   logging: ^1.2.0
   package_config: ^2.1.0
-  path: ^1.9.0
+  path: ^1.8.3
   source_span: ^1.10.0
 dev_dependencies:
   build_test: ^2.2.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
-  analyzer: ^6.3.0
+  analyzer: ^6.4.0
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.0.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 4.0.5
+version: 4.0.6
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
@@ -7,19 +7,19 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=2.19.0 <4.0.0'
 dependencies:
-  analyzer: ^5.4.0
-  build: ^2.0.0
-  build_resolvers: ^2.0.0
+  analyzer: ^6.3.0
+  build: ^2.4.0
+  build_resolvers: ^2.4.0
   build_config: ^1.0.0
-  build_runner: ^2.0.1
-  build_runner_core: ^7.0.0
-  dart_style: ^2.0.0
-  glob: ^2.0.0
-  logging: ^1.0.0
-  package_config: ^2.0.0
-  path: ^1.8.0
-  source_span: ^1.8.1
+  build_runner: ^2.4.0
+  build_runner_core: ^7.2.0
+  dart_style: ^2.3.0
+  glob: ^2.1.0
+  logging: ^1.2.0
+  package_config: ^2.1.0
+  path: ^1.9.0
+  source_span: ^1.10.0
 dev_dependencies:
-  build_test: ^2.0.0
-  lints: ^2.0.0
-  test: ^1.16.0-nullsafety
+  build_test: ^2.2.0
+  lints: ^3.0.0
+  test: ^1.25.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -5,7 +5,7 @@ description: >
   specify which operations to support, on which objects.
 homepage: https://github.com/google/reflectable.dart
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 dependencies:
   analyzer: ^6.3.0
   build: ^2.4.0

--- a/test_reflectable/pubspec.yaml
+++ b/test_reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ description: >
   package. It is not intended to be useful for other purposes than
   testing package reflectable.
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 dependencies:
   build_runner: any
   glob: any
@@ -17,4 +17,4 @@ dev_dependencies:
   analyzer: any
   build_test: any
   lints: any
-  test: ^1.16.0-nullsafety
+  test: ^1.25.0

--- a/test_reflectable/test/enum_test.dart
+++ b/test_reflectable/test/enum_test.dart
@@ -4,6 +4,7 @@
 
 /// File used to test reflectable code generation.
 /// Based on https://github.com/dart-lang/reflectable/issues/80.
+library test_reflectable.test.enum_test;
 
 import 'package:reflectable/reflectable.dart';
 import 'package:test/test.dart';

--- a/test_reflectable/test/generic_mixin_test.dart
+++ b/test_reflectable/test/generic_mixin_test.dart
@@ -25,7 +25,7 @@ class Reflector extends Reflectable {
 const reflector = Reflector();
 
 @reflector
-class M<E> {
+mixin class M<E> {
   E? e;
 }
 

--- a/test_reflectable/test/meta_reflector_test.dart
+++ b/test_reflectable/test/meta_reflector_test.dart
@@ -110,7 +110,7 @@ class ReflectorUpwardsClosedUntilA extends Reflectable
 @Reflector()
 @Reflector2()
 @P()
-class M1 {
+mixin class M1 {
   void foo() {}
   // ignore:prefer_typing_uninitialized_variables
   var field;
@@ -123,11 +123,11 @@ class P {
 
 @Reflector()
 @Reflector2()
-class M2 {}
+mixin class M2 {}
 
 @Reflector()
 @Reflector2()
-class M3 {}
+mixin class M3 {}
 
 @Reflector()
 class A {

--- a/test_reflectable/test/meta_reflectors_domain.dart
+++ b/test_reflectable/test/meta_reflectors_domain.dart
@@ -16,16 +16,16 @@ class P {
 }
 
 @P()
-class M1 {
+mixin class M1 {
   void foo() {}
   // ignore:prefer_typing_uninitialized_variables
   var field;
   static void staticFoo(x) {}
 }
 
-class M2 {}
+mixin class M2 {}
 
-class M3 {}
+mixin class M3 {}
 
 class A {
   void foo() {}

--- a/test_reflectable/test/mixin_application_static_invoke_test.dart
+++ b/test_reflectable/test/mixin_application_static_invoke_test.dart
@@ -17,7 +17,7 @@ class Reflector extends Reflectable {
 }
 
 @Reflector()
-class M {
+mixin class M {
   static dynamic staticFoo(x) => x + 1;
 }
 

--- a/test_reflectable/test/mixin_application_static_member_test.dart
+++ b/test_reflectable/test/mixin_application_static_member_test.dart
@@ -17,7 +17,7 @@ class Reflector extends Reflectable {
 }
 
 @Reflector()
-class M {
+mixin class M {
   static dynamic staticFoo(x) => x + 1;
 }
 

--- a/test_reflectable/test/mixin_static_const_test.dart
+++ b/test_reflectable/test/mixin_static_const_test.dart
@@ -17,7 +17,7 @@ const reflector = Reflector();
 class A {}
 
 @reflector
-class M {
+mixin class M {
   static const String s = 'dart';
 }
 

--- a/test_reflectable/test/mixin_test.dart
+++ b/test_reflectable/test/mixin_test.dart
@@ -53,7 +53,7 @@ class ReflectorUpwardsClosedUntilA extends Reflectable {
 @Reflector()
 @Reflector2()
 @P()
-class M1 {
+mixin class M1 {
   void foo() {}
   // ignore:prefer_typing_uninitialized_variables
   var field;
@@ -66,11 +66,11 @@ class P {
 
 @Reflector()
 @Reflector2()
-class M2 {}
+mixin class M2 {}
 
 @Reflector()
 @Reflector2()
-class M3 {}
+mixin class M3 {}
 
 @Reflector()
 class A {
@@ -98,12 +98,12 @@ class C extends B with M2, M3 {}
 @ReflectorUpwardsClosedUntilA()
 class D = A with M1;
 
-class M4 {}
+mixin class M4 {}
 
 @Reflector3()
-class M5 {}
+mixin class M5 {}
 
-class M6 {}
+mixin class M6 {}
 
 class AA {}
 

--- a/test_reflectable/test/reflect_type_test.dart
+++ b/test_reflectable/test/reflect_type_test.dart
@@ -57,7 +57,7 @@ void main() {
         broadReflector.findLibrary('test_reflectable.test.reflect_type_test');
     expect(libraryMirror, isNotNull);
     var uriString = libraryMirror.uri.toString();
-    expect(uriString ==
-        'asset:test_reflectable/test/reflect_type_test.dart', isTrue);
+    expect(uriString == 'asset:test_reflectable/test/reflect_type_test.dart',
+        isTrue);
   });
 }

--- a/test_reflectable/test/reflectors_test.dart
+++ b/test_reflectable/test/reflectors_test.dart
@@ -73,7 +73,7 @@ class ReflectorUpwardsClosedUntilA extends Reflectable {
 @Reflector()
 @Reflector2()
 @P()
-class M1 {
+mixin class M1 {
   void foo() {}
   // ignore:prefer_typing_uninitialized_variables
   var field;
@@ -86,11 +86,11 @@ class P {
 
 @Reflector()
 @Reflector2()
-class M2 {}
+mixin class M2 {}
 
 @Reflector()
 @Reflector2()
-class M3 {}
+mixin class M3 {}
 
 @Reflector()
 class A {

--- a/test_reflectable/test/serialize_test.dart
+++ b/test_reflectable/test/serialize_test.dart
@@ -54,7 +54,7 @@ class B extends A {
   var c;
   B();
 
-  B.fromValues(a, b, this.c) : super.fromValues(a, b);
+  B.fromValues(super.a, super.b, this.c) : super.fromValues();
 
   // The == operator is defined for testing if the reconstructed object is the
   // same as the original.

--- a/test_reflectable/test/serialize_test.dart
+++ b/test_reflectable/test/serialize_test.dart
@@ -40,7 +40,8 @@ class A {
   // The == operator is defined for testing if the reconstructed object is the
   // same as the original.
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other_) {
+    dynamic other = other_;
     return _equalsHandlingLists(a, other.a) && _equalsHandlingLists(b, other.b);
   }
 
@@ -60,7 +61,8 @@ class B extends A {
   // same as the original.
   // This is defined for easier testing.
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other_) {
+    dynamic other = other_;
     return _equalsHandlingLists(a, other.a) &&
         _equalsHandlingLists(b, other.b) &&
         _equalsHandlingLists(c, other.c);

--- a/test_reflectable/test/subtype_quantify_test.dart
+++ b/test_reflectable/test/subtype_quantify_test.dart
@@ -31,7 +31,7 @@ class C implements A {
   int foo() => 44;
 }
 
-class M {
+mixin class M {
   int foo() => 45;
 }
 

--- a/test_reflectable/test/subtype_test.dart
+++ b/test_reflectable/test/subtype_test.dart
@@ -36,9 +36,9 @@ class E extends D implements B {}
 
 class F implements E, D {}
 
-class M1 {}
+mixin class M1 {}
 
-class M2 {}
+mixin class M2 {}
 
 class G extends D with M1, M2 {}
 


### PR DESCRIPTION
This PR changes reflectable such that it uses the analyzer version 6.4.0, and also updates other dependencies.

This includes several changes to the code associated with evaluation of constant expressions (where the new version of the analyzer does not support the approach which was used for this purpose previously).
