### PR TITLE
Update dependencies again

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.8
+
+* Downgrade analyzer to 6.5.0, to avoid version conflict involving
+  `macros` and `_macros` (that we can't do anything about from here).
+
 ## 4.0.7
 
 * Update dependencies to use sdk 3.4.0 and analyzer 6.7.0.

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=3.4.0 <4.0.0'
 dependencies:
-  analyzer: ^6.7.0
+  analyzer: ^6.6.0
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.1.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 4.0.7
+version: 4.0.8
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=3.4.0 <4.0.0'
 dependencies:
-  analyzer: ^6.6.0
+  analyzer: ^6.5.0
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.1.0


### PR DESCRIPTION
4.0.7 was just published, but a dependency conflict around macros causes the published code to cause failures during static analysis.

This PR downgrades the version of the analyzer in order to avoid the conflict. See https://github.com/dart-lang/pub-dev/issues/7855 for details. Note that no failures are seen locally.

Hello @sigurdm, I'll land this now because of the failing static analysis on pub.dev!
