### PR TITLE
Revert deps to analyzer 6.8.0

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.0.12
 
-* Reverting analyzer dependency to 6.8.0 due to macros conflict.
+* Revert analyzer dependency to 6.8.0 and lints to 5.0.0 due to macro
+  related version resolution conflict.
 
 ## 4.0.11
 
@@ -52,8 +53,8 @@
   https://pub.dev/documentation/build/latest/build/AssetId-class.html .
 
   For documentation about package URIs, please see
-  https://api.dart.dev/stable/2.19.2/dart-isolate/Isolate/packageConfig.html 
-  and, for example, https://pub.dev/packages/package_config .
+  `https://api.dart.dev/stable/2.19.2/dart-isolate/Isolate/packageConfig.html`
+  and, for example, `https://pub.dev/packages/package_config`.
 
 ## 4.0.4
 

--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.12
+
+* Reverting analyzer dependency to 6.8.0 due to macros conflict.
+
 ## 4.0.11
 
 * Fix bug 291 (such that metadata on enum values can be obtained).

--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 4.0.12
 
 * Revert analyzer dependency to 6.8.0 and lints to 5.0.0 due to macro
-  related version resolution conflict.
+  related version resolution conflict. Undo some changes that are
+  required for analyzer 6.11.0, but which are errors with 6.8.0.
 
 ## 4.0.11
 

--- a/reflectable/analysis_options.yaml
+++ b/reflectable/analysis_options.yaml
@@ -4,5 +4,6 @@ linter:
     await_only_futures: true
     unnecessary_library_name: false
     omit_local_variable_types: false
-    omit_obvious_local_variable_types: true
-    specify_nonobvious_local_variable_types: true
+    # Enable the following when analyzer ^6.11.0 can be used:
+    # omit_obvious_local_variable_types: true
+    # specify_nonobvious_local_variable_types: true

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -721,7 +721,7 @@ class _ReflectorDomain {
     // would suppress an error in a very-hard-to-explain case, so that's safer
     // in a sense, but too weird.
     if (constructor.library.isDartCore &&
-        constructor.enclosingElement3.name == 'List' &&
+        constructor.enclosingElement.name == 'List' &&
         constructor.name == '') {
       return '(bool b) => ([length]) => '
           'b ? (length == null ? [] : List.filled(length, null)) : null';
@@ -1291,9 +1291,9 @@ class _ReflectorDomain {
 
   Future<int?> _computeOwnerIndex(
       ExecutableElement element, int descriptor) async {
-    if (element.enclosingElement3 is InterfaceElement) {
-      return (await classes).indexOf(element.enclosingElement3);
-    } else if (element.enclosingElement3 is CompilationUnitElement) {
+    if (element.enclosingElement is InterfaceElement) {
+      return (await classes).indexOf(element.enclosingElement);
+    } else if (element.enclosingElement is CompilationUnitElement) {
       return _libraries.indexOf(element.library);
     }
     await _severe('Unexpected kind of request for owner');
@@ -1337,7 +1337,7 @@ class _ReflectorDomain {
       }
     }
     int? ownerIndex =
-        (await classes).indexOf(typeParameterElement.enclosingElement3!);
+        (await classes).indexOf(typeParameterElement.enclosingElement!);
     // TODO(eernst) implement: Update when type variables support metadata.
     var metadataCode = _capabilities._supportsMetadata ? '<Object>[]' : 'null';
     return "r.TypeVariableMirrorImpl(r'${typeParameterElement.name}', "
@@ -1452,7 +1452,7 @@ class _ReflectorDomain {
     } else {
       var mapEntries = <String>[];
       for (ConstructorElement constructor in classDomain._constructors) {
-        InterfaceElement enclosingElement = constructor.enclosingElement3;
+        InterfaceElement enclosingElement = constructor.enclosingElement;
         if (constructor.isFactory ||
             ((enclosingElement is ClassElement &&
                     !enclosingElement.isAbstract) &&
@@ -1772,7 +1772,7 @@ class _ReflectorDomain {
       Map<FunctionType, int> typedefs,
       bool reflectedTypeRequested) async {
     int descriptor = _fieldDescriptor(element);
-    int ownerIndex = (await classes).indexOf(element.enclosingElement3) ??
+    int ownerIndex = (await classes).indexOf(element.enclosingElement) ??
         constants.noCapabilityIndex;
     int classMirrorIndex = await _computeVariableTypeIndex(element, descriptor);
     int reflectedTypeIndex = reflectedTypeRequested
@@ -2286,7 +2286,7 @@ class _ReflectorDomain {
       bool reflectedTypeRequested) async {
     int descriptor = _parameterDescriptor(element);
     int ownerIndex =
-        members.indexOf(element.enclosingElement3!)! + fields.length;
+        members.indexOf(element.enclosingElement!)! + fields.length;
     int classMirrorIndex = constants.noCapabilityIndex;
     if (_capabilities._impliesTypes) {
       if (descriptor & constants.dynamicAttribute != 0 ||
@@ -3476,7 +3476,7 @@ class BuilderImplementation {
 
     Element? element = elementAnnotation.element;
     if (element is ConstructorElement) {
-      DartType enclosingType = _typeForReflectable(element.enclosingElement3);
+      DartType enclosingType = _typeForReflectable(element.enclosingElement);
       DartType focusClassType = _typeForReflectable(focusClass);
       bool isOk = enclosingType is ParameterizedType &&
           focusClassType is InterfaceType &&
@@ -3561,8 +3561,7 @@ class BuilderImplementation {
             .getNamedConstructor('')!;
 
     for (LibraryElement library in _libraries) {
-      List<LibraryImportElement> imports =
-          library.definingCompilationUnit.libraryImports;
+      List<LibraryImportElement> imports = library.libraryImports;
       for (var import in imports) {
         if (import.importedLibrary?.id != reflectableLibrary.id) continue;
         for (ElementAnnotation metadatum in import.metadata) {
@@ -4618,7 +4617,7 @@ int _declarationDescriptor(ExecutableElement element) {
   if (element is! ConstructorElement) {
     if (element.isAbstract) result |= constants.abstractAttribute;
   }
-  if (element.enclosingElement3 is! InterfaceElement) {
+  if (element.enclosingElement is! InterfaceElement) {
     result |= constants.topLevelAttribute;
   }
   return result;
@@ -4626,8 +4625,8 @@ int _declarationDescriptor(ExecutableElement element) {
 
 Future<String> _nameOfConstructor(ConstructorElement element) async {
   String name = element.name == ''
-      ? element.enclosingElement3.name
-      : '${element.enclosingElement3.name}.${element.name}';
+      ? element.enclosingElement.name
+      : '${element.enclosingElement.name}.${element.name}';
   if (_isPrivateName(name)) {
     await _severe('Cannot access private name $name', element);
   }
@@ -4817,7 +4816,7 @@ Future<String> _extractConstantCode(
                   elementLibrary, generatedLibraryId, resolver)) {
             importCollector._addLibrary(elementLibrary);
             String prefix = importCollector._getPrefix(elementLibrary);
-            Element? enclosingElement = element.enclosingElement3;
+            Element? enclosingElement = element.enclosingElement;
             if (enclosingElement is InterfaceElement) {
               prefix += '${enclosingElement.name}.';
             }
@@ -5594,7 +5593,7 @@ String _qualifiedFunctionName(FunctionElement functionElement) {
 
 String _qualifiedTypeParameterName(TypeParameterElement? typeParameterElement) {
   if (typeParameterElement == null) return 'null';
-  return '${_qualifiedName(typeParameterElement.enclosingElement3!)}.'
+  return '${_qualifiedName(typeParameterElement.enclosingElement!)}.'
       '${typeParameterElement.name}';
 }
 

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -21,5 +21,5 @@ dependencies:
   source_span: ^1.10.0
 dev_dependencies:
   build_test: ^2.2.0
-  lints: ^5.1.0
+  lints: ^5.0.0
   test: ^1.25.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reflectable
-version: 4.0.11
+version: 4.0.12
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=3.5.0 <4.0.0'
 dependencies:
-  analyzer: ^6.11.0
+  analyzer: ^6.8.0
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.1.0


### PR DESCRIPTION
The dependency upgrades in 4.0.11 caused no issues locally, but on github they cause failures of basically all the score related checks (pub version resolution fails with respect to some macro packages). This PR changes the dependency on the analyzer to 6.8.0 and lints to 5.0.0, and reverts some changes that were required with analyzer 6.11.0 but which cause errors with analyzer 6.8.0.