### PR TITLE
Update reflectable dependencies to use SDK 3.4.0 and analyzer 6.7.0

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.7
+
+* Update dependencies to use sdk 3.4.0 and analyzer 6.7.0.
+
 ## 4.0.6
 
 * Update dependencies to use analyzer 6.4.0.

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, the Dart Team. All rights reserved. Use of thisgg
+// Copyright (c) 2016, the Dart Team. All rights reserved. Use of this
 // source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
@@ -1667,7 +1667,9 @@ class _ReflectorDomain {
       PropertyInducingElement? variable = accessorElement.variable2;
       int variableMirrorIndex = variable is TopLevelVariableElement
           ? topLevelVariables.indexOf(variable)!
-          : fields.indexOf(variable!)!;
+          : variable is FieldElement
+              ? fields.indexOf(variable)!
+              : constants.noCapabilityIndex;
       int selfIndex = members.indexOf(accessorElement)! + fields.length;
       if (accessorElement.isGetter) {
         return 'r.ImplicitGetterMirrorImpl('
@@ -2875,7 +2877,7 @@ class _ClassDomain {
         // the metadata on the original field.
         List<ElementAnnotation> metadata =
             (member is PropertyAccessorElement && member.isSynthetic)
-                ? (member.variable2?.metadata ?? <ElementAnnotation>[])
+                ? (member.variable2?.metadata ?? const <ElementAnnotation>[])
                 : member.metadata;
         List<ElementAnnotation>? getterMetadata;
         if (_reflectorDomain._capabilities._impliesCorrespondingSetters &&
@@ -2959,7 +2961,7 @@ class _ClassDomain {
       // If [member] is a synthetic accessor created from a field, search for
       // the metadata on the original field.
       List<ElementAnnotation> metadata = accessor.isSynthetic
-          ? (accessor.variable2?.metadata ?? <ElementAnnotation>[])
+          ? (accessor.variable2?.metadata ?? const <ElementAnnotation>[])
           : accessor.metadata;
       List<ElementAnnotation>? getterMetadata;
       if (_reflectorDomain._capabilities._impliesCorrespondingSetters &&
@@ -5195,7 +5197,7 @@ Iterable<PropertyAccessorElement> _extractLibraryAccessors(Resolver resolver,
       List<ElementAnnotation> metadata;
       List<ElementAnnotation>? getterMetadata;
       if (accessor.isSynthetic) {
-        metadata = accessor.variable2?.metadata ?? <ElementAnnotation>[];
+        metadata = accessor.variable2?.metadata ?? const <ElementAnnotation>[];
         getterMetadata = metadata;
       } else {
         metadata = accessor.metadata;
@@ -5235,7 +5237,7 @@ Iterable<PropertyAccessorElement> _extractAccessors(Resolver resolver,
         ? capabilities.supportsStaticInvoke
         : capabilities.supportsInstanceInvoke;
     List<ElementAnnotation> metadata = accessor.isSynthetic
-        ? (accessor.variable2?.metadata ?? <ElementAnnotation>[])
+        ? (accessor.variable2?.metadata ?? const <ElementAnnotation>[])
         : accessor.metadata;
     List<ElementAnnotation>? getterMetadata;
     if (capabilities._impliesCorrespondingSetters &&
@@ -5455,10 +5457,10 @@ class MixinApplication implements ClassElement {
   String get displayName => name;
 
   @override
-  List<InterfaceType> get interfaces => <InterfaceType>[];
+  List<InterfaceType> get interfaces => const <InterfaceType>[];
 
   @override
-  List<ElementAnnotation> get metadata => <ElementAnnotation>[];
+  List<ElementAnnotation> get metadata => const <ElementAnnotation>[];
 
   @override
   bool get isSynthetic => declaredName == null;

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -2069,7 +2069,7 @@ class _ReflectorDomain {
         return '$returnType Function$typeArguments($argumentTypes)';
       }
     } else if (dartType is TypeParameterType &&
-        typeVariablesInScope .contains(dartType.getDisplayString())) {
+        typeVariablesInScope.contains(dartType.getDisplayString())) {
       return dartType.getDisplayString();
     } else {
       return fail();
@@ -2958,10 +2958,9 @@ class _ClassDomain {
       if (!accessor.isStatic || accessor.isPrivate) return;
       // If [member] is a synthetic accessor created from a field, search for
       // the metadata on the original field.
-      List<ElementAnnotation> metadata =
-          accessor.isSynthetic
-              ? (accessor.variable2?.metadata ?? <ElementAnnotation>[])
-              : accessor.metadata;
+      List<ElementAnnotation> metadata = accessor.isSynthetic
+          ? (accessor.variable2?.metadata ?? <ElementAnnotation>[])
+          : accessor.metadata;
       List<ElementAnnotation>? getterMetadata;
       if (_reflectorDomain._capabilities._impliesCorrespondingSetters &&
           accessor.isSetter &&
@@ -5235,10 +5234,9 @@ Iterable<PropertyAccessorElement> _extractAccessors(Resolver resolver,
     CapabilityChecker capabilityChecker = accessor.isStatic
         ? capabilities.supportsStaticInvoke
         : capabilities.supportsInstanceInvoke;
-    List<ElementAnnotation> metadata =
-        accessor.isSynthetic
-            ? (accessor.variable2?.metadata ?? <ElementAnnotation>[])
-            : accessor.metadata;
+    List<ElementAnnotation> metadata = accessor.isSynthetic
+        ? (accessor.variable2?.metadata ?? <ElementAnnotation>[])
+        : accessor.metadata;
     List<ElementAnnotation>? getterMetadata;
     if (capabilities._impliesCorrespondingSetters &&
         accessor.isSetter &&
@@ -5547,7 +5545,6 @@ class MixinApplication implements ClassElement {
 
   @override
   Null get augmentationTarget => null;
-
 
   @override
   String toString() => 'MixinApplication($superclass, $mixin)';

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -5546,6 +5546,10 @@ class MixinApplication implements ClassElement {
   int get hashCode => superclass.hashCode ^ mixin.hashCode ^ library.hashCode;
 
   @override
+  Null get augmentationTarget => null;
+
+
+  @override
   String toString() => 'MixinApplication($superclass, $mixin)';
 
   // Let the compiler generate forwarders for all remaining methods: Instances

--- a/reflectable/lib/src/reflectable_builder_based.dart
+++ b/reflectable/lib/src/reflectable_builder_based.dart
@@ -738,7 +738,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       throw NoSuchCapabilityError(
           'Requesting metadata of "$description" without capability');
     }
-    return _metadata!;
+    return _metadata;
   }
 
   @override
@@ -874,7 +874,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
           '`superclass` of `$qualifiedName`');
     }
     if (_superclassIndex == null) return null; // Superclass of [Object].
-    return _data.typeMirrors[_superclassIndex!] as ClassMirrorBase?;
+    return _data.typeMirrors[_superclassIndex] as ClassMirrorBase?;
   }
 }
 

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,25 +1,25 @@
 name: reflectable
-version: 4.0.6
+version: 4.0.7
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
 homepage: https://github.com/google/reflectable.dart
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 dependencies:
-  analyzer: ^6.4.0
+  analyzer: ^6.7.0
   build: ^2.4.0
   build_resolvers: ^2.4.0
-  build_config: ^1.0.0
+  build_config: ^1.1.0
   build_runner: ^2.4.0
   build_runner_core: ^7.2.0
   dart_style: ^2.3.0
   glob: ^2.1.0
   logging: ^1.2.0
   package_config: ^2.1.0
-  path: ^1.8.3
+  path: ^1.9.0
   source_span: ^1.10.0
 dev_dependencies:
   build_test: ^2.2.0
-  lints: ^3.0.0
+  lints: ^4.0.0
   test: ^1.25.0

--- a/test_reflectable/pubspec.yaml
+++ b/test_reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ description: >
   package. It is not intended to be useful for other purposes than
   testing package reflectable.
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 dependencies:
   build_runner: any
   glob: any


### PR DESCRIPTION
Update the package dependencies and resolve static analysis issues caused by this change.

In particular, remove several occurrences of named parameters that are now deprecated (e.g., `withNullability`), change invocations of `variable` to `variable2` (the analyzer package made this change in order to be able to migrate `variable` to a new semantics).

The new getter `variable2` has a nullable return type. It can only be null in the case where the given declaration is augmenting. Reflectable uses a defensive approach to handle these nulls, and it will most likely need to be updated when the augmentation feature is fully specified and implemented.