### PR TITLE
Update dependencies, fix 291, use 'obvious' style for local variable types

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Fix bug 291 (such that metadata on enum values can be obtained).
 * Update dependencies to use analyzer 6.11.0 and lints 5.1.0.
+* Change the implementation to use `..._obvious_local_variable_types`
+  lints.
 
 ## 4.0.10
 

--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.11
+
+* Fix bug 291 (such that metadata on enum values can be obtained).
+* Update dependencies
+
 ## 4.0.10
 
 * Reintroduce support for newer versions of the analyzer (6.7.0 and up).

--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Update dependencies to use analyzer 6.11.0 and lints 5.1.0.
 * Change the implementation to use `..._obvious_local_variable_types`
   lints.
+* Update the [capability design document][1] slightly.
 
 ## 4.0.10
 

--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 4.0.11
 
 * Fix bug 291 (such that metadata on enum values can be obtained).
-* Update dependencies
+* Update dependencies to use analyzer 6.11.0 and lints 5.1.0.
 
 ## 4.0.10
 

--- a/reflectable/analysis_options.yaml
+++ b/reflectable/analysis_options.yaml
@@ -1,4 +1,8 @@
 include: package:lints/recommended.yaml
 linter:
   rules:
-    - await_only_futures
+    await_only_futures: true
+    unnecessary_library_names: false
+    omit_local_variable_types: false
+    omit_obvious_local_variable_types: true
+    specify_nonobvious_local_variable_types: true

--- a/reflectable/analysis_options.yaml
+++ b/reflectable/analysis_options.yaml
@@ -2,7 +2,7 @@ include: package:lints/recommended.yaml
 linter:
   rules:
     await_only_futures: true
-    unnecessary_library_names: false
+    unnecessary_library_name: false
     omit_local_variable_types: false
     omit_obvious_local_variable_types: true
     specify_nonobvious_local_variable_types: true

--- a/reflectable/doc/TheDesignOfReflectableCapabilities.md
+++ b/reflectable/doc/TheDesignOfReflectableCapabilities.md
@@ -794,6 +794,10 @@ not support getting a mirror on their instances.
 
 #### Considerations around Admitting Subtypes
 
+**This feature has not been implemented.** It is not obviously a desirable
+feature, and hence it might not be implemented at all. The following
+explains why.
+
 When a *`targetMetadata`* on the form *`apiSelection`*&#42; is attached
 to a given class `C`, the effect is that reflection support is provided
 for the class `C` and for instances of `C`. However, that support can be
@@ -914,19 +918,19 @@ return tolerate the partial support for reflection (using `admitSubtype`).
 We have described the design of the capabilities used in the package
 reflectable to specify the desired level of support for reflection. The
 underlying idea is that the capabilities at the base level specify a
-selection of operations from the API of the mirror classes, along with some
-simple restrictions on the allowable arguments to those operations.  On top
-of that, the API based capabilities can be associated with specific parts
-of the target program (though at this point only classes) such that exactly
-those classes will have the reflection support specified with the API based
-capabilities. The target classes can be selected individually, by adding a
-reflector as metadata on each target class. Alternatively, target classes
-can be selected by quantification: For instance, it is possible to quantify
+selection of operations from the API of the mirror classes, along with
+some simple restrictions on the allowable arguments to those operations.
+On top of that, the API based capabilities can be associated with specific
+parts of the target program such that exactly those declarations will have
+the reflection support specified with the API based capabilities. The
+target declarations can be selected individually, by adding a reflector as
+metadata on each target declaration. Alternatively, target declarations can
+be selected by quantification: For instance, it is possible to quantify
 over all subtypes, in which case not only the class `C` that holds the
 metadata receives reflection support, but also all subtypes of `C`.
 Finally, it is possible to admit instances of subtypes as reflectees of a
 small set of mirrors, such that partial reflection support is achieved for
-many classes, without the cost of having many mirror classes.
+many declarations, without the cost of having many mirror classes.
 
 # References
 

--- a/reflectable/example/example.dart
+++ b/reflectable/example/example.dart
@@ -44,7 +44,7 @@ void main() {
 
   // Get hold of a few mirrors.
   var instance = A();
-  var instanceMirror = myReflectable.reflect(instance);
+  InstanceMirror instanceMirror = myReflectable.reflect(instance);
   var classMirror = myReflectable.reflectType(A) as ClassMirror;
 
   // Invocations of methods accepting positional arguments (printing '42').

--- a/reflectable/lib/capability.dart
+++ b/reflectable/lib/capability.dart
@@ -554,13 +554,6 @@ class ReflectableNoSuchMethodError extends Error
         break;
       case StringInvocationKind.constructor:
         kindName = 'constructor';
-        break;
-      default:
-        // Reaching this point is a bug, so we ought to do this:
-        // `throw unreachableError('Unexpected StringInvocationKind value');`
-        // but it is a bit harsh to raise an exception because of a slightly
-        // imprecise diagnostic message, so we use a default instead.
-        kindName = '';
     }
     var description = 'NoSuchCapabilityError: no capability to invoke the '
         '$kindName "$memberName"\n'

--- a/reflectable/lib/mirrors.dart
+++ b/reflectable/lib/mirrors.dart
@@ -269,7 +269,7 @@ abstract class DeclarationMirror implements Mirror {
   /// had been encountered.
   ///
   /// Note that the return type of the corresponding method in
-  /// dart:mirrors is List<InstanceMirror>.
+  /// dart:mirrors is `List<InstanceMirror>`.
   //
   // TODO(eernst) doc: Make this comment more user friendly.
   // TODO(eernst) implement: Include comments as `metadata`, remember to
@@ -643,7 +643,7 @@ abstract class LibraryDependencyMirror implements Mirror {
   SourceLocation get location;
 
   /// Note that the return type of the corresponding method in
-  /// dart:mirrors is List<InstanceMirror>.
+  /// dart:mirrors is `List<InstanceMirror>`.
   ///
   /// Required capabilities: [metadata] requires a [MetadataCapability].
   List<Object?> get metadata; // TYARG: InstanceMirror

--- a/reflectable/lib/reflectable.dart
+++ b/reflectable/lib/reflectable.dart
@@ -134,7 +134,7 @@ abstract class Reflectable extends implementation.ReflectableImpl
   /// but no entities are covered (that is, it is unused, so we don't have
   /// any reflection data for it) then [null] is returned.
   static Reflectable? getInstance(Type type) {
-    for (var reflector in implementation.reflectors) {
+    for (Reflectable reflector in implementation.reflectors) {
       if (reflector.runtimeType == type) return reflector;
     }
     return null;

--- a/reflectable/lib/reflectable_builder.dart
+++ b/reflectable/lib/reflectable_builder.dart
@@ -5,6 +5,7 @@
 library reflectable.reflectable_builder;
 
 import 'dart:async';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:build_config/build_config.dart';
 import 'package:build_runner_core/build_runner_core.dart';
@@ -23,12 +24,12 @@ class ReflectableBuilder implements Builder {
         targetId.contains('.browser_test.')) {
       return;
     }
-    var inputLibrary = await buildStep.inputLibrary;
-    var resolver = buildStep.resolver;
-    var inputId = buildStep.inputId;
-    var outputId = inputId.changeExtension('.reflectable.dart');
-    var visibleLibraries = await resolver.libraries.toList();
-    var generatedSource = await BuilderImplementation().buildMirrorLibrary(
+    LibraryElement inputLibrary = await buildStep.inputLibrary;
+    Resolver resolver = buildStep.resolver;
+    AssetId inputId = buildStep.inputId;
+    AssetId outputId = inputId.changeExtension('.reflectable.dart');
+    List<LibraryElement> visibleLibraries = await resolver.libraries.toList();
+    String generatedSource = await BuilderImplementation().buildMirrorLibrary(
         resolver, inputId, outputId, inputLibrary, visibleLibraries, true, []);
     await buildStep.writeAsString(outputId, generatedSource);
   }
@@ -61,18 +62,18 @@ Future<BuildResult> reflectableBuild(List<String> arguments) async {
     var builders = <BuilderApplication>[
       applyToRoot(builder, generateFor: InputSet(include: arguments))
     ];
-    var packageGraph = await PackageGraph.forThisPackage();
+    PackageGraph packageGraph = await PackageGraph.forThisPackage();
     var environment = OverrideableEnvironment(IOEnvironment(packageGraph));
-    var buildOptions = await BuildOptions.create(
+    BuildOptions buildOptions = await BuildOptions.create(
       LogSubscription(environment),
       deleteFilesByDefault: true,
       packageGraph: packageGraph,
     );
     try {
-      var build = await BuildRunner.create(
+      BuildRunner build = await BuildRunner.create(
           buildOptions, environment, builders, const {},
           isReleaseBuild: false);
-      var result = await build.run(const {});
+      BuildResult result = await build.run(const {});
       await build.beforeExit();
       return result;
     } finally {

--- a/reflectable/lib/reflectable_builder.dart
+++ b/reflectable/lib/reflectable_builder.dart
@@ -20,7 +20,9 @@ class ReflectableBuilder implements Builder {
     var targetId = buildStep.inputId.toString();
     if (targetId.contains('.vm_test.') ||
         targetId.contains('.node_test.') ||
-        targetId.contains('.browser_test.')) return;
+        targetId.contains('.browser_test.')) {
+      return;
+    }
     var inputLibrary = await buildStep.inputLibrary;
     var resolver = buildStep.resolver;
     var inputId = buildStep.inputId;

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -4933,10 +4933,14 @@ NodeList<Annotation>? _getLibraryMetadata(CompilationUnit? unit) {
 
 // Helper for _extractMetadataCode.
 NodeList<Annotation>? _getOtherMetadata(AstNode? node, Element element) {
-  if (node == null || node is EnumConstantDeclaration) {
+  if (node == null) {
     // `node` can be null with members of subclasses of `Element` from
-    // 'dart:html', and individual enum values cannot have metadata.
+    // 'dart:html'.
     return null;
+  }
+
+  if (node is EnumConstantDeclaration) {
+    return node.metadata;
   }
 
   // The `element.node` of a field is the [VariableDeclaration] that is nested

--- a/reflectable/lib/src/fixed_point.dart
+++ b/reflectable/lib/src/fixed_point.dart
@@ -14,7 +14,7 @@ abstract class FixedPoint<T> {
   /// Finally it also returns the expanded `initialSet`.
   Future<Set<T>> expand(final Set<T> initialSet) async {
     // Invariant: Every element that may have successors is in `workingSet`.
-    var workingSet = initialSet;
+    Set<T> workingSet = initialSet;
     bool isNew(T element) => !initialSet.contains(element);
     while (workingSet.isNotEmpty) {
       var newSet = <T>{};
@@ -35,7 +35,7 @@ abstract class FixedPoint<T> {
     var newSet = <T>{};
     Future<void> addSuccessors(T t) async =>
         (await successors(t)).forEach(newSet.add);
-    for (var t in initialSet) {
+    for (T t in initialSet) {
       await addSuccessors(t);
     }
     initialSet.addAll(newSet);

--- a/reflectable/lib/src/reflectable_builder_based.dart
+++ b/reflectable/lib/src/reflectable_builder_based.dart
@@ -124,7 +124,7 @@ class ReflectorData {
   ///
   /// Returns `null` if the given class is not marked for reflection.
   TypeMirror? typeMirrorForType(Type type) {
-    var typeToTypeMirrorCache = _typeToTypeMirrorCache;
+    Map<Type, TypeMirror>? typeToTypeMirrorCache = _typeToTypeMirrorCache;
     if (typeToTypeMirrorCache == null) {
       if (typeMirrors.isEmpty) {
         // This is the case when the capabilities do not include a
@@ -186,7 +186,7 @@ abstract class _DataCaching {
   ReflectableImpl get _reflector;
 
   ReflectorData get _data {
-    var dataCache = _dataCache;
+    ReflectorData? dataCache = _dataCache;
     if (dataCache == null) {
       // We should never call this method except from a mirror, and we should
       // never have a mirror unless it has a reflector, so it should never be
@@ -475,9 +475,9 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
 
   @override
   Map<String, DeclarationMirror> get declarations {
-    var declarations = _declarations;
+    Map<String, DeclarationMirror>? declarations = _declarations;
     if (declarations == null) {
-      Map<String, DeclarationMirror> result = <String, DeclarationMirror>{};
+      var result = <String, DeclarationMirror>{};
       for (int declarationIndex in _declarationIndices) {
         // We encode a missing `declarations` capability as an index with
         // the value noCapabilityIndex. Note that `_declarations` will not be
@@ -503,14 +503,14 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
 
   @override
   Map<String, MethodMirror> get instanceMembers {
-    var instanceMembers = _instanceMembers;
+    Map<String, MethodMirror>? instanceMembers = _instanceMembers;
     if (instanceMembers == null) {
-      var instanceMemberIndices = _instanceMemberIndices;
+      List<int>? instanceMemberIndices = _instanceMemberIndices;
       if (instanceMemberIndices == null) {
         throw NoSuchCapabilityError(
             'Requesting instanceMembers without `declarationsCapability`.');
       }
-      Map<String, MethodMirror> result = <String, MethodMirror>{};
+      var result = <String, MethodMirror>{};
       for (int instanceMemberIndex in instanceMemberIndices) {
         DeclarationMirror declarationMirror =
             _data.memberMirrors![instanceMemberIndex];
@@ -527,14 +527,14 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
 
   @override
   Map<String, MethodMirror> get staticMembers {
-    var staticMembers = _staticMembers;
+    Map<String, MethodMirror>? staticMembers = _staticMembers;
     if (staticMembers == null) {
-      var staticMemberIndices = _staticMemberIndices;
+      List<int>? staticMemberIndices = _staticMemberIndices;
       if (staticMemberIndices == null) {
         throw NoSuchCapabilityError(
             'Requesting instanceMembers without `declarationsCapability`.');
       }
-      Map<String, MethodMirror> result = <String, MethodMirror>{};
+      var result = <String, MethodMirror>{};
       for (int staticMemberIndex in staticMemberIndices) {
         DeclarationMirror declarationMirror =
             _data.memberMirrors![staticMemberIndex];
@@ -590,7 +590,7 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
               .every((Symbol name) => namesOfNamedParameters.contains(name));
     }
 
-    var parameterListShapes = _parameterListShapes;
+    Map<String, int>? parameterListShapes = _parameterListShapes;
     if (parameterListShapes != null) {
       // We have the ready-to-use parameter list shape information; we check
       // for that first because it is preferred over the slower computation
@@ -968,9 +968,9 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   /// Used to enable instance checks. Let O be an instance and let C denote the
   /// generic class modeled by this mirror. The check is then such that the
   /// result is true iff there exists a list of type arguments X1..Xk such that
-  /// O is an instance of C<X1..Xk>. We can perform this check by checking that
-  /// O is an instance of C<dynamic .. dynamic>, and O is not an instance
-  /// of any of Dj<dynamic .. dynamic> for j in {1..n}, where D1..Dn is the
+  /// O is an instance of `C<X1..Xk>`. We can perform this check by checking
+  /// that O is an instance of `C<dynamic .. dynamic>`, and O is not an instance
+  /// of any of `Dj<dynamic .. dynamic>` for j in {1..n}, where D1..Dn is the
   /// complete set of classes in the current program which are direct,
   /// non-abstract subinterfaces of C (i.e., classes which directly `extends`
   /// or `implements` C, or their subtypes again in case they are abstract).
@@ -1036,7 +1036,7 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   // model a non-generic class.
   @override
   List<TypeVariableMirror> get typeVariables {
-    var typeVariableIndices = _typeVariableIndices;
+    List<int>? typeVariableIndices = _typeVariableIndices;
     if (typeVariableIndices == null) {
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
@@ -1046,7 +1046,7 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
       throw NoSuchCapabilityError(
           'Requesting type variables of `$qualifiedName` without capability');
     }
-    List<TypeVariableMirror> result = <TypeVariableMirror>[];
+    var result = <TypeVariableMirror>[];
     for (int typeVariableIndex in typeVariableIndices) {
       var typeVariableMirror =
           _data.typeMirrors[typeVariableIndex] as TypeVariableMirror;
@@ -1153,7 +1153,7 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
           'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
           'without `typeRelationsCapability` or `reflectedTypeCapability`');
     }
-    var reflectedTypeArgumentIndices = _reflectedTypeArgumentIndices;
+    List<int>? reflectedTypeArgumentIndices = _reflectedTypeArgumentIndices;
     if (reflectedTypeArgumentIndices == null) {
       throw unimplementedError('reflectedTypeArguments');
     }
@@ -1184,7 +1184,7 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
 
   @override
   Type get reflectedType {
-    var reflectedType = _reflectedType;
+    Type? reflectedType = _reflectedType;
     if (reflectedType != null) {
       return reflectedType;
     }
@@ -1312,7 +1312,7 @@ class TypeVariableMirrorImpl extends _DataCaching
 
   @override
   TypeMirror get upperBound {
-    var upperBoundIndex = _upperBoundIndex;
+    int? upperBoundIndex = _upperBoundIndex;
     if (upperBoundIndex == null) return DynamicMirrorImpl();
     if (upperBoundIndex == noCapabilityIndex) {
       throw NoSuchCapabilityError('Attempt to get `upperBound` from type '
@@ -1474,9 +1474,9 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
 
   @override
   Map<String, DeclarationMirror> get declarations {
-    var declarations = _declarations;
+    Map<String, DeclarationMirror>? declarations = _declarations;
     if (declarations == null) {
-      Map<String, DeclarationMirror> result = <String, DeclarationMirror>{};
+      var result = <String, DeclarationMirror>{};
       for (int declarationIndex in _declarationIndices) {
         // We encode a missing `declarations` capability as an index with
         // the value noCapabilityIndex. Note that [declarations] will not be
@@ -1492,7 +1492,7 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
             _data.memberMirrors![declarationIndex];
         result[declarationMirror.simpleName] = declarationMirror;
       }
-      for (var typeMirror in _data.typeMirrors) {
+      for (TypeMirror typeMirror in _data.typeMirrors) {
         if (typeMirror is ClassMirror && typeMirror.owner == this) {
           result[typeMirror.simpleName] = typeMirror;
         }
@@ -1522,7 +1522,7 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
           .every((Symbol name) => namesOfNamedParameters.contains(name));
     }
 
-    var parameterListShapes = _parameterListShapes;
+    Map<String, int>? parameterListShapes = _parameterListShapes;
     if (parameterListShapes != null) {
       // We have the ready-to-use parameter list shape information; we check
       // for that first because it is preferred over the slower computation
@@ -1618,7 +1618,7 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
 
   @override
   List<Object> get metadata {
-    var metadata = _metadata;
+    List<Object>? metadata = _metadata;
     if (metadata == null) {
       throw NoSuchCapabilityError(
           'Requesting metadata of library `$simpleName` without capability');
@@ -1789,7 +1789,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
 
   @override
   List<Object> get metadata {
-    var metadata = _metadata;
+    List<Object>? metadata = _metadata;
     if (metadata == null) {
       throw NoSuchCapabilityError(
           'Requesting metadata of method `$simpleName` without capability');
@@ -1875,7 +1875,7 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
     var numberOfPositionalParameters = 0;
     var numberOfOptionalPositionalParameters = 0;
     var namesOfNamedParameters = <Symbol>{};
-    for (var parameterMirror in parameters) {
+    for (ParameterMirror parameterMirror in parameters) {
       parameterMirror as ParameterMirrorImpl;
       if (parameterMirror.isNamed) {
         namesOfNamedParameters.add(parameterMirror._nameSymbol!);
@@ -2173,7 +2173,7 @@ abstract class VariableMirrorBase extends _DataCaching
 
   @override
   List<Object> get metadata {
-    var metadata = _metadata;
+    List<Object>? metadata = _metadata;
     if (metadata == null) {
       throw NoSuchCapabilityError(
           'Requesting metadata of field `$simpleName` without capability');
@@ -2588,7 +2588,7 @@ abstract class ReflectableImpl extends ReflectableBase
     }
     // The specification says that an exception shall be thrown if there
     // is anything other than one library with a matching name.
-    int matchCount = 0;
+    var matchCount = 0;
     LibraryMirror? matchingLibrary;
     for (LibraryMirror libraryMirror in reflectorData.libraryMirrors!) {
       if (libraryMirror.qualifiedName == libraryName) {
@@ -2613,7 +2613,7 @@ abstract class ReflectableImpl extends ReflectableBase
       throw NoSuchCapabilityError('Using `libraries` without capability. '
           'Try adding `libraryCapability`.');
     }
-    Map<Uri, LibraryMirror> result = <Uri, LibraryMirror>{};
+    var result = <Uri, LibraryMirror>{};
     for (LibraryMirror library in reflectorData.libraryMirrors!) {
       result[library.uri] = library;
     }

--- a/reflectable/lib/src/reflectable_errors.dart
+++ b/reflectable/lib/src/reflectable_errors.dart
@@ -51,8 +51,8 @@ const String isEnum = 'Encountered a reflector class which is an enum.';
 /// with the corresponding value in [replacements].
 String applyTemplate(String template, Map<String, String> replacements) {
   return template.replaceAllMapped(RegExp(r'{(.*?)}'), (Match match) {
-    var index = match.group(1);
-    var replacement = replacements[index];
+    String? index = match.group(1);
+    String? replacement = replacements[index];
     if (replacement == null) {
       throw ArgumentError('Missing template replacement for $index');
     }

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -21,5 +21,5 @@ dependencies:
   source_span: ^1.10.0
 dev_dependencies:
   build_test: ^2.2.0
-  lints: ^4.0.0
+  lints: ^5.1.0
   test: ^1.25.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 4.0.10
+version: 4.0.11
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=3.5.0 <4.0.0'
 dependencies:
-  analyzer: ^6.7.0
+  analyzer: ^6.11.0
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.1.0


### PR DESCRIPTION
This PR updates reflectable to use analyzer 6.11.0 and lints 5.1.0. It fixes issue #291 (such that metadata of an enum value can be obtained). It also changes the implementation of reflectable to follow the style defined by the lints `omit_obvious_local_variable_types` and `specify_nonobvious_local_variable_types`. Finally, it prepares reflectable for release as version 4.0.11.