### PR TITLE
Update to the new element model

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.13
+
+* Update dependencies: `analyzer` 7.4, `build_runner` 2.4.15,
+  `dart_style` 3.0.0, `lints` 6.0.0.
+
 ## 4.0.12
 
 * Revert analyzer dependency to 6.8.0 and lints to 5.0.0 due to macro

--- a/reflectable/lib/capability.dart
+++ b/reflectable/lib/capability.dart
@@ -337,8 +337,10 @@ const subtypeQuantifyCapability = _SubtypeQuantifyCapability();
 class SuperclassQuantifyCapability implements ReflecteeQuantifyCapability {
   final Type upperBound;
   final bool excludeUpperBound;
-  const SuperclassQuantifyCapability(this.upperBound,
-      {this.excludeUpperBound = false});
+  const SuperclassQuantifyCapability(
+    this.upperBound, {
+    this.excludeUpperBound = false,
+  });
 }
 
 /// Gives support for reflection on all superclasses of covered classes.
@@ -371,8 +373,9 @@ const typeAnnotationQuantifyCapability = TypeAnnotationQuantifyCapability();
 /// the vocered classes, as well as the transitive closure thereof (that is,
 /// including classes used as type annotations in classes used as type
 /// annotations, etc.).
-const typeAnnotationDeepQuantifyCapability =
-    TypeAnnotationQuantifyCapability(transitive: true);
+const typeAnnotationDeepQuantifyCapability = TypeAnnotationQuantifyCapability(
+  transitive: true,
+);
 
 /// Quantifying capability instance specifying that the reflection support
 /// for any given explicitly declared getter must also be given to its
@@ -427,7 +430,7 @@ class ImportAttachedCapability {
 class GlobalQuantifyCapability extends ImportAttachedCapability {
   final String classNamePattern;
   const GlobalQuantifyCapability(this.classNamePattern, Reflectable reflector)
-      : super(reflector);
+    : super(reflector);
 }
 
 /// Gives reflection support in [reflector] for every class
@@ -443,7 +446,7 @@ class GlobalQuantifyCapability extends ImportAttachedCapability {
 class GlobalQuantifyMetaCapability extends ImportAttachedCapability {
   final Type metadataType;
   const GlobalQuantifyMetaCapability(this.metadataType, Reflectable reflector)
-      : super(reflector);
+    : super(reflector);
 }
 
 // ---------- Private classes used to enable capability instances above.
@@ -509,8 +512,12 @@ class _StringInvocation extends StringInvocation {
   @override
   bool get isSetter => kind == StringInvocationKind.setter;
 
-  _StringInvocation(this.memberName, this.positionalArguments,
-      this.namedArguments, this.kind);
+  _StringInvocation(
+    this.memberName,
+    this.positionalArguments,
+    this.namedArguments,
+    this.kind,
+  );
 }
 
 /// Thrown when a method is invoked via a reflectable, but the reflectable
@@ -533,11 +540,20 @@ class ReflectableNoSuchMethodError extends Error
 
   final StringInvocationKind kind;
 
-  ReflectableNoSuchMethodError(this.receiver, this.memberName,
-      this.positionalArguments, this.namedArguments, this.kind);
+  ReflectableNoSuchMethodError(
+    this.receiver,
+    this.memberName,
+    this.positionalArguments,
+    this.namedArguments,
+    this.kind,
+  );
 
   StringInvocation get invocation => _StringInvocation(
-      memberName, positionalArguments, namedArguments ?? const {}, kind);
+    memberName,
+    positionalArguments,
+    namedArguments ?? const {},
+    kind,
+  );
 
   @override
   String toString() {
@@ -555,7 +571,8 @@ class ReflectableNoSuchMethodError extends Error
       case StringInvocationKind.constructor:
         kindName = 'constructor';
     }
-    var description = 'NoSuchCapabilityError: no capability to invoke the '
+    var description =
+        'NoSuchCapabilityError: no capability to invoke the '
         '$kindName "$memberName"\n'
         'Receiver: $receiver\n'
         'Arguments: $positionalArguments\n';
@@ -567,38 +584,77 @@ class ReflectableNoSuchMethodError extends Error
 }
 
 dynamic reflectableNoSuchInvokableError(
-    Object? receiver,
-    String memberName,
-    List positionalArguments,
-    Map<Symbol, dynamic>? namedArguments,
-    StringInvocationKind kind) {
+  Object? receiver,
+  String memberName,
+  List positionalArguments,
+  Map<Symbol, dynamic>? namedArguments,
+  StringInvocationKind kind,
+) {
   throw ReflectableNoSuchMethodError(
-      receiver, memberName, positionalArguments, namedArguments, kind);
+    receiver,
+    memberName,
+    positionalArguments,
+    namedArguments,
+    kind,
+  );
 }
 
-dynamic reflectableNoSuchMethodError(Object? receiver, String memberName,
-    List positionalArguments, Map<Symbol, dynamic>? namedArguments) {
-  throw ReflectableNoSuchMethodError(receiver, memberName, positionalArguments,
-      namedArguments, StringInvocationKind.method);
+dynamic reflectableNoSuchMethodError(
+  Object? receiver,
+  String memberName,
+  List positionalArguments,
+  Map<Symbol, dynamic>? namedArguments,
+) {
+  throw ReflectableNoSuchMethodError(
+    receiver,
+    memberName,
+    positionalArguments,
+    namedArguments,
+    StringInvocationKind.method,
+  );
 }
 
-dynamic reflectableNoSuchGetterError(Object? receiver, String memberName,
-    List positionalArguments, Map<Symbol, dynamic>? namedArguments) {
-  throw ReflectableNoSuchMethodError(receiver, memberName, positionalArguments,
-      namedArguments, StringInvocationKind.getter);
+dynamic reflectableNoSuchGetterError(
+  Object? receiver,
+  String memberName,
+  List positionalArguments,
+  Map<Symbol, dynamic>? namedArguments,
+) {
+  throw ReflectableNoSuchMethodError(
+    receiver,
+    memberName,
+    positionalArguments,
+    namedArguments,
+    StringInvocationKind.getter,
+  );
 }
 
-dynamic reflectableNoSuchSetterError(Object? receiver, String memberName,
-    List positionalArguments, Map<Symbol, dynamic>? namedArguments) {
-  throw ReflectableNoSuchMethodError(receiver, memberName, positionalArguments,
-      namedArguments, StringInvocationKind.setter);
+dynamic reflectableNoSuchSetterError(
+  Object? receiver,
+  String memberName,
+  List positionalArguments,
+  Map<Symbol, dynamic>? namedArguments,
+) {
+  throw ReflectableNoSuchMethodError(
+    receiver,
+    memberName,
+    positionalArguments,
+    namedArguments,
+    StringInvocationKind.setter,
+  );
 }
 
 dynamic reflectableNoSuchConstructorError(
-    Object? receiver,
-    String constructorName,
-    List positionalArguments,
-    Map<Symbol, dynamic>? namedArguments) {
-  throw ReflectableNoSuchMethodError(receiver, constructorName,
-      positionalArguments, namedArguments, StringInvocationKind.constructor);
+  Object? receiver,
+  String constructorName,
+  List positionalArguments,
+  Map<Symbol, dynamic>? namedArguments,
+) {
+  throw ReflectableNoSuchMethodError(
+    receiver,
+    constructorName,
+    positionalArguments,
+    namedArguments,
+    StringInvocationKind.constructor,
+  );
 }

--- a/reflectable/lib/mirrors.dart
+++ b/reflectable/lib/mirrors.dart
@@ -337,8 +337,11 @@ abstract class ObjectMirror implements Mirror {
   /// [StaticInvokeMetaCapability]; and [invoke] on a top-level function
   /// requires a matching [TopLevelInvokeCapability] or
   /// [TopLevelInvokeMetaCapability].
-  Object? invoke(String memberName, List positionalArguments,
-      [Map<Symbol, dynamic>? namedArguments]); // RET: InstanceMirror
+  Object? invoke(
+    String memberName,
+    List positionalArguments, [
+    Map<Symbol, dynamic>? namedArguments,
+  ]); // RET: InstanceMirror
 
   /// Invokes a getter and returns the result. The getter can be the
   /// implicit getter for a field, or a user-defined getter method.
@@ -540,8 +543,10 @@ abstract class ClosureMirror implements InstanceMirror {
   /// Required capabilities: [apply] requires a matching
   /// [InstanceInvokeCapability] or [InstanceInvokeMetaCapability], targeting
   /// the relevant `call` method.
-  Object? apply(List positionalArguments,
-      [Map<Symbol, dynamic>? namedArguments]); // RET: InstanceMirror
+  Object? apply(
+    List positionalArguments, [
+    Map<Symbol, dynamic>? namedArguments,
+  ]); // RET: InstanceMirror
 }
 
 /// A [LibraryMirror] reflects a Dart language library, providing
@@ -965,8 +970,11 @@ abstract class ClassMirror implements TypeMirror, ObjectMirror {
   ///
   /// Required capabilities: [newInstance] requires a matching
   /// [NewInstanceCapability] or [NewInstanceMetaCapability].
-  Object newInstance(String constructorName, List positionalArguments,
-      [Map<Symbol, dynamic> namedArguments]); // RET: InstanceMirror
+  Object newInstance(
+    String constructorName,
+    List positionalArguments, [
+    Map<Symbol, dynamic> namedArguments,
+  ]); // RET: InstanceMirror
 
   /// Whether this mirror is equal to [other].
   ///

--- a/reflectable/lib/reflectable.dart
+++ b/reflectable/lib/reflectable.dart
@@ -114,17 +114,18 @@ abstract class Reflectable extends implementation.ReflectableImpl
 
   /// Const constructor, to enable usage as metadata, allowing for varargs
   /// style invocation with up to ten arguments.
-  const Reflectable(
-      [super.cap0,
-      super.cap1,
-      super.cap2,
-      super.cap3,
-      super.cap4,
-      super.cap5,
-      super.cap6,
-      super.cap7,
-      super.cap8,
-      super.cap9]);
+  const Reflectable([
+    super.cap0,
+    super.cap1,
+    super.cap2,
+    super.cap3,
+    super.cap4,
+    super.cap5,
+    super.cap6,
+    super.cap7,
+    super.cap8,
+    super.cap9,
+  ]);
 
   const Reflectable.fromList(super.capabilities) : super.fromList();
 

--- a/reflectable/lib/reflectable_builder.dart
+++ b/reflectable/lib/reflectable_builder.dart
@@ -30,14 +30,21 @@ class ReflectableBuilder implements Builder {
     AssetId outputId = inputId.changeExtension('.reflectable.dart');
     List<LibraryElement> visibleLibraries = await resolver.libraries.toList();
     String generatedSource = await BuilderImplementation().buildMirrorLibrary(
-        resolver, inputId, outputId, inputLibrary, visibleLibraries, true, []);
+      resolver,
+      inputId,
+      outputId,
+      inputLibrary,
+      visibleLibraries,
+      true,
+      [],
+    );
     await buildStep.writeAsString(outputId, generatedSource);
   }
 
   @override
   Map<String, List<String>> get buildExtensions => const {
-        '.dart': ['.reflectable.dart']
-      };
+    '.dart': ['.reflectable.dart'],
+  };
 }
 
 ReflectableBuilder reflectableBuilder(BuilderOptions options) {
@@ -55,12 +62,13 @@ Future<BuildResult> reflectableBuild(List<String> arguments) async {
   } else {
     // TODO(eernst) feature: We should support some customization of
     // the settings, e.g., specifying options like `suppress_warnings`.
-    var options = BuilderOptions(
-        <String, dynamic>{'entry_points': arguments, 'formatted': true},
-        isRoot: true);
+    var options = BuilderOptions(<String, dynamic>{
+      'entry_points': arguments,
+      'formatted': true,
+    }, isRoot: true);
     final builder = ReflectableBuilder(options);
     var builders = <BuilderApplication>[
-      applyToRoot(builder, generateFor: InputSet(include: arguments))
+      applyToRoot(builder, generateFor: InputSet(include: arguments)),
     ];
     PackageGraph packageGraph = await PackageGraph.forThisPackage();
     var environment = OverrideableEnvironment(IOEnvironment(packageGraph));
@@ -71,8 +79,12 @@ Future<BuildResult> reflectableBuild(List<String> arguments) async {
     );
     try {
       BuildRunner build = await BuildRunner.create(
-          buildOptions, environment, builders, const {},
-          isReleaseBuild: false);
+        buildOptions,
+        environment,
+        builders,
+        const {},
+        isReleaseBuild: false,
+      );
       BuildResult result = await build.run(const {});
       await build.beforeExit();
       return result;

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -3988,9 +3988,9 @@ class BuilderImplementation {
             .getNamedConstructor('')!;
 
     for (LibraryElement library in _libraries) {
-      List<LibraryImportElement> imports = library.libraryImports;
+      List<LibraryElement> imports = library.importedLibraries;
       for (var import in imports) {
-        if (import.importedLibrary?.id != reflectableLibrary.id) continue;
+        if (import.id != reflectableLibrary.id) continue;
         for (ElementAnnotation metadatum in import.metadata) {
           Element? metadatumElement = metadatum.element?.declaration;
           if (metadatumElement == globalQuantifyCapabilityConstructor) {

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -40,6 +40,12 @@ import 'incompleteness.dart';
 import 'reflectable_class_constants.dart' as reflectable_class_constants;
 import 'reflectable_errors.dart' as errors;
 
+// !!!MIGRATION!!!
+
+extension on InterfaceElement2 {
+  dynamic get typeParameters => throw "!!!TODO!!!";
+}
+
 // ignore_for_file: omit_local_variable_types
 
 /// Specifiers for warnings that may be suppressed; `allWarnings` disables all
@@ -1754,7 +1760,7 @@ class _ReflectorDomain {
                 !await _isImportable(subtype, _generatedLibraryId, _resolver)) {
               await helper(list, subtype);
             } else {
-              String prefix = importCollector._getPrefix(subtype.library);
+              String prefix = importCollector._getPrefix(subtype.library2);
               list.add(' && o is! $prefix${subtype.name3!}');
             }
           }
@@ -1809,10 +1815,10 @@ class _ReflectorDomain {
     Map<FunctionType, int> typedefs,
     bool reflectedTypeRequested,
   ) async {
-    if (element is PropertyAccessorElement && element.isSynthetic) {
+    if (element is PropertyAccessorElement2 && element.isSynthetic) {
       // There is no type propagation, so we declare an `accessorElement`.
       PropertyAccessorElement2 accessorElement = element;
-      PropertyInducingElement2? variable = accessorElement.variable2;
+      PropertyInducingElement2? variable = accessorElement.variable3;
       int variableMirrorIndex =
           variable is TopLevelVariableElement2
               ? topLevelVariables.indexOf(variable)!
@@ -1820,12 +1826,12 @@ class _ReflectorDomain {
               ? fields.indexOf(variable)!
               : constants.noCapabilityIndex;
       int selfIndex = members.indexOf(accessorElement)! + fields.length;
-      if (accessorElement.isGetter) {
+      if (accessorElement is GetterElement) {
         return 'r.ImplicitGetterMirrorImpl('
             '${await _constConstructionCode(importCollector)}, '
             '$variableMirrorIndex, $selfIndex)';
       } else {
-        assert(accessorElement.isSetter);
+        assert(accessorElement is SetterElement);
         return 'r.ImplicitSetterMirrorImpl('
             '${await _constConstructionCode(importCollector)}, '
             '$variableMirrorIndex, $selfIndex)';
@@ -1884,7 +1890,7 @@ class _ReflectorDomain {
                 _generatedLibraryId,
               )
               : null;
-      return "r.MethodMirrorImpl(r'${element.name}', $descriptor, "
+      return "r.MethodMirrorImpl(r'${element.name3}', $descriptor, "
           '$ownerIndex, $returnTypeIndex, $reflectedReturnTypeIndex, '
           '$dynamicReflectedReturnTypeIndex, '
           '$reflectedTypeArgumentsOfReturnType, $parameterIndicesCode, '
@@ -2090,7 +2096,7 @@ class _ReflectorDomain {
       return constants.noCapabilityIndex;
     }
     if (dartType is InterfaceType) {
-      InterfaceElement2 interfaceElement = dartType.element;
+      InterfaceElement2 interfaceElement = dartType.element3;
       if (classes.contains(interfaceElement)) {
         return classes.indexOf(interfaceElement)!;
       }
@@ -2186,13 +2192,13 @@ class _ReflectorDomain {
 
     if (dartType is DynamicType) return 'dynamic';
     if (dartType is InterfaceType) {
-      InterfaceElement2 interfaceElement = dartType.element;
+      InterfaceElement2 interfaceElement = dartType.element3;
       if ((interfaceElement is MixinApplication &&
               interfaceElement.declaredName == null) ||
           interfaceElement.isPrivate) {
         return await fail();
       }
-      String prefix = importCollector._getPrefix(interfaceElement.library);
+      String prefix = importCollector._getPrefix(interfaceElement.library2);
       if (interfaceElement.typeParameters.isEmpty) {
         return '$prefix${interfaceElement.name3}';
       } else {
@@ -2249,8 +2255,8 @@ class _ReflectorDomain {
           useNameOfGenericFunctionType: useNameOfGenericFunctionType,
         );
         var typeArguments = '';
-        if (dartType.typeFormals.isNotEmpty) {
-          Iterable<String> typeArgumentList = dartType.typeFormals.map(
+        if (dartType.typeParameters.isNotEmpty) {
+          Iterable<String> typeArgumentList = dartType.typeParameters.map(
             (TypeParameterElement2 typeParameter) => typeParameter.toString(),
           );
           typeArguments = '<${typeArgumentList.join(', ')}>';
@@ -2331,7 +2337,7 @@ class _ReflectorDomain {
     var typeVariablesInScope = <String>{}; // None at this level.
     if (dartType is DynamicType) return 'dynamic';
     if (dartType is InterfaceType) {
-      InterfaceElement2 interfaceElement = dartType.element;
+      InterfaceElement2 interfaceElement = dartType.element3;
       if ((interfaceElement is MixinApplication &&
               interfaceElement.declaredName == null) ||
           interfaceElement.isPrivate) {
@@ -2347,7 +2353,7 @@ class _ReflectorDomain {
         // class.
         return "const r.FakeType(r'${_qualifiedName(interfaceElement)}')";
       }
-      String prefix = importCollector._getPrefix(interfaceElement.library);
+      String prefix = importCollector._getPrefix(interfaceElement.library2);
       if (interfaceElement.typeParameters.isEmpty) {
         return '$prefix${interfaceElement.name3}';
       } else {
@@ -2376,7 +2382,7 @@ class _ReflectorDomain {
       // 0.36.4, so it is a bug to test for it.
       final Element2? dartTypeElement = dartType.alias?.element2;
       if (dartTypeElement is TypeAliasElement2) {
-        String prefix = importCollector._getPrefix(dartTypeElement.library);
+        String prefix = importCollector._getPrefix(dartTypeElement.library2);
         return '$prefix${dartTypeElement.name3}';
       } else {
         if (dartType.typeFormals.isNotEmpty) {
@@ -2546,12 +2552,12 @@ class _ReflectorDomain {
           ParameterListShape shape = parameterListShapeOf[element]!;
           // index != null: every shape is in `..Shapes`.
           int index = parameterListShapes.indexOf(shape)!;
-          return "r'${element.name}': $index";
+          return "r'${element.name3}': $index";
         }),
       );
     }
 
-    return "r.LibraryMirrorImpl(r'${library.name}', $uriCode, "
+    return "r.LibraryMirrorImpl(r'${library.name3}', $uriCode, "
         '${await _constConstructionCode(importCollector)}, '
         '$declarationsCode, $gettersCode, $settersCode, $metadataCode, '
         '$parameterListShapesCode)';
@@ -2583,7 +2589,7 @@ class _ReflectorDomain {
         // capability is absent.
         DartType elementType = element.type;
         if (elementType is InterfaceType) {
-          InterfaceElement2 elementTypeElement = elementType.element;
+          InterfaceElement2 elementTypeElement = elementType.element3;
           classMirrorIndex =
               (await classes).contains(elementTypeElement)
                   ? (await classes).indexOf(elementTypeElement)!
@@ -2627,7 +2633,7 @@ class _ReflectorDomain {
     if (_capabilities._supportsMetadata) {
       // TODO(eernst): 'dart:*' is not considered valid. To survive, we
       // return the empty metadata for elements from 'dart:*'. Issue 173.
-      if (_isPlatformLibrary(element.library!)) {
+      if (_isPlatformLibrary(element.library2!)) {
         metadataCode = 'const []';
       } else {
         var node =
@@ -2650,10 +2656,10 @@ class _ReflectorDomain {
     var defaultValueCode = code.isEmpty ? 'null' : code;
     var parameterSymbolCode =
         descriptor & constants.namedAttribute != 0
-            ? '#${element.name}'
+            ? '#${element.name3}'
             : 'null';
 
-    return "r.ParameterMirrorImpl(r'${element.name}', $descriptor, "
+    return "r.ParameterMirrorImpl(r'${element.name3}', $descriptor, "
         '$ownerIndex, ${await _constConstructionCode(importCollector)}, '
         '$classMirrorIndex, $reflectedTypeIndex, $dynamicReflectedTypeIndex, '
         '$reflectedTypeArguments, $metadataCode, $defaultValueCode, '
@@ -2669,7 +2675,7 @@ class _ReflectorDomain {
   ) async {
     // TODO(eernst): 'dart:*' is not considered valid. To survive, we return
     // '' for all declarations from there. Issue 173.
-    if (_isPlatformLibrary(parameterElement.library!)) return '';
+    if (_isPlatformLibrary(parameterElement.library2!)) return '';
     var parameterNode =
         await _getDeclarationAst(parameterElement, _resolver)
             as FormalParameter?;
@@ -2704,7 +2710,7 @@ DartType _typeForReflectable(InterfaceElement2 interfaceElement) {
   // be able to improve performance by working on classes as such.
   var typeArguments = List<DartType>.filled(
     interfaceElement.typeParameters.length,
-    interfaceElement.library.typeProvider.dynamicType,
+    interfaceElement.library2.typeProvider.dynamicType,
   );
   return interfaceElement.instantiate(
     typeArguments: typeArguments,
@@ -2761,7 +2767,7 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement2> {
     if (workingSuperType == null) {
       return []; // "Superclass of [Object]", ignore.
     }
-    InterfaceElement2 workingSuperclass = workingSuperType.element;
+    InterfaceElement2 workingSuperclass = workingSuperType.element3;
 
     var result = <InterfaceElement2>[];
 
@@ -2781,7 +2787,7 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement2> {
     // is done with [subClass].
     var superclass = workingSuperclass;
     for (InterfaceType mixin in element.mixins) {
-      InterfaceElement2 mixinClass = mixin.element;
+      InterfaceElement2 mixinClass = mixin.element3;
       if (mixinsRequested) result.add(mixinClass);
       InterfaceElement2? subClass =
           mixin == element.mixins.last ? element : null;
@@ -2795,7 +2801,7 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement2> {
         name,
         superclass,
         mixinClass,
-        element.library,
+        element.library2,
         subClass,
       );
       // We have already ensured that `workingSuperclass` is a
@@ -2822,7 +2828,7 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement2> {
         }
         InterfaceType? interfaceElementSupertype = interfaceElement.supertype;
         if (interfaceElementSupertype == null) return false;
-        return helper(interfaceElementSupertype.element, false);
+        return helper(interfaceElementSupertype.element3, false);
       }
 
       return upwardsClosureBounds.keys.any(isSuperclassOfInterfaceElement);
@@ -2843,7 +2849,7 @@ Set<InterfaceElement2> _mixinApplicationsOfClasses(
     if (interfaceElement is MixinApplication) continue;
     InterfaceType? supertype = interfaceElement.supertype;
     if (supertype == null) continue; // "Superclass of [Object]", ignore.
-    InterfaceElement2 superclass = supertype.element;
+    InterfaceElement2 superclass = supertype.element3;
     // Note that we iterate from the most general mixin to more specific ones,
     // that is, with `class C extends B with M1, M2..` we visit `M1` before
     // `M2`; this ensures that the right `superclass` is available for each
@@ -2851,7 +2857,7 @@ Set<InterfaceElement2> _mixinApplicationsOfClasses(
     // of each [MixinApplication] when it is a regular class (not a mixin
     // application), otherwise [null], which is done with [subClass].
     for (InterfaceType mixin in interfaceElement.mixins) {
-      InterfaceElement2 mixinClass = mixin.element;
+      InterfaceElement2 mixinClass = mixin.element3;
       InterfaceElement2? subClass =
           mixin == interfaceElement.mixins.last ? interfaceElement : null;
       String? name =
@@ -2865,7 +2871,7 @@ Set<InterfaceElement2> _mixinApplicationsOfClasses(
         name,
         superclass,
         mixinClass,
-        interfaceElement.library,
+        interfaceElement.library2,
         subClass,
       );
       mixinApplications.add(mixinApplication);
@@ -2917,33 +2923,33 @@ class _AnnotationClassFixedPoint extends FixedPoint<InterfaceElement2> {
     for (FieldElement2 fieldElement in classDomain._declaredFields) {
       DartType fieldType = fieldElement.type;
       if (fieldType is InterfaceType) {
-        result.add(fieldType.element);
+        result.add(fieldType.element3);
       }
     }
     for (FormalParameterElement parameterElement
         in classDomain._declaredParameters) {
       DartType parameterType = parameterElement.type;
       if (parameterType is InterfaceType) {
-        result.add(parameterType.element);
+        result.add(parameterType.element3);
       }
     }
     for (FormalParameterElement parameterElement
         in classDomain._instanceParameters) {
       DartType parameterType = parameterElement.type;
       if (parameterType is InterfaceType) {
-        result.add(parameterType.element);
+        result.add(parameterType.element3);
       }
     }
     for (ExecutableElement2 executableElement in classDomain._declaredMethods) {
       DartType executableReturnType = executableElement.returnType;
       if (executableReturnType is InterfaceType) {
-        result.add(executableReturnType.element);
+        result.add(executableReturnType.element3);
       }
     }
     for (ExecutableElement2 executableElement in classDomain._instanceMembers) {
       DartType executableReturnType = executableElement.returnType;
       if (executableReturnType is InterfaceType) {
-        result.add(executableReturnType.element);
+        result.add(executableReturnType.element3);
       }
     }
     return result;
@@ -2985,8 +2991,8 @@ Future<String> _staticGettingClosure(
   InterfaceElement2 interfaceElement,
   String getterName,
 ) async {
-  String className = interfaceElement.name;
-  String prefix = importCollector._getPrefix(interfaceElement.library);
+  String className = interfaceElement.name3!;
+  String prefix = importCollector._getPrefix(interfaceElement.library2);
   // Operators cannot be static.
   if (_isPrivateName(getterName)) {
     await _severe('Cannot access private name $getterName', interfaceElement);
@@ -3006,8 +3012,8 @@ Future<String> _staticSettingClosure(
   assert(setterName.substring(setterName.length - 1) == '=');
   // The [setterName] includes the '=', remove it.
   String name = setterName.substring(0, setterName.length - 1);
-  String className = interfaceElement.name;
-  String prefix = importCollector._getPrefix(interfaceElement.library);
+  String className = interfaceElement.name3!;
+  String prefix = importCollector._getPrefix(interfaceElement.library2);
   if (_isPrivateName(setterName)) {
     await _severe('Cannot access private name $setterName', interfaceElement);
   }
@@ -3058,12 +3064,12 @@ class _LibraryDomain {
   /// Fields declared by [_libraryElement] and included for reflection support,
   /// according to the reflector described by the [_reflectorDomain];
   /// obtained by filtering `_libraryElement.fields`.
-  final Iterable<TopLevelVariableElement> _declaredVariables;
+  final Iterable<TopLevelVariableElement2> _declaredVariables;
 
   /// Methods which are declared by [_libraryElement] and included for
   /// reflection support, according to the reflector described by
   /// [_reflectorDomain]; obtained by filtering `_libraryElement.functions`.
-  final Iterable<FunctionElement> _declaredFunctions;
+  final Iterable<TopLevelFunctionElement> _declaredFunctions;
 
   /// Formal parameters declared by one of the [_declaredFunctions].
   final Iterable<FormalParameterElement> _declaredParameters;
@@ -3199,13 +3205,13 @@ class _ClassDomain {
       var firstSeparator = true;
       for (var mixin in mixins) {
         name.write(firstSeparator ? ' with ' : ', ');
-        name.write(_qualifiedName(mixin.element));
+        name.write(_qualifiedName(mixin.element3));
         firstSeparator = false;
       }
       return name.toString();
     } else {
       // This is a regular class, i.e., we can use its declared name.
-      return interfaceElement.name;
+      return interfaceElement.name3!;
     }
   }
 
@@ -3236,8 +3242,7 @@ class _ClassDomain {
         // the metadata on the original field.
         List<ElementAnnotation> metadata =
             (member is PropertyAccessorElement2 && member.isSynthetic)
-                ? member.variable3?.metadata2.annotations ??
-                    const <ElementAnnotation>[]
+                ? member.variable3?.metadata2.annotations ?? const []
                 : member.metadata2.annotations;
         List<ElementAnnotation>? getterMetadata;
         if (_reflectorDomain._capabilities._impliesCorrespondingSetters &&
@@ -3281,12 +3286,13 @@ class _ClassDomain {
       }
       InterfaceType? superclassType = interfaceElement.supertype;
       if (superclassType is InterfaceType) {
-        InterfaceElement2 superclassElement = superclassType.element;
+        InterfaceElement2 superclassElement = superclassType.element3;
         helper(superclassElement).forEach(addIfCapable);
       }
       interfaceElement.mixins.forEach(addTypeIfCapable);
-      interfaceElement.methods.forEach(addIfCapableConcreteInstance);
-      interfaceElement.accessors.forEach(addIfCapableConcreteInstance);
+      interfaceElement.methods2.forEach(addIfCapableConcreteInstance);
+      interfaceElement.getters2.forEach(addIfCapableConcreteInstance);
+      interfaceElement.setters2.forEach(addIfCapableConcreteInstance);
 
       return cacheResult(result);
     }
@@ -3299,7 +3305,7 @@ class _ClassDomain {
     var result = <FormalParameterElement>[];
     if (_reflectorDomain._capabilities._impliesDeclarations) {
       for (ExecutableElement2 executableElement in _instanceMembers) {
-        result.addAll(executableElement.parameters);
+        result.addAll(executableElement.formalParameters);
       }
     }
     return result;
@@ -3314,34 +3320,34 @@ class _ClassDomain {
       if (method.isStatic &&
           !method.isPrivate &&
           _reflectorDomain._capabilities.supportsStaticInvoke(
-            method.library.typeSystem,
-            method.name,
-            method.metadata,
+            method.library2.typeSystem,
+            method.name3!,
+            method.metadata2.annotations,
             null,
           )) {
         result.add(method);
       }
     }
 
-    void possiblyAddAccessor(PropertyAccessorElement accessor) {
+    void possiblyAddAccessor(PropertyAccessorElement2 accessor) {
       if (!accessor.isStatic || accessor.isPrivate) return;
       // If [member] is a synthetic accessor created from a field, search for
       // the metadata on the original field.
       List<ElementAnnotation> metadata =
           accessor.isSynthetic
-              ? (accessor.variable2?.metadata ?? const <ElementAnnotation>[])
-              : accessor.metadata;
+              ? (accessor.variable3?.metadata2.annotations ?? const [])
+              : accessor.metadata2.annotations;
       List<ElementAnnotation>? getterMetadata;
       if (_reflectorDomain._capabilities._impliesCorrespondingSetters &&
-          accessor.isSetter &&
+          accessor is SetterElement &&
           !accessor.isSynthetic) {
-        PropertyAccessorElement? correspondingGetter =
+        PropertyAccessorElement2? correspondingGetter =
             accessor.correspondingGetter;
-        getterMetadata = correspondingGetter?.metadata;
+        getterMetadata = correspondingGetter?.metadata2.annotations;
       }
       if (_reflectorDomain._capabilities.supportsStaticInvoke(
-        accessor.library.typeSystem,
-        accessor.name,
+        accessor.library2.typeSystem,
+        accessor.name3!,
         metadata,
         getterMetadata,
       )) {
@@ -3349,8 +3355,9 @@ class _ClassDomain {
       }
     }
 
-    _interfaceElement.methods.forEach(possiblyAddMethod);
-    _interfaceElement.accessors.forEach(possiblyAddAccessor);
+    _interfaceElement.methods2.forEach(possiblyAddMethod);
+    _interfaceElement.getters2.forEach(possiblyAddAccessor);
+    _interfaceElement.setters2.forEach(possiblyAddAccessor);
     return result;
   }
 
@@ -3832,10 +3839,11 @@ class BuilderImplementation {
     LibraryElement2 reflectableLibrary,
   ) async {
     for (LibraryFragment fragment in reflectableLibrary.fragments) {
-      for (InterfaceElement2 type in fragment.classes) {
-        if (type.name3 == reflectable_class_constants.name &&
-            _equalsClassReflectable(type)) {
-          return type;
+      for (ClassFragment fragment in fragment.classes2) {
+        final element = fragment.element;
+        if (element.name3 == reflectable_class_constants.name &&
+            _equalsClassReflectable(element)) {
+          return element;
         }
       }
       // No need to check `unit.enums`: [Reflectable] is not an enum.
@@ -3901,7 +3909,7 @@ class BuilderImplementation {
         // of [classReflectable]: Not supported, report an error.
         await _severe(
           errors.metadataNotDirectSubclass,
-          elementAnnotation.element,
+          elementAnnotation.element2,
         );
         return false;
       }
@@ -3909,7 +3917,7 @@ class BuilderImplementation {
       return true;
     }
 
-    Element2? element = elementAnnotation.element;
+    Element2? element = elementAnnotation.element2;
     if (element is ConstructorElement2) {
       DartType enclosingType = _typeForReflectable(element.enclosingElement2);
       DartType focusClassType = _typeForReflectable(focusClass);
@@ -3919,15 +3927,15 @@ class BuilderImplementation {
           await checkInheritance(enclosingType, focusClassType);
       if (isOk) {
         if (enclosingType is InterfaceType) {
-          return enclosingType.element;
+          return enclosingType.element3;
         } else {
           return null;
         }
       } else {
         return null;
       }
-    } else if (element is PropertyAccessorElement) {
-      PropertyInducingElement? variable = element.variable2;
+    } else if (element is PropertyAccessorElement2) {
+      PropertyInducingElement2? variable = element.variable3;
       DartObject? constantValue = variable?.computeConstantValue();
       // Handle errors during evaluation. In general `constantValue` is
       // null for (1) non-const variables, (2) variables without an
@@ -3946,7 +3954,7 @@ class BuilderImplementation {
       // When `isOK` is true, result.value.type.element is a InterfaceElement2.
       if (isOk) {
         if (constantValueType is InterfaceType) {
-          return constantValueType.element;
+          return constantValueType.element3;
         } else {
           return null;
         }
@@ -3958,7 +3966,7 @@ class BuilderImplementation {
     await _fine(
       'Ignoring metadata in a form ($elementAnnotation) '
       'which is not yet supported.',
-      elementAnnotation.element,
+      elementAnnotation.element2,
     );
     return null;
   }
@@ -3993,7 +4001,7 @@ class BuilderImplementation {
     ClassElement2 reflectableClass =
         reflectableLibrary.getClass('Reflectable')!;
     InterfaceType typeType = reflectableLibrary.typeProvider.typeType;
-    InterfaceElement2 typeTypeClass = typeType.element;
+    InterfaceElement2 typeTypeClass = typeType.element3;
 
     ConstructorElement2 globalQuantifyCapabilityConstructor =
         capabilityLibrary
@@ -4008,8 +4016,8 @@ class BuilderImplementation {
       List<LibraryElement2> imports = library.importedLibraries;
       for (var import in imports) {
         if (import.id != reflectableLibrary.id) continue;
-        for (ElementAnnotation metadatum in import.metadata) {
-          Element2? metadatumElement = metadatum.element?.declaration;
+        for (ElementAnnotation metadatum in import.metadata2.annotations) {
+          Element2? metadatumElement = metadatum.element2?.declaration;
           if (metadatumElement == globalQuantifyCapabilityConstructor) {
             DartObject? value = _getEvaluatedMetadatum(metadatum);
             if (value != null) {
@@ -4018,7 +4026,7 @@ class BuilderImplementation {
               DartType? valueType =
                   value.getField('(super)')?.getField('reflector')?.type;
               InterfaceElement2? reflector =
-                  valueType is InterfaceType ? valueType.element : null;
+                  valueType is InterfaceType ? valueType.element3 : null;
               if (reflector == null) {
                 await _warn(
                   WarningKind.badSuperclass,
@@ -4033,7 +4041,7 @@ class BuilderImplementation {
                   await _warn(
                     WarningKind.badSuperclass,
                     'The reflector must be a direct subclass of '
-                    'Reflectable. Found ${reflector.name}.',
+                    'Reflectable. Found ${reflector.name3}.',
                     metadatumElement,
                   );
                   continue;
@@ -4054,7 +4062,7 @@ class BuilderImplementation {
               DartType? metadataFieldType = metadataType?.toTypeValue();
               InterfaceElement2? metadataFieldValue =
                   metadataFieldType is InterfaceType
-                      ? metadataFieldType.element
+                      ? metadataFieldType.element3
                       : null;
               DartType? metadataTypeType = metadataType?.type;
               if (metadataFieldValue == null) {
@@ -4074,7 +4082,9 @@ class BuilderImplementation {
                       ?.getField('reflector')
                       ?.type;
               InterfaceElement2? reflector =
-                  reflectorType is InterfaceType ? reflectorType.element : null;
+                  reflectorType is InterfaceType
+                      ? reflectorType.element3
+                      : null;
               if (reflector == null) {
                 await _warn(
                   WarningKind.badSuperclass,
@@ -4090,7 +4100,7 @@ class BuilderImplementation {
                   await _warn(
                     WarningKind.badSuperclass,
                     'The reflector must be a direct subclass of '
-                    'Reflectable. Found ${reflector.name}.',
+                    'Reflectable. Found ${reflector.name3}.',
                     metadatumElement,
                   );
                   continue;
@@ -4156,14 +4166,14 @@ class BuilderImplementation {
       );
     }
 
-    if (potentialReflectorClass.constructors.length != 1) {
+    if (potentialReflectorClass.constructors2.length != 1) {
       // We "own" the direct subclasses of `Reflectable` so when they are
       // malformed as reflector classes we raise an error.
       await constructorFail();
       return false;
     }
-    ConstructorElement2 constructor = potentialReflectorClass.constructors[0];
-    if (constructor.parameters.isNotEmpty || !constructor.isConst) {
+    ConstructorElement2 constructor = potentialReflectorClass.constructors2[0];
+    if (constructor.formalParameters.isNotEmpty || !constructor.isConst) {
       // We still "own" `potentialReflectorClass`.
       await constructorFail();
       return false;
@@ -4248,7 +4258,7 @@ class BuilderImplementation {
     ) async {
       _ReflectorDomain? domain = domains[reflector];
       if (domain == null) {
-        LibraryElement2 reflectorLibrary = reflector.library;
+        LibraryElement2 reflectorLibrary = reflector.library2;
         _Capabilities capabilities = await _capabilitiesOf(
           capabilityLibrary,
           reflector,
@@ -4282,16 +4292,16 @@ class BuilderImplementation {
       InterfaceElement2 reflector,
     ) async {
       if (!await _isImportable(type, dataId, _resolver)) {
-        await _fine('Ignoring unrepresentable class ${type.name}', type);
+        await _fine('Ignoring unrepresentable class ${type.name3}', type);
       } else {
         _ReflectorDomain domain = await getReflectorDomain(reflector);
         if (!domain._classes.contains(type)) {
           if (type is MixinApplication && type.isMixinApplication) {
             // Iterate over all mixins in most-general-first order (so with
             // `class C extends B with M1, M2..` we visit `M1` then `M2`.
-            InterfaceElement2 superclass = type.supertype!.element;
+            InterfaceElement2 superclass = type.supertype!.element3;
             for (InterfaceType mixin in type.mixins) {
-              InterfaceElement2 mixinElement = mixin.element;
+              InterfaceElement2 mixinElement = mixin.element3;
               MixinApplication? subClass =
                   mixin == type.mixins.last ? type : null;
               String? name = subClass == null ? null : type.name;
@@ -4308,7 +4318,7 @@ class BuilderImplementation {
           } else {
             domain._classes.add(type);
           }
-          await addLibrary(type.library, reflector);
+          await addLibrary(type.library2, reflector);
           // We need to ensure that the [importCollector] has indeed added
           // `type.library` (if we have no library capability `addLibrary` will
           // not do that), because it may be needed in import directives in the
@@ -4317,7 +4327,7 @@ class BuilderImplementation {
           // TODO(eernst) clarify: Maybe the following statement could be moved
           // out of the `if` in `addLibrary` such that we don't have to have
           // an extra copy of it here.
-          importCollector._addLibrary(type.library);
+          importCollector._addLibrary(type.library2);
         }
       }
     }
@@ -4383,39 +4393,42 @@ class BuilderImplementation {
     // reflector.
     for (LibraryElement2 library in _libraries) {
       for (InterfaceElement2 reflector in await getReflectors(
-        library.name,
-        library.metadata,
+        library.name3,
+        library.metadata2.annotations,
       )) {
         assert(await _isImportableLibrary(library, dataId, _resolver));
         await addLibrary(library, reflector);
       }
 
-      for (LibraryFragment unit in library.units) {
-        for (InterfaceElement2 type in unit.classes) {
+      for (LibraryFragment fragment in library.fragments) {
+        for (ClassFragment classFragment in fragment.classes2) {
           for (InterfaceElement2 reflector in await getReflectors(
-            _qualifiedName(type),
-            type.metadata,
+            _qualifiedName(classFragment.element),
+            classFragment.metadata2.annotations,
           )) {
-            await addClassDomain(type, reflector);
+            await addClassDomain(classFragment.element, reflector);
           }
-          if (!allReflectors.contains(type) &&
-              await _isReflectorClass(type, classReflectable)) {
-            allReflectors.add(type);
+          if (!allReflectors.contains(classFragment.element) &&
+              await _isReflectorClass(
+                classFragment.element,
+                classReflectable,
+              )) {
+            allReflectors.add(classFragment.element);
           }
         }
-        for (EnumElement2 type in unit.enums) {
+        for (EnumFragment type in fragment.enums2) {
           for (InterfaceElement2 reflector in await getReflectors(
-            _qualifiedName(type),
-            type.metadata,
+            _qualifiedName(type.element),
+            type.metadata2.annotations,
           )) {
-            await addClassDomain(type, reflector);
+            await addClassDomain(type.element, reflector);
           }
           // An enum is never a reflector class, hence no `_isReflectorClass`.
         }
-        for (FunctionElement function in unit.functions) {
+        for (TopLevelFunctionElement function in fragment.functions) {
           for (InterfaceElement2 reflector in await getReflectors(
             _qualifiedFunctionName(function),
-            function.metadata,
+            function.metadata2.annotations,
           )) {
             // We just add the library here, the function itself will be
             // supported using `invoke` and `declarations` of that library
@@ -4499,7 +4512,7 @@ class BuilderImplementation {
     // be in the given `capabilityLibrary` (because we could never know
     // how to interpret the meaning of a user-written capability class, so
     // users cannot write their own capability classes).
-    InterfaceElement2 dartTypeElement = (dartType as InterfaceType).element;
+    InterfaceElement2 dartTypeElement = (dartType as InterfaceType).element3;
     if (dartTypeElement is! ClassElement2) {
       String typeString = dartType.getDisplayString();
       await _severe(
@@ -4510,7 +4523,7 @@ class BuilderImplementation {
       );
       return null; // Error default.
     }
-    if (dartTypeElement.library != capabilityLibrary) {
+    if (dartTypeElement.library2 != capabilityLibrary) {
       await _severe(
         errors.applyTemplate(errors.superArgumentWrongLibrary, {
           'library': '$capabilityLibrary',
@@ -4571,7 +4584,7 @@ class BuilderImplementation {
       return null;
     }
 
-    switch (dartTypeElement.name) {
+    switch (dartTypeElement.name3) {
       case 'NameCapability':
         return ec.nameCapability;
       case 'ClassifyCapability':
@@ -4649,7 +4662,7 @@ class BuilderImplementation {
         DartType constantUpperBoundType = constantUpperBound.toTypeValue()!;
         if (constantUpperBoundType is! InterfaceType) return null;
         return ec.SuperclassQuantifyCapability(
-          constantUpperBoundType.element,
+          constantUpperBoundType.element3,
           excludeUpperBound: constantExcludeUpperBound.toBoolValue()!,
         );
       case 'TypeAnnotationQuantifyCapability':
@@ -4684,7 +4697,7 @@ class BuilderImplementation {
     LibraryElement2 capabilityLibrary,
     InterfaceElement2 reflector,
   ) async {
-    List<ConstructorElement2> constructors = reflector.constructors;
+    List<ConstructorElement2> constructors = reflector.constructors2;
 
     // Well-formedness for each reflector class is checked by
     // `_isReflectorClass`, so we do not report errors here. But errors will
@@ -4738,7 +4751,7 @@ class BuilderImplementation {
       return await _capabilityOfExpression(
         capabilityLibrary,
         expression,
-        reflector.library,
+        reflector.library2,
         constructorElement,
       );
     }
@@ -4874,7 +4887,7 @@ void initializeReflectable() {
     _libraries = visibleLibraries;
 
     for (LibraryElement2 library in _libraries) {
-      _librariesByName[library.name] = library;
+      _librariesByName[library.name3!] = library;
     }
     LibraryElement2? reflectableLibrary =
         _librariesByName['reflectable.reflectable'];
@@ -4952,12 +4965,13 @@ void initializeReflectable() {
   }
 }
 
-bool _accessorIsntImplicitGetterOrSetter(PropertyAccessorElement accessor) {
-  return !accessor.isSynthetic || (!accessor.isGetter && !accessor.isSetter);
+bool _accessorIsntImplicitGetterOrSetter(PropertyAccessorElement2 accessor) {
+  return !accessor.isSynthetic ||
+      (accessor is! GetterElement && accessor is! SetterElement);
 }
 
 bool _executableIsntImplicitGetterOrSetter(ExecutableElement2 executable) {
-  if (executable is PropertyAccessorElement) {
+  if (executable is PropertyAccessorElement2) {
     return _accessorIsntImplicitGetterOrSetter(executable);
   } else {
     return true;
@@ -4980,7 +4994,7 @@ int _classDescriptor(InterfaceElement2 element) {
     return result;
   }
   DartType thisType = element.thisType;
-  LibraryElement2 library = element.library;
+  LibraryElement2 library = element.library2;
   if (library.typeSystem.isNullable(thisType)) {
     result |= constants.nullableAttribute;
   }
@@ -4992,7 +5006,7 @@ int _classDescriptor(InterfaceElement2 element) {
 
 /// Returns an integer encoding of the kind and attributes of the given
 /// variable.
-int _topLevelVariableDescriptor(TopLevelVariableElement element) {
+int _topLevelVariableDescriptor(TopLevelVariableElement2 element) {
   int result = constants.field;
   if (element.isPrivate) result |= constants.privateAttribute;
   if (element.isSynthetic) result |= constants.syntheticAttribute;
@@ -5011,13 +5025,13 @@ int _topLevelVariableDescriptor(TopLevelVariableElement element) {
   if (declaredType is DynamicType) result |= constants.dynamicAttribute;
   if (declaredType is NeverType) result |= constants.neverAttribute;
   if (declaredType is InterfaceType) {
-    Element2? elementType = declaredType.element;
+    Element2? elementType = declaredType.element3;
     if (elementType is InterfaceElement2) {
       result |= constants.classTypeAttribute;
     }
     result |= constants.topLevelAttribute;
   }
-  LibraryElement2 library = element.library;
+  LibraryElement2 library = element.library2;
   if (library.typeSystem.isNullable(declaredType)) {
     result |= constants.nullableAttribute;
   }
@@ -5048,7 +5062,7 @@ int _fieldDescriptor(FieldElement2 element) {
   if (declaredType is DynamicType) result |= constants.dynamicAttribute;
   if (declaredType is NeverType) result |= constants.neverAttribute;
   if (declaredType is InterfaceType) {
-    Element2? elementType = declaredType.element;
+    Element2? elementType = declaredType.element3;
     if (elementType is InterfaceElement2) {
       result |= constants.classTypeAttribute;
       if (elementType.typeParameters.isNotEmpty) {
@@ -5056,7 +5070,7 @@ int _fieldDescriptor(FieldElement2 element) {
       }
     }
   }
-  LibraryElement2 library = element.library;
+  LibraryElement2 library = element.library2;
   if (library.typeSystem.isNullable(declaredType)) {
     result |= constants.nullableAttribute;
   }
@@ -5084,7 +5098,7 @@ int _parameterDescriptor(FormalParameterElement element) {
   if (declaredType is DynamicType) result |= constants.dynamicAttribute;
   if (declaredType is NeverType) result |= constants.neverAttribute;
   if (declaredType is InterfaceType) {
-    Element2? elementType = declaredType.element;
+    Element2? elementType = declaredType.element3;
     if (elementType is InterfaceElement2) {
       result |= constants.classTypeAttribute;
       if (elementType.typeParameters.isNotEmpty) {
@@ -5092,7 +5106,7 @@ int _parameterDescriptor(FormalParameterElement element) {
       }
     }
   }
-  LibraryElement2? library = element.library;
+  LibraryElement2? library = element.library2;
   if (library != null) {
     if (library.typeSystem.isNullable(declaredType)) {
       result |= constants.nullableAttribute;
@@ -5121,7 +5135,7 @@ int _declarationDescriptor(ExecutableElement2 element) {
       result |= constants.neverReturnTypeAttribute;
     }
     if (returnType is InterfaceType) {
-      Element2? elementReturnType = returnType.element;
+      Element2? elementReturnType = returnType.element3;
       if (elementReturnType is InterfaceElement2) {
         result |= constants.classReturnTypeAttribute;
         if (elementReturnType.typeParameters.isNotEmpty) {
@@ -5131,8 +5145,8 @@ int _declarationDescriptor(ExecutableElement2 element) {
     }
   }
 
-  if (element is PropertyAccessorElement) {
-    result |= element.isGetter ? constants.getter : constants.setter;
+  if (element is PropertyAccessorElement2) {
+    result |= element is GetterElement ? constants.getter : constants.setter;
     handleReturnType(element);
   } else if (element is ConstructorElement2) {
     if (element.isFactory) {
@@ -5148,7 +5162,7 @@ int _declarationDescriptor(ExecutableElement2 element) {
     result |= constants.method;
     handleReturnType(element);
   } else {
-    assert(element is FunctionElement);
+    assert(element is TopLevelFunctionElement);
     result |= constants.function;
     handleReturnType(element);
   }
@@ -5201,7 +5215,7 @@ Future<String> _extractConstantCode(
   Future<String> typeAnnotationHelper(TypeAnnotation typeName) async {
     DartType? interfaceType = typeName.type;
     if (interfaceType is InterfaceType) {
-      LibraryElement2 library = interfaceType.element.library;
+      LibraryElement2 library = interfaceType.element3.library2;
       String prefix = importCollector._getPrefix(library);
       return '$prefix$typeName';
     } else {

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -1407,9 +1407,9 @@ class _ReflectorDomain {
     ExecutableElement element,
     int descriptor,
   ) async {
-    if (element.enclosingElement is InterfaceElement) {
-      return (await classes).indexOf(element.enclosingElement);
-    } else if (element.enclosingElement is CompilationUnitElement) {
+    if (element.enclosingElement3 is InterfaceElement) {
+      return (await classes).indexOf(element.enclosingElement3);
+    } else if (element.enclosingElement3 is CompilationUnitElement) {
       return _libraries.indexOf(element.library);
     }
     await _severe('Unexpected kind of request for owner');
@@ -1456,7 +1456,7 @@ class _ReflectorDomain {
       }
     }
     int? ownerIndex = (await classes).indexOf(
-      typeParameterElement.enclosingElement!,
+      typeParameterElement.enclosingElement3!,
     );
     // TODO(eernst) implement: Update when type variables support metadata.
     var metadataCode = _capabilities._supportsMetadata ? '<Object>[]' : 'null';
@@ -1581,7 +1581,7 @@ class _ReflectorDomain {
     } else {
       var mapEntries = <String>[];
       for (ConstructorElement constructor in classDomain._constructors) {
-        InterfaceElement enclosingElement = constructor.enclosingElement;
+        InterfaceElement enclosingElement = constructor.enclosingElement3;
         if (constructor.isFactory ||
             ((enclosingElement is ClassElement &&
                     !enclosingElement.isAbstract) &&
@@ -1967,7 +1967,7 @@ class _ReflectorDomain {
   ) async {
     int descriptor = _fieldDescriptor(element);
     int ownerIndex =
-        (await classes).indexOf(element.enclosingElement) ??
+        (await classes).indexOf(element.enclosingElement3) ??
         constants.noCapabilityIndex;
     int classMirrorIndex = await _computeVariableTypeIndex(element, descriptor);
     int reflectedTypeIndex =
@@ -2572,7 +2572,7 @@ class _ReflectorDomain {
   ) async {
     int descriptor = _parameterDescriptor(element);
     int ownerIndex =
-        members.indexOf(element.enclosingElement!)! + fields.length;
+        members.indexOf(element.enclosingElement3!)! + fields.length;
     int classMirrorIndex = constants.noCapabilityIndex;
     if (_capabilities._impliesTypes) {
       if (descriptor & constants.dynamicAttribute != 0 ||
@@ -3895,7 +3895,7 @@ class BuilderImplementation {
 
     Element? element = elementAnnotation.element;
     if (element is ConstructorElement) {
-      DartType enclosingType = _typeForReflectable(element.enclosingElement);
+      DartType enclosingType = _typeForReflectable(element.enclosingElement3);
       DartType focusClassType = _typeForReflectable(focusClass);
       bool isOk =
           enclosingType is ParameterizedType &&
@@ -5143,7 +5143,7 @@ int _declarationDescriptor(ExecutableElement element) {
   if (element is! ConstructorElement) {
     if (element.isAbstract) result |= constants.abstractAttribute;
   }
-  if (element.enclosingElement is! InterfaceElement) {
+  if (element.enclosingElement3 is! InterfaceElement) {
     result |= constants.topLevelAttribute;
   }
   return result;
@@ -5152,8 +5152,8 @@ int _declarationDescriptor(ExecutableElement element) {
 Future<String> _nameOfConstructor(ConstructorElement element) async {
   String name =
       element.name == ''
-          ? element.enclosingElement.name
-          : '${element.enclosingElement.name}.${element.name}';
+          ? element.enclosingElement3.name
+          : '${element.enclosingElement3.name}.${element.name}';
   if (_isPrivateName(name)) {
     await _severe('Cannot access private name $name', element);
   }
@@ -5369,7 +5369,7 @@ Future<String> _extractConstantCode(
               )) {
             importCollector._addLibrary(elementLibrary);
             String prefix = importCollector._getPrefix(elementLibrary);
-            Element? enclosingElement = element.enclosingElement;
+            Element? enclosingElement = element.enclosingElement3;
             if (enclosingElement is InterfaceElement) {
               prefix += '${enclosingElement.name}.';
             }
@@ -6305,7 +6305,7 @@ String _qualifiedFunctionName(FunctionElement functionElement) {
 
 String _qualifiedTypeParameterName(TypeParameterElement? typeParameterElement) {
   if (typeParameterElement == null) return 'null';
-  return '${_qualifiedName(typeParameterElement.enclosingElement!)}.'
+  return '${_qualifiedName(typeParameterElement.enclosingElement3!)}.'
       '${typeParameterElement.name}';
 }
 

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -12,7 +12,6 @@ import 'package:analyzer/dart/analysis/session.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';
-// import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
@@ -22,13 +21,13 @@ import 'package:analyzer/error/listener.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:analyzer/source/source.dart';
 import 'package:analyzer/source/file_source.dart';
-import 'package:analyzer/src/dart/constant/compute.dart';
-import 'package:analyzer/src/dart/constant/evaluation.dart';
-import 'package:analyzer/src/dart/constant/utilities.dart';
-import 'package:analyzer/src/dart/constant/value.dart';
-import 'package:analyzer/src/dart/element/element.dart';
-import 'package:analyzer/src/dart/element/type.dart';
-import 'package:analyzer/src/summary/package_bundle_reader.dart';
+//import 'package:analyzer/src/dart/constant/compute.dart';
+//import 'package:analyzer/src/dart/constant/evaluation.dart';
+//import 'package:analyzer/src/dart/constant/utilities.dart';
+//import 'package:analyzer/src/dart/constant/value.dart';
+//import 'package:analyzer/src/dart/element/element.dart';
+//import 'package:analyzer/src/dart/element/type.dart';
+//import 'package:analyzer/src/summary/package_bundle_reader.dart';
 import 'package:build/build.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:path/path.dart' as path;
@@ -127,12 +126,13 @@ class _ReflectionWorld {
             InterfaceElement2 mixinElement = mixin.element3;
             InterfaceElement2? subClass =
                 mixin == interfaceElement.mixins.last ? interfaceElement : null;
-            String? name = subClass == null
-                ? null
-                : (interfaceElement is MixinApplication &&
-                        interfaceElement.isMixinApplication
-                    ? interfaceElement.name
-                    : null);
+            String? name =
+                subClass == null
+                    ? null
+                    : (interfaceElement is MixinApplication &&
+                            interfaceElement.isMixinApplication
+                        ? interfaceElement.name3
+                        : null);
             var mixinApplication = MixinApplication(
               name,
               superclass,
@@ -627,14 +627,16 @@ class ParameterListShape {
   );
 
   @override
-  bool operator ==(other) => other is ParameterListShape
-      ? numberOfPositionalParameters == other.numberOfPositionalParameters &&
-          numberOfOptionalPositionalParameters ==
-              other.numberOfOptionalPositionalParameters &&
-          namesOfNamedParameters
-              .difference(other.namesOfNamedParameters)
-              .isEmpty
-      : false;
+  bool operator ==(other) =>
+      other is ParameterListShape
+          ? numberOfPositionalParameters ==
+                  other.numberOfPositionalParameters &&
+              numberOfOptionalPositionalParameters ==
+                  other.numberOfOptionalPositionalParameters &&
+              namesOfNamedParameters
+                  .difference(other.namesOfNamedParameters)
+                  .isEmpty
+          : false;
 
   @override
   int get hashCode =>
@@ -750,9 +752,10 @@ class _ReflectorDomain {
     int requiredPositionalCount = type.normalParameterTypes.length;
     int optionalPositionalCount = type.optionalParameterTypes.length;
 
-    List<String> parameterNames = type.formalParameters
-        .map((FormalParameterElement parameter) => parameter.name3!)
-        .toList();
+    List<String> parameterNames =
+        type.formalParameters
+            .map((FormalParameterElement parameter) => parameter.name3!)
+            .toList();
 
     List<String> namedParameterNames = type.namedParameterTypes.keys.toList();
 
@@ -819,8 +822,9 @@ class _ReflectorDomain {
       optionalPositionalCount,
       (int i) => parameterNames[i + requiredPositionalCount],
     ).join(', ');
-    String namedArguments =
-        namedParameterNames.map((String name) => '$name: $name').join(', ');
+    String namedArguments = namedParameterNames
+        .map((String name) => '$name: $name')
+        .join(', ');
 
     var parameterParts = <String>[];
     var argumentParts = <String>[];
@@ -1501,22 +1505,23 @@ class _ReflectorDomain {
     Iterable<int> methodsIndices = classDomain._declarations
         .where(_executableIsntImplicitGetterOrSetter)
         .map((ExecutableElement2 element) {
-      // TODO(eernst) implement: The "magic" default constructor in `Object`
-      // (the one that ultimately allocates the memory for _every_ new
-      // object) has no index, which creates the need to catch a `null`
-      // here. Search for "magic" to find other occurrences of the same
-      // issue. For now, we use the index [constants.noCapabilityIndex]
-      // for this declaration, because it is not yet supported.
-      // Need to find the correct solution, though!
-      int? index = members.indexOf(element);
-      return index == null
-          ? constants.noCapabilityIndex
-          : index + methodsOffset;
-    });
+          // TODO(eernst) implement: The "magic" default constructor in `Object`
+          // (the one that ultimately allocates the memory for _every_ new
+          // object) has no index, which creates the need to catch a `null`
+          // here. Search for "magic" to find other occurrences of the same
+          // issue. For now, we use the index [constants.noCapabilityIndex]
+          // for this declaration, because it is not yet supported.
+          // Need to find the correct solution, though!
+          int? index = members.indexOf(element);
+          return index == null
+              ? constants.noCapabilityIndex
+              : index + methodsOffset;
+        });
 
-    String declarationsCode = _capabilities._impliesDeclarations
-        ? _formatAsConstList('int', [...fieldsIndices, ...methodsIndices])
-        : 'const <int>[${constants.noCapabilityIndex}]';
+    String declarationsCode =
+        _capabilities._impliesDeclarations
+            ? _formatAsConstList('int', [...fieldsIndices, ...methodsIndices])
+            : 'const <int>[${constants.noCapabilityIndex}]';
 
     // All instance members belong to the behavioral interface, so they
     // also get an offset of `fields.length`.
@@ -1563,10 +1568,11 @@ class _ReflectorDomain {
       // convention we make it supported and report it in the same way as
       // 'dart:mirrors'. Other superclasses use `noCapabilityIndex` to
       // indicate missing support.
-      superclassIndex = (interfaceElement is! MixinApplication &&
-              _typeForReflectable(interfaceElement).isDartCoreObject)
-          ? 'null'
-          : ((await classes).contains(superclass))
+      superclassIndex =
+          (interfaceElement is! MixinApplication &&
+                  _typeForReflectable(interfaceElement).isDartCoreObject)
+              ? 'null'
+              : ((await classes).contains(superclass))
               ? '${(await classes).indexOf(superclass!)}'
               : '${constants.noCapabilityIndex}';
     }
@@ -1654,9 +1660,10 @@ class _ReflectorDomain {
       mixinIndex ??= constants.noCapabilityIndex;
     }
 
-    int ownerIndex = _capabilities._supportsLibraries
-        ? libraries.indexOf(libraryMap[interfaceElement.library2]!)!
-        : constants.noCapabilityIndex;
+    int ownerIndex =
+        _capabilities._supportsLibraries
+            ? libraries.indexOf(libraryMap[interfaceElement.library2]!)!
+            : constants.noCapabilityIndex;
 
     var superinterfaceIndices = 'const <int>[${constants.noCapabilityIndex}]';
     if (_capabilities._impliesTypeRelations) {
@@ -1815,9 +1822,10 @@ class _ReflectorDomain {
       // There is no type propagation, so we declare an `accessorElement`.
       PropertyAccessorElement2 accessorElement = element;
       PropertyInducingElement2? variable = accessorElement.variable3;
-      int variableMirrorIndex = variable is TopLevelVariableElement2
-          ? topLevelVariables.indexOf(variable)!
-          : variable is FieldElement2
+      int variableMirrorIndex =
+          variable is TopLevelVariableElement2
+              ? topLevelVariables.indexOf(variable)!
+              : variable is FieldElement2
               ? fields.indexOf(variable)!
               : constants.noCapabilityIndex;
       int selfIndex = members.indexOf(accessorElement)! + fields.length;
@@ -1836,18 +1844,19 @@ class _ReflectorDomain {
       // getter or setter.
       int descriptor = _declarationDescriptor(element);
       int returnTypeIndex = await _computeReturnTypeIndex(element, descriptor);
-      int ownerIndex = (await _computeOwnerIndex(element, descriptor)) ??
+      int ownerIndex =
+          (await _computeOwnerIndex(element, descriptor)) ??
           constants.noCapabilityIndex;
       var reflectedTypeArgumentsOfReturnType = 'null';
       if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
         reflectedTypeArgumentsOfReturnType =
             await _computeReflectedTypeArguments(
-          element.returnType,
-          reflectedTypes,
-          reflectedTypesOffset,
-          importCollector,
-          typedefs,
-        );
+              element.returnType,
+              reflectedTypes,
+              reflectedTypesOffset,
+              importCollector,
+              typedefs,
+            );
       }
       String parameterIndicesCode = _formatAsConstList(
         'int',
@@ -1875,14 +1884,15 @@ class _ReflectorDomain {
           typedefs,
         );
       }
-      String? metadataCode = _capabilities._supportsMetadata
-          ? await _extractMetadataCode(
-              element,
-              _resolver,
-              importCollector,
-              _generatedLibraryId,
-            )
-          : null;
+      String? metadataCode =
+          _capabilities._supportsMetadata
+              ? await _extractMetadataCode(
+                element,
+                _resolver,
+                importCollector,
+                _generatedLibraryId,
+              )
+              : null;
       return "r.MethodMirrorImpl(r'${element.name3}', $descriptor, "
           '$ownerIndex, $returnTypeIndex, $reflectedReturnTypeIndex, '
           '$dynamicReflectedReturnTypeIndex, '
@@ -1903,24 +1913,26 @@ class _ReflectorDomain {
     LibraryElement2 owner = element.library2;
     int ownerIndex = _libraries.indexOf(owner) ?? constants.noCapabilityIndex;
     int classMirrorIndex = await _computeVariableTypeIndex(element, descriptor);
-    int? reflectedTypeIndex = reflectedTypeRequested
-        ? _typeCodeIndex(
-            element.type,
-            await classes,
-            reflectedTypes,
-            reflectedTypesOffset,
-            typedefs,
-          )
-        : constants.noCapabilityIndex;
-    int? dynamicReflectedTypeIndex = reflectedTypeRequested
-        ? _dynamicTypeCodeIndex(
-            element.type,
-            await classes,
-            reflectedTypes,
-            reflectedTypesOffset,
-            typedefs,
-          )
-        : constants.noCapabilityIndex;
+    int? reflectedTypeIndex =
+        reflectedTypeRequested
+            ? _typeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
+    int? dynamicReflectedTypeIndex =
+        reflectedTypeRequested
+            ? _dynamicTypeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
     var reflectedTypeArguments = 'null';
     if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
       reflectedTypeArguments = await _computeReflectedTypeArguments(
@@ -1960,27 +1972,30 @@ class _ReflectorDomain {
     bool reflectedTypeRequested,
   ) async {
     int descriptor = _fieldDescriptor(element);
-    int ownerIndex = (await classes).indexOf(element.enclosingElement2) ??
+    int ownerIndex =
+        (await classes).indexOf(element.enclosingElement2) ??
         constants.noCapabilityIndex;
     int classMirrorIndex = await _computeVariableTypeIndex(element, descriptor);
-    int reflectedTypeIndex = reflectedTypeRequested
-        ? _typeCodeIndex(
-            element.type,
-            await classes,
-            reflectedTypes,
-            reflectedTypesOffset,
-            typedefs,
-          )
-        : constants.noCapabilityIndex;
-    int dynamicReflectedTypeIndex = reflectedTypeRequested
-        ? _dynamicTypeCodeIndex(
-            element.type,
-            await classes,
-            reflectedTypes,
-            reflectedTypesOffset,
-            typedefs,
-          )
-        : constants.noCapabilityIndex;
+    int reflectedTypeIndex =
+        reflectedTypeRequested
+            ? _typeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
+    int dynamicReflectedTypeIndex =
+        reflectedTypeRequested
+            ? _dynamicTypeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
     var reflectedTypeArguments = 'null';
     if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
       reflectedTypeArguments = await _computeReflectedTypeArguments(
@@ -2223,9 +2238,10 @@ class _ReflectorDomain {
         if (dartType.typeFormals.isNotEmpty) {
           if (useNameOfGenericFunctionType) {
             // Requested: just the name of the typedef; get it and return.
-            int dartTypeNumber = typedefs.containsKey(dartType)
-                ? typedefs[dartType]!
-                : typedefNumber++;
+            int dartTypeNumber =
+                typedefs.containsKey(dartType)
+                    ? typedefs[dartType]!
+                    : typedefNumber++;
             return _typedefName(dartTypeNumber);
           } else {
             // Requested: the spelled-out generic function type; continue.
@@ -2278,7 +2294,8 @@ class _ReflectorDomain {
             );
           }
           var connector = argumentTypes.isEmpty ? '' : ', ';
-          argumentTypes = '$argumentTypes$connector'
+          argumentTypes =
+              '$argumentTypes$connector'
               '[${optionalParameterTypeList.join(', ')}]';
         }
         if (dartType.namedParameterTypes.isNotEmpty) {
@@ -2296,7 +2313,8 @@ class _ReflectorDomain {
             namedParameterTypeList.add('$typeCode $name');
           }
           var connector = argumentTypes.isEmpty ? '' : ', ';
-          argumentTypes = '$argumentTypes$connector'
+          argumentTypes =
+              '$argumentTypes$connector'
               '{${namedParameterTypeList.join(', ')}}';
         }
         return '$returnType Function$typeArguments($argumentTypes)';
@@ -2417,9 +2435,10 @@ class _ReflectorDomain {
     TypeDefiningElement2 typeDefiningElement,
     _ImportCollector importCollector,
   ) {
-    DartType? type = typeDefiningElement is InterfaceElement2
-        ? _typeForReflectable(typeDefiningElement)
-        : null;
+    DartType? type =
+        typeDefiningElement is InterfaceElement2
+            ? _typeForReflectable(typeDefiningElement)
+            : null;
     if (type is DynamicType) return 'dynamic';
     if (type is InterfaceType) {
       InterfaceElement2 interfaceElement = type.element3;
@@ -2484,9 +2503,9 @@ class _ReflectorDomain {
     Iterable<int> methodIndices = libraryDomain._declarations
         .where(_executableIsntImplicitGetterOrSetter)
         .map((ExecutableElement2 element) {
-      int index = members.indexOf(element)!;
-      return index + methodsOffset;
-    });
+          int index = members.indexOf(element)!;
+          return index + methodsOffset;
+        });
 
     var declarationsCode = 'const <int>[${constants.noCapabilityIndex}]';
     if (_capabilities._impliesDeclarations) {
@@ -2574,32 +2593,35 @@ class _ReflectorDomain {
         DartType elementType = element.type;
         if (elementType is InterfaceType) {
           InterfaceElement2 elementTypeElement = elementType.element3;
-          classMirrorIndex = (await classes).contains(elementTypeElement)
-              ? (await classes).indexOf(elementTypeElement)!
-              : constants.noCapabilityIndex;
+          classMirrorIndex =
+              (await classes).contains(elementTypeElement)
+                  ? (await classes).indexOf(elementTypeElement)!
+                  : constants.noCapabilityIndex;
         } else {
           classMirrorIndex = constants.noCapabilityIndex;
         }
       }
     }
-    int reflectedTypeIndex = reflectedTypeRequested
-        ? _typeCodeIndex(
-            element.type,
-            await classes,
-            reflectedTypes,
-            reflectedTypesOffset,
-            typedefs,
-          )
-        : constants.noCapabilityIndex;
-    int dynamicReflectedTypeIndex = reflectedTypeRequested
-        ? _dynamicTypeCodeIndex(
-            element.type,
-            await classes,
-            reflectedTypes,
-            reflectedTypesOffset,
-            typedefs,
-          )
-        : constants.noCapabilityIndex;
+    int reflectedTypeIndex =
+        reflectedTypeRequested
+            ? _typeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
+    int dynamicReflectedTypeIndex =
+        reflectedTypeRequested
+            ? _dynamicTypeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
     var reflectedTypeArguments = 'null';
     if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
       reflectedTypeArguments = await _computeReflectedTypeArguments(
@@ -2635,9 +2657,10 @@ class _ReflectorDomain {
     }
     String code = await _extractDefaultValueCode(importCollector, element);
     var defaultValueCode = code.isEmpty ? 'null' : code;
-    var parameterSymbolCode = descriptor & constants.namedAttribute != 0
-        ? '#${element.name3}'
-        : 'null';
+    var parameterSymbolCode =
+        descriptor & constants.namedAttribute != 0
+            ? '#${element.name3}'
+            : 'null';
 
     return "r.ParameterMirrorImpl(r'${element.name3}', $descriptor, "
         '$ownerIndex, ${await _constConstructionCode(importCollector)}, '
@@ -2656,8 +2679,9 @@ class _ReflectorDomain {
     // TODO(eernst): 'dart:*' is not considered valid. To survive, we return
     // '' for all declarations from there. Issue 173.
     if (_isPlatformLibrary(parameterElement.library2!)) return '';
-    var parameterNode = await _getDeclarationAst(parameterElement, _resolver)
-        as FormalParameter?;
+    var parameterNode =
+        await _getDeclarationAst(parameterElement, _resolver)
+            as FormalParameter?;
     // The node can be null because the declaration is synthetic, e.g.,
     // the parameter of an induced setter; they have no default value.
     if (parameterNode is DefaultFormalParameter &&
@@ -2770,11 +2794,12 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement2> {
       if (mixinsRequested) result.add(mixinClass);
       InterfaceElement2? subClass =
           mixin == element.mixins.last ? element : null;
-      String? name = subClass == null
-          ? null
-          : (element is MixinApplication && element.isMixinApplication
-              ? element.name
-              : null);
+      String? name =
+          subClass == null
+              ? null
+              : (element is MixinApplication && element.isMixinApplication
+                  ? element.name
+                  : null);
       InterfaceElement2 mixinApplication = MixinApplication(
         name,
         superclass,
@@ -2838,12 +2863,13 @@ Set<InterfaceElement2> _mixinApplicationsOfClasses(
       InterfaceElement2 mixinClass = mixin.element3;
       InterfaceElement2? subClass =
           mixin == interfaceElement.mixins.last ? interfaceElement : null;
-      String? name = subClass == null
-          ? null
-          : (interfaceElement is MixinApplication &&
-                  interfaceElement.isMixinApplication
-              ? interfaceElement.name
-              : null);
+      String? name =
+          subClass == null
+              ? null
+              : (interfaceElement is MixinApplication &&
+                      interfaceElement.isMixinApplication
+                  ? interfaceElement.name
+                  : null);
       InterfaceElement2 mixinApplication = MixinApplication(
         name,
         superclass,
@@ -3085,10 +3111,10 @@ class _LibraryDomain {
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
   Iterable<ExecutableElement2> get _declarations => [
-        ..._declaredFunctions,
-        ..._getters,
-        ..._setters,
-      ];
+    ..._declaredFunctions,
+    ..._getters,
+    ..._setters,
+  ];
 
   @override
   String toString() {
@@ -3198,12 +3224,12 @@ class _ClassDomain {
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
   Iterable<ExecutableElement2> get _declarations => [
-        // TODO(sigurdm) feature: Include type variables (if we keep them).
-        ..._declaredMethods,
-        ..._getters,
-        ..._setters,
-        ..._constructors,
-      ];
+    // TODO(sigurdm) feature: Include type variables (if we keep them).
+    ..._declaredMethods,
+    ..._getters,
+    ..._setters,
+    ..._constructors,
+  ];
 
   /// Finds all instance members by going through the class hierarchy.
   Iterable<ExecutableElement2> get _instanceMembers {
@@ -3310,9 +3336,10 @@ class _ClassDomain {
       if (!accessor.isStatic || accessor.isPrivate) return;
       // If [member] is a synthetic accessor created from a field, search for
       // the metadata on the original field.
-      List<ElementAnnotation> metadata = accessor.isSynthetic
-          ? (accessor.variable3?.metadata2.annotations ?? const [])
-          : accessor.metadata2.annotations;
+      List<ElementAnnotation> metadata =
+          accessor.isSynthetic
+              ? (accessor.variable3?.metadata2.annotations ?? const [])
+              : accessor.metadata2.annotations;
       List<ElementAnnotation>? getterMetadata;
       if (_reflectorDomain._capabilities._impliesCorrespondingSetters &&
           accessor is SetterElement &&
@@ -3897,7 +3924,8 @@ class BuilderImplementation {
     if (element is ConstructorElement2) {
       DartType enclosingType = _typeForReflectable(element.enclosingElement2);
       DartType focusClassType = _typeForReflectable(focusClass);
-      bool isOk = enclosingType is ParameterizedType &&
+      bool isOk =
+          enclosingType is ParameterizedType &&
           focusClassType is InterfaceType &&
           await checkInheritance(enclosingType, focusClassType);
       if (isOk) {
@@ -3922,7 +3950,8 @@ class BuilderImplementation {
       if (constantValue == null) return null;
       DartType? constantValueType = constantValue.type;
       DartType focusClassType = _typeForReflectable(focusClass);
-      bool isOk = constantValueType is ParameterizedType &&
+      bool isOk =
+          constantValueType is ParameterizedType &&
           focusClassType is InterfaceType &&
           await checkInheritance(constantValueType, focusClassType);
       // When `isOK` is true, result.value.type.element is a InterfaceElement2.
@@ -3973,24 +4002,25 @@ class BuilderImplementation {
     LibraryElement2 capabilityLibrary =
         _librariesByName['reflectable.capability']!;
     ClassElement2 reflectableClass =
-        reflectableLibrary.getClass('Reflectable')!;
+        reflectableLibrary.getClass2('Reflectable')!;
     InterfaceType typeType = reflectableLibrary.typeProvider.typeType;
     InterfaceElement2 typeTypeClass = typeType.element3;
 
-    ConstructorElement2 globalQuantifyCapabilityConstructor = capabilityLibrary
-        .getClass('GlobalQuantifyCapability')!
-        .getNamedConstructor('')!;
+    ConstructorElement2 globalQuantifyCapabilityConstructor =
+        capabilityLibrary
+            .getClass2('GlobalQuantifyCapability')!
+            .getNamedConstructor2('')!;
     ConstructorElement2 globalQuantifyMetaCapabilityConstructor =
         capabilityLibrary
-            .getClass('GlobalQuantifyMetaCapability')!
-            .getNamedConstructor('')!;
+            .getClass2('GlobalQuantifyMetaCapability')!
+            .getNamedConstructor2('')!;
 
     for (LibraryElement2 library in _libraries) {
       List<LibraryElement2> imports = library.importedLibraries;
       for (var import in imports) {
         if (import.id != reflectableLibrary.id) continue;
         for (ElementAnnotation metadatum in import.metadata2.annotations) {
-          Element2? metadatumElement = metadatum.element2?.declaration;
+          Element2? metadatumElement = metadatum.element2?.baseElement;
           if (metadatumElement == globalQuantifyCapabilityConstructor) {
             DartObject? value = _getEvaluatedMetadatum(metadatum);
             if (value != null) {
@@ -4049,13 +4079,15 @@ class BuilderImplementation {
                 await _warn(WarningKind.badMetadata, message, metadatumElement);
                 continue;
               }
-              DartType? reflectorType = constantValue
-                  .getField('(super)')
-                  ?.getField('reflector')
-                  ?.type;
-              InterfaceElement2? reflector = reflectorType is InterfaceType
-                  ? reflectorType.element3
-                  : null;
+              DartType? reflectorType =
+                  constantValue
+                      .getField('(super)')
+                      ?.getField('reflector')
+                      ?.type;
+              InterfaceElement2? reflector =
+                  reflectorType is InterfaceType
+                      ? reflectorType.element3
+                      : null;
               if (reflector == null) {
                 await _warn(
                   WarningKind.badSuperclass,
@@ -4793,9 +4825,10 @@ class BuilderImplementation {
 
     var imports = <String>[];
     for (LibraryElement2 library in world.importCollector._libraries) {
-      Uri uri = library == world.entryPointLibrary
-          ? Uri.parse(originalEntryPointFilename)
-          : await _getImportUri(library, _resolver, generatedLibraryId);
+      Uri uri =
+          library == world.entryPointLibrary
+              ? Uri.parse(originalEntryPointFilename)
+              : await _getImportUri(library, _resolver, generatedLibraryId);
       String prefix = world.importCollector._getPrefix(library);
       if (prefix.isNotEmpty) {
         imports.add(
@@ -5151,9 +5184,10 @@ int _declarationDescriptor(ExecutableElement2 element) {
 }
 
 Future<String> _nameOfConstructor(ConstructorElement2 element) async {
-  String name = element.name3 == ''
-      ? element.enclosingElement2.name3!
-      : '${element.enclosingElement2.name3}.${element.name3}';
+  String name =
+      element.name3 == ''
+          ? element.enclosingElement2.name3!
+          : '${element.enclosingElement2.name3}.${element.name3}';
   if (_isPrivateName(name)) {
     await _severe('Cannot access private name $name', element);
   }
@@ -5332,9 +5366,10 @@ Future<String> _extractConstantCode(
         Element2? staticElement = expression.element;
         if (staticElement is PropertyAccessorElement2) {
           VariableElement2? variable = staticElement.variable3;
-          AstNode? variableDeclaration = variable != null
-              ? await _getDeclarationAst(variable, resolver)
-              : null;
+          AstNode? variableDeclaration =
+              variable != null
+                  ? await _getDeclarationAst(variable, resolver)
+                  : null;
           if (variableDeclaration == null ||
               variableDeclaration is! VariableDeclaration) {
             await _severe('Cannot handle private identifier $expression');
@@ -5667,7 +5702,7 @@ Future<String> _extractNameWithoutPrefix(
     // The identifier is of the form `p.id` where `p` is a library
     // prefix, or it is on the form `C.id` where `C` is a class and
     // `id` a named constructor.
-    if (identifier.prefix.staticElement is PrefixElement2) {
+    if (identifier.prefix.element is PrefixElement2) {
       // We will replace the library prefix by the appropriate prefix for
       // code in the generated library, so we omit the prefix specified in
       // client code.
@@ -5753,12 +5788,13 @@ Iterable<FormalParameterElement> _extractDeclaredFunctionParameters(
   return result;
 }
 
-typedef CapabilityChecker = bool Function(
-  TypeSystem,
-  String methodName,
-  Iterable<ElementAnnotation> metadata,
-  Iterable<ElementAnnotation>? getterMetadata,
-);
+typedef CapabilityChecker =
+    bool Function(
+      TypeSystem,
+      String methodName,
+      Iterable<ElementAnnotation> metadata,
+      Iterable<ElementAnnotation>? getterMetadata,
+    );
 
 /// Returns the declared fields in the given [interfaceElement], filtered such
 /// that the returned ones are the ones that are supported by [capabilities].
@@ -5769,9 +5805,10 @@ Iterable<FieldElement2> _extractDeclaredFields(
 ) {
   return interfaceElement.fields2.where((FieldElement2 field) {
     if (field.isPrivate) return false;
-    CapabilityChecker capabilityChecker = field.isStatic
-        ? capabilities.supportsStaticInvoke
-        : capabilities.supportsInstanceInvoke;
+    CapabilityChecker capabilityChecker =
+        field.isStatic
+            ? capabilities.supportsStaticInvoke
+            : capabilities.supportsInstanceInvoke;
     return !field.isSynthetic &&
         capabilityChecker(
           interfaceElement.library2.typeSystem,
@@ -5791,9 +5828,10 @@ Iterable<MethodElement2> _extractDeclaredMethods(
 ) {
   return interfaceElement.methods2.where((MethodElement2 method) {
     if (method.isPrivate) return false;
-    CapabilityChecker capabilityChecker = method.isStatic
-        ? capabilities.supportsStaticInvoke
-        : capabilities.supportsInstanceInvoke;
+    CapabilityChecker capabilityChecker =
+        method.isStatic
+            ? capabilities.supportsStaticInvoke
+            : capabilities.supportsInstanceInvoke;
     return capabilityChecker(
       method.library2.typeSystem,
       method.name3!,
@@ -5913,13 +5951,15 @@ Iterable<GetterElement> _extractGetters(
     // such that we avoid passing in `null` at all call sites except one,
     // when we might as well move the processing to that single call site (such
     // as here, but also in `_extractLibraryAccessors()`, etc).
-    CapabilityChecker capabilityChecker = getter.isStatic
-        ? capabilities.supportsStaticInvoke
-        : capabilities.supportsInstanceInvoke;
-    List<ElementAnnotation> metadata = getter.isSynthetic
-        ? (getter.variable3?.metadata2.annotations ??
-            const <ElementAnnotation>[])
-        : getter.metadata2.annotations;
+    CapabilityChecker capabilityChecker =
+        getter.isStatic
+            ? capabilities.supportsStaticInvoke
+            : capabilities.supportsInstanceInvoke;
+    List<ElementAnnotation> metadata =
+        getter.isSynthetic
+            ? (getter.variable3?.metadata2.annotations ??
+                const <ElementAnnotation>[])
+            : getter.metadata2.annotations;
     List<ElementAnnotation>? getterMetadata;
     return capabilityChecker(
       getter.library2.typeSystem,
@@ -5945,13 +5985,15 @@ Iterable<SetterElement> _extractSetters(
 ) {
   return interfaceElement.setters2.where((SetterElement setter) {
     if (setter.isPrivate) return false;
-    CapabilityChecker capabilityChecker = setter.isStatic
-        ? capabilities.supportsStaticInvoke
-        : capabilities.supportsInstanceInvoke;
-    List<ElementAnnotation> metadata = setter.isSynthetic
-        ? (setter.variable3?.metadata2.annotations ??
-            const <ElementAnnotation>[])
-        : setter.metadata2.annotations;
+    CapabilityChecker capabilityChecker =
+        setter.isStatic
+            ? capabilities.supportsStaticInvoke
+            : capabilities.supportsInstanceInvoke;
+    List<ElementAnnotation> metadata =
+        setter.isSynthetic
+            ? (setter.variable3?.metadata2.annotations ??
+                const <ElementAnnotation>[])
+            : setter.metadata2.annotations;
     List<ElementAnnotation>? getterMetadata;
     if (capabilities._impliesCorrespondingSetters && !setter.isSynthetic) {
       GetterElement? correspondingGetter = setter.correspondingGetter;
@@ -5994,32 +6036,34 @@ _LibraryDomain _createLibraryDomain(
 ) {
   Iterable<TopLevelVariableElement2> declaredVariablesOfLibrary =
       _extractDeclaredVariables(
-    domain._resolver,
-    library,
-    domain._capabilities,
-  ).toList();
+        domain._resolver,
+        library,
+        domain._capabilities,
+      ).toList();
   Iterable<TopLevelFunctionElement> declaredFunctionsOfLibrary =
       _extractDeclaredFunctions(
-    domain._resolver,
-    library,
-    domain._capabilities,
-  ).toList();
-  Iterable<GetterElement> gettersOfLibrary = _extractLibraryGetters(
-    domain._resolver,
-    library,
-    domain._capabilities,
-  ).toList();
-  Iterable<SetterElement> settersOfLibrary = _extractLibrarySetters(
-    domain._resolver,
-    library,
-    domain._capabilities,
-  ).toList();
+        domain._resolver,
+        library,
+        domain._capabilities,
+      ).toList();
+  Iterable<GetterElement> gettersOfLibrary =
+      _extractLibraryGetters(
+        domain._resolver,
+        library,
+        domain._capabilities,
+      ).toList();
+  Iterable<SetterElement> settersOfLibrary =
+      _extractLibrarySetters(
+        domain._resolver,
+        library,
+        domain._capabilities,
+      ).toList();
   Iterable<FormalParameterElement> declaredParametersOfLibrary =
       _extractDeclaredFunctionParameters(
-    domain._resolver,
-    declaredFunctionsOfLibrary,
-    gettersOfLibrary,
-  ).toList();
+        domain._resolver,
+        declaredFunctionsOfLibrary,
+        gettersOfLibrary,
+      ).toList();
   return _LibraryDomain(
     library,
     declaredVariablesOfLibrary,
@@ -6036,34 +6080,38 @@ _ClassDomain _createClassDomain(
   _ReflectorDomain domain,
 ) {
   if (type is MixinApplication) {
-    Iterable<FieldElement2> declaredFieldsOfClass = _extractDeclaredFields(
-      domain._resolver,
-      type.mixin,
-      domain._capabilities,
-    ).where((FieldElement2 e) => !e.isStatic).toList();
-    Iterable<MethodElement2> declaredMethodsOfClass = _extractDeclaredMethods(
-      domain._resolver,
-      type.mixin,
-      domain._capabilities,
-    ).where((MethodElement2 e) => !e.isStatic).toList();
-    Iterable<GetterElement> declaredAndImplicitGettersOfClass = _extractGetters(
-      domain._resolver,
-      type.mixin,
-      domain._capabilities,
-    ).toList();
-    Iterable<SetterElement> declaredAndImplicitSettersOfClass = _extractSetters(
-      domain._resolver,
-      type.mixin,
-      domain._capabilities,
-    ).toList();
+    Iterable<FieldElement2> declaredFieldsOfClass =
+        _extractDeclaredFields(
+          domain._resolver,
+          type.mixin,
+          domain._capabilities,
+        ).where((FieldElement2 e) => !e.isStatic).toList();
+    Iterable<MethodElement2> declaredMethodsOfClass =
+        _extractDeclaredMethods(
+          domain._resolver,
+          type.mixin,
+          domain._capabilities,
+        ).where((MethodElement2 e) => !e.isStatic).toList();
+    Iterable<GetterElement> declaredAndImplicitGettersOfClass =
+        _extractGetters(
+          domain._resolver,
+          type.mixin,
+          domain._capabilities,
+        ).toList();
+    Iterable<SetterElement> declaredAndImplicitSettersOfClass =
+        _extractSetters(
+          domain._resolver,
+          type.mixin,
+          domain._capabilities,
+        ).toList();
     Iterable<ConstructorElement2> declaredConstructorsOfClass =
         <ConstructorElement2>[];
     Iterable<FormalParameterElement> declaredParametersOfClass =
         _extractDeclaredParameters(
-      declaredMethodsOfClass,
-      declaredConstructorsOfClass,
-      declaredAndImplicitSettersOfClass,
-    );
+          declaredMethodsOfClass,
+          declaredConstructorsOfClass,
+          declaredAndImplicitSettersOfClass,
+        );
 
     return _ClassDomain(
       type,
@@ -6077,33 +6125,35 @@ _ClassDomain _createClassDomain(
     );
   }
 
-  List<FieldElement2> declaredFieldsOfClass = _extractDeclaredFields(
-    domain._resolver,
-    type,
-    domain._capabilities,
-  ).toList();
-  List<MethodElement2> declaredMethodsOfClass = _extractDeclaredMethods(
-    domain._resolver,
-    type,
-    domain._capabilities,
-  ).toList();
+  List<FieldElement2> declaredFieldsOfClass =
+      _extractDeclaredFields(
+        domain._resolver,
+        type,
+        domain._capabilities,
+      ).toList();
+  List<MethodElement2> declaredMethodsOfClass =
+      _extractDeclaredMethods(
+        domain._resolver,
+        type,
+        domain._capabilities,
+      ).toList();
   List<GetterElement> declaredAndImplicitGettersOfClass =
       _extractGetters(domain._resolver, type, domain._capabilities).toList();
   List<SetterElement> declaredAndImplicitSettersOfClass =
       _extractSetters(domain._resolver, type, domain._capabilities).toList();
   List<ConstructorElement2> declaredConstructorsOfClass =
       _extractDeclaredConstructors(
-    domain._resolver,
-    type.library2,
-    type,
-    domain._capabilities,
-  ).toList();
+        domain._resolver,
+        type.library2,
+        type,
+        domain._capabilities,
+      ).toList();
   List<FormalParameterElement> declaredParametersOfClass =
       _extractDeclaredParameters(
-    declaredMethodsOfClass,
-    declaredConstructorsOfClass,
-    declaredAndImplicitSettersOfClass,
-  );
+        declaredMethodsOfClass,
+        declaredConstructorsOfClass,
+        declaredAndImplicitSettersOfClass,
+      );
   return _ClassDomain(
     type,
     declaredFieldsOfClass,
@@ -6264,12 +6314,11 @@ class MixinApplication implements ClassElementImpl2 {
   InterfaceType instantiate({
     required List<DartType> typeArguments,
     required NullabilitySuffix nullabilitySuffix,
-  }) =>
-      InterfaceTypeImpl(
-        element: this,
-        typeArguments: typeArguments,
-        nullabilitySuffix: nullabilitySuffix,
-      );
+  }) => InterfaceTypeImpl(
+    element: this,
+    typeArguments: typeArguments,
+    nullabilitySuffix: nullabilitySuffix,
+  );
 
   @override
   InterfaceType? get supertype {
@@ -6510,7 +6559,7 @@ Future<String> _formatDiagnosticMessage(
   Element2? target,
   Resolver resolver,
 ) async {
-  Source? source = target?.source;
+  Source? source = target?.firstFragment.source;
   if (source == null) return message;
   var locationString = '';
   int? nameOffset = target?.firstFragment.nameOffset2;
@@ -6525,8 +6574,8 @@ Future<String> _formatDiagnosticMessage(
       resolver,
     );
     if (resolvedLibrary != null) {
-      final ElementDeclarationResult? targetDeclaration =
-          resolvedLibrary.getElementDeclaration(target!);
+      final ElementDeclarationResult? targetDeclaration = resolvedLibrary
+          .getElementDeclaration2(target!.firstFragment);
       final CompilationUnit? unit = targetDeclaration?.resolvedUnit?.unit;
       final CharacterLocation? location = unit?.lineInfo.getLocation(
         nameOffset,
@@ -6548,9 +6597,10 @@ Future<void> _emitMessage(
   Element2? target,
   Resolver? resolver,
 ]) async {
-  String formattedMessage = (target != null && resolver != null)
-      ? await _formatDiagnosticMessage(message, target, resolver)
-      : message;
+  String formattedMessage =
+      (target != null && resolver != null)
+          ? await _formatDiagnosticMessage(message, target, resolver)
+          : message;
   log.warning(formattedMessage);
 }
 
@@ -6571,8 +6621,8 @@ Future<ResolvedLibraryResult?> _getResolvedLibrary(
     await resolver.assetIdForElement(library),
   );
   final AnalysisSession freshSession = freshLibrary.session;
-  final SomeResolvedLibraryResult someResult =
-      await freshSession.getResolvedLibraryByElement(freshLibrary);
+  final SomeResolvedLibraryResult someResult = await freshSession
+      .getResolvedLibraryByElement2(freshLibrary);
   if (someResult is ResolvedLibraryResult) {
     return someResult;
   } else {

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -31,6 +31,7 @@ import 'package:analyzer/src/summary/package_bundle_reader.dart';
 import 'package:build/build.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:path/path.dart' as path;
+import 'package:pub_semver/pub_semver.dart';
 import 'element_capability.dart' as ec;
 import 'encoding_constants.dart' as constants;
 import 'fixed_point.dart';
@@ -765,7 +766,7 @@ class _ReflectorDomain {
     // would suppress an error in a very-hard-to-explain case, so that's safer
     // in a sense, but too weird.
     if (constructor.library.isDartCore &&
-        constructor.enclosingElement.name == 'List' &&
+        constructor.enclosingElement3.name == 'List' &&
         constructor.name == '') {
       return '(bool b) => ([length]) => '
           'b ? (length == null ? [] : List.filled(length, null)) : null';
@@ -4831,7 +4832,7 @@ void initializeReflectable() {
 }
 ''';
     if (_formatted) {
-      var formatter = DartFormatter();
+      var formatter = DartFormatter(languageVersion: Version(3, 0, 0));
       result = formatter.format(result);
     }
     return result;

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -51,7 +51,7 @@ enum WarningKind {
   badMetadata,
   badReflectorClass,
   unrecognizedReflector,
-  unusedReflector
+  unusedReflector,
 }
 
 class _ReflectionWorld {
@@ -69,13 +69,14 @@ class _ReflectionWorld {
   final Set<String> memberNames = <String>{};
 
   _ReflectionWorld(
-      this.resolver,
-      this.libraries,
-      this.generatedLibraryId,
-      this.reflectors,
-      this.reflectableLibrary,
-      this.entryPointLibrary,
-      this.importCollector);
+    this.resolver,
+    this.libraries,
+    this.generatedLibraryId,
+    this.reflectors,
+    this.reflectableLibrary,
+    this.entryPointLibrary,
+    this.importCollector,
+  );
 
   /// The inverse relation of `superinterfaces` union `superclass`, globally.
   Map<InterfaceElement, Set<InterfaceElement>> get subtypes {
@@ -85,7 +86,9 @@ class _ReflectionWorld {
     var subtypes = <InterfaceElement, Set<InterfaceElement>>{};
 
     void addSubtypeRelation(
-        InterfaceElement supertype, InterfaceElement subtype) {
+      InterfaceElement supertype,
+      InterfaceElement subtype,
+    ) {
       Set<InterfaceElement>? subtypesOfSupertype = subtypes[supertype];
       if (subtypesOfSupertype == null) {
         subtypesOfSupertype = <InterfaceElement>{};
@@ -112,14 +115,20 @@ class _ReflectionWorld {
             InterfaceElement mixinElement = mixin.element;
             InterfaceElement? subClass =
                 mixin == interfaceElement.mixins.last ? interfaceElement : null;
-            String? name = subClass == null
-                ? null
-                : (interfaceElement is MixinApplication &&
-                        interfaceElement.isMixinApplication
-                    ? interfaceElement.name
-                    : null);
+            String? name =
+                subClass == null
+                    ? null
+                    : (interfaceElement is MixinApplication &&
+                            interfaceElement.isMixinApplication
+                        ? interfaceElement.name
+                        : null);
             var mixinApplication = MixinApplication(
-                name, superclass, mixinElement, library, subClass);
+              name,
+              superclass,
+              mixinElement,
+              library,
+              subClass,
+            );
             addSubtypeRelation(superclass, mixinApplication);
             addSubtypeRelation(mixinElement, mixinApplication);
             if (subClass != null) {
@@ -156,21 +165,29 @@ class _ReflectionWorld {
     var typedefsCode = '\n';
     var reflectorsCode = <String>[];
     for (_ReflectorDomain reflector in reflectors) {
-      String reflectorCode =
-          await reflector._generateCode(this, importCollector, typedefs);
+      String reflectorCode = await reflector._generateCode(
+        this,
+        importCollector,
+        typedefs,
+      );
       if (typedefs.isNotEmpty) {
         for (DartType dartType in typedefs.keys) {
           String body = await reflector._typeCodeOfTypeArgument(
-              dartType, importCollector, typeVariablesInScope, typedefs,
-              useNameOfGenericFunctionType: false);
+            dartType,
+            importCollector,
+            typeVariablesInScope,
+            typedefs,
+            useNameOfGenericFunctionType: false,
+          );
           typedefsCode +=
               '\ntypedef ${_typedefName(typedefs[dartType]!)} = $body;';
         }
         typedefs.clear();
       }
-      reflectorsCode
-          .add('${await reflector._constConstructionCode(importCollector)}: '
-              '$reflectorCode');
+      reflectorsCode.add(
+        '${await reflector._constConstructionCode(importCollector)}: '
+        '$reflectorCode',
+      );
     }
     return 'final _data = <r.Reflectable, r.ReflectorData>'
         '${_formatAsMap(reflectorsCode)};$typedefsCode';
@@ -181,11 +198,14 @@ class _ReflectionWorld {
   /// is collected during the execution of `generateCode`, which means that
   /// this method must be called after `generateCode`.
   String generateSymbolMap() {
-    if (reflectors.any((_ReflectorDomain reflector) =>
-        reflector._capabilities._impliesMemberSymbols)) {
+    if (reflectors.any(
+      (_ReflectorDomain reflector) =>
+          reflector._capabilities._impliesMemberSymbols,
+    )) {
       // Generate the mapping when requested, even if it is empty.
       String mapping = _formatAsMap(
-          memberNames.map((String name) => "const Symbol(r'$name'): r'$name'"));
+        memberNames.map((String name) => "const Symbol(r'$name'): r'$name'"),
+      );
       return mapping;
     } else {
       // The value `null` unambiguously indicates lack of capability.
@@ -304,7 +324,8 @@ class _InterfaceElementEnhancedSet implements Set<InterfaceElement> {
 
   @override
   InterfaceElement reduce(
-      InterfaceElement Function(InterfaceElement, InterfaceElement) combine) {
+    InterfaceElement Function(InterfaceElement, InterfaceElement) combine,
+  ) {
     return interfaceElements.items.reduce(combine);
   }
 
@@ -358,7 +379,8 @@ class _InterfaceElementEnhancedSet implements Set<InterfaceElement> {
 
   @override
   Iterable<InterfaceElement> followedBy(
-      Iterable<InterfaceElement> other) sync* {
+    Iterable<InterfaceElement> other,
+  ) sync* {
     yield* this;
     yield* other;
   }
@@ -373,20 +395,26 @@ class _InterfaceElementEnhancedSet implements Set<InterfaceElement> {
   InterfaceElement get single => interfaceElements.items.single;
 
   @override
-  InterfaceElement firstWhere(bool Function(InterfaceElement) test,
-      {InterfaceElement Function()? orElse}) {
+  InterfaceElement firstWhere(
+    bool Function(InterfaceElement) test, {
+    InterfaceElement Function()? orElse,
+  }) {
     return interfaceElements.items.firstWhere(test, orElse: orElse);
   }
 
   @override
-  InterfaceElement lastWhere(bool Function(InterfaceElement) test,
-      {InterfaceElement Function()? orElse}) {
+  InterfaceElement lastWhere(
+    bool Function(InterfaceElement) test, {
+    InterfaceElement Function()? orElse,
+  }) {
     return interfaceElements.items.lastWhere(test, orElse: orElse);
   }
 
   @override
-  InterfaceElement singleWhere(bool Function(InterfaceElement) test,
-      {InterfaceElement Function()? orElse}) {
+  InterfaceElement singleWhere(
+    bool Function(InterfaceElement) test, {
+    InterfaceElement Function()? orElse,
+  }) {
     return interfaceElements.items.singleWhere(test);
   }
 
@@ -580,18 +608,23 @@ class ParameterListShape {
   final int numberOfOptionalPositionalParameters;
   final Set<String> namesOfNamedParameters;
 
-  const ParameterListShape(this.numberOfPositionalParameters,
-      this.numberOfOptionalPositionalParameters, this.namesOfNamedParameters);
+  const ParameterListShape(
+    this.numberOfPositionalParameters,
+    this.numberOfOptionalPositionalParameters,
+    this.namesOfNamedParameters,
+  );
 
   @override
-  bool operator ==(other) => other is ParameterListShape
-      ? numberOfPositionalParameters == other.numberOfPositionalParameters &&
-          numberOfOptionalPositionalParameters ==
-              other.numberOfOptionalPositionalParameters &&
-          namesOfNamedParameters
-              .difference(other.namesOfNamedParameters)
-              .isEmpty
-      : false;
+  bool operator ==(other) =>
+      other is ParameterListShape
+          ? numberOfPositionalParameters ==
+                  other.numberOfPositionalParameters &&
+              numberOfOptionalPositionalParameters ==
+                  other.numberOfOptionalPositionalParameters &&
+              namesOfNamedParameters
+                  .difference(other.namesOfNamedParameters)
+                  .isEmpty
+          : false;
 
   @override
   int get hashCode =>
@@ -643,9 +676,10 @@ class _ReflectorDomain {
         await _SubtypesFixedPoint(_world.subtypes).expand(_classes);
       }
       if (_capabilities._impliesUpwardsClosure) {
-        await _SuperclassFixedPoint(await _capabilities._upwardsClosureBounds,
-                _capabilities._impliesMixins)
-            .expand(_classes);
+        await _SuperclassFixedPoint(
+          await _capabilities._upwardsClosureBounds,
+          _capabilities._impliesMixins,
+        ).expand(_classes);
       } else {
         // Even without an upwards closure we cover some superclasses, namely
         // mixin applications where the class applied as a mixin is covered (it
@@ -657,7 +691,10 @@ class _ReflectorDomain {
       if (_capabilities._impliesTypes &&
           _capabilities._impliesTypeAnnotations) {
         var fix = _AnnotationClassFixedPoint(
-            _resolver, _generatedLibraryId, _classes.domainOf);
+          _resolver,
+          _generatedLibraryId,
+          _classes.domainOf,
+        );
         if (_capabilities._impliesTypeAnnotationClosure) {
           await fix.expand(_classes);
         } else {
@@ -673,8 +710,12 @@ class _ReflectorDomain {
 
   final _Capabilities _capabilities;
 
-  _ReflectorDomain(this._resolver, this._generatedLibraryId, this._reflector,
-      this._capabilities) {
+  _ReflectorDomain(
+    this._resolver,
+    this._generatedLibraryId,
+    this._reflector,
+    this._capabilities,
+  ) {
     _classes = _InterfaceElementEnhancedSet(this);
   }
 
@@ -691,15 +732,18 @@ class _ReflectorDomain {
   /// returns "(x, {y: 3}) => prefix1.Foo(x, y)", and records an import of
   /// the library of `Foo` associated with prefix1 in [importCollector].
   Future<String> _constructorCode(
-      ConstructorElement constructor, _ImportCollector importCollector) async {
+    ConstructorElement constructor,
+    _ImportCollector importCollector,
+  ) async {
     FunctionType type = constructor.type;
 
     int requiredPositionalCount = type.normalParameterTypes.length;
     int optionalPositionalCount = type.optionalParameterTypes.length;
 
-    List<String> parameterNames = type.parameters
-        .map((ParameterElement parameter) => parameter.name)
-        .toList();
+    List<String> parameterNames =
+        type.parameters
+            .map((ParameterElement parameter) => parameter.name)
+            .toList();
 
     List<String> namedParameterNames = type.namedParameterTypes.keys.toList();
 
@@ -727,17 +771,21 @@ class _ReflectorDomain {
           'b ? (length == null ? [] : List.filled(length, null)) : null';
     }
 
-    String positionals =
-        Iterable.generate(requiredPositionalCount, (int i) => parameterNames[i])
-            .join(', ');
+    String positionals = Iterable.generate(
+      requiredPositionalCount,
+      (int i) => parameterNames[i],
+    ).join(', ');
 
     var optionalsWithDefaultList = <String>[];
     for (var i = 0; i < optionalPositionalCount; i++) {
       String code = await _extractDefaultValueCode(
-          importCollector, constructor.parameters[requiredPositionalCount + i]);
+        importCollector,
+        constructor.parameters[requiredPositionalCount + i],
+      );
       var defaultPart = code.isEmpty ? '' : ' = $code';
-      optionalsWithDefaultList
-          .add('${parameterNames[requiredPositionalCount + i]}$defaultPart');
+      optionalsWithDefaultList.add(
+        '${parameterNames[requiredPositionalCount + i]}$defaultPart',
+      );
     }
     String optionalsWithDefaults = optionalsWithDefaultList.join(', ');
 
@@ -749,17 +797,22 @@ class _ReflectorDomain {
       // any named parameters then all optional parameters are named.
       ParameterElement parameterElement =
           constructor.parameters[requiredPositionalCount + i];
-      String code =
-          await _extractDefaultValueCode(importCollector, parameterElement);
+      String code = await _extractDefaultValueCode(
+        importCollector,
+        parameterElement,
+      );
       var defaultPart = code.isEmpty ? '' : ' = $code';
       namedWithDefaultList.add('${parameterElement.name}$defaultPart');
     }
     String namedWithDefaults = namedWithDefaultList.join(', ');
 
-    String optionalArguments = Iterable.generate(optionalPositionalCount,
-        (int i) => parameterNames[i + requiredPositionalCount]).join(', ');
-    String namedArguments =
-        namedParameterNames.map((String name) => '$name: $name').join(', ');
+    String optionalArguments = Iterable.generate(
+      optionalPositionalCount,
+      (int i) => parameterNames[i + requiredPositionalCount],
+    ).join(', ');
+    String namedArguments = namedParameterNames
+        .map((String name) => '$name: $name')
+        .join(', ');
 
     var parameterParts = <String>[];
     var argumentParts = <String>[];
@@ -790,11 +843,14 @@ class _ReflectorDomain {
 
   /// The code of the const-construction of this reflector.
   Future<String> _constConstructionCode(
-      _ImportCollector importCollector) async {
+    _ImportCollector importCollector,
+  ) async {
     String prefix = importCollector._getPrefix(_reflector.library);
     if (_isPrivateName(_reflector.name)) {
       await _severe(
-          'Cannot access private name `${_reflector.name}`', _reflector);
+        'Cannot access private name `${_reflector.name}`',
+        _reflector,
+      );
     }
     return 'const $prefix${_reflector.name}()';
   }
@@ -802,8 +858,11 @@ class _ReflectorDomain {
   /// Generate the code which will create a `ReflectorData` instance
   /// containing the mirrors and other reflection data which is needed for
   /// `_reflector` to behave correctly.
-  Future<String> _generateCode(_ReflectionWorld world,
-      _ImportCollector importCollector, Map<FunctionType, int> typedefs) async {
+  Future<String> _generateCode(
+    _ReflectionWorld world,
+    _ImportCollector importCollector,
+    Map<FunctionType, int> typedefs,
+  ) async {
     // Library related collections.
     var libraries = Enumerator<_LibraryDomain>();
     var libraryMap = <LibraryElement, _LibraryDomain>{};
@@ -843,7 +902,10 @@ class _ReflectorDomain {
     /// that it is importable and registering it with [importCollector].
     Future<void> addLibrary(LibraryElement library) async {
       if (!await _isImportableLibrary(
-          library, _generatedLibraryId, _resolver)) {
+        library,
+        _generatedLibraryId,
+        _resolver,
+      )) {
         return;
       }
       importCollector._addLibrary(library);
@@ -855,8 +917,10 @@ class _ReflectorDomain {
     _libraries.items.forEach(uncheckedAddLibrary);
     for (InterfaceElement classElement in await classes) {
       LibraryElement classLibrary = classElement.library;
-      if (!libraries.items.any((_LibraryDomain libraryDomain) =>
-          libraryDomain._libraryElement == classLibrary)) {
+      if (!libraries.items.any(
+        (_LibraryDomain libraryDomain) =>
+            libraryDomain._libraryElement == classLibrary,
+      )) {
         addLibrary(classLibrary);
       }
       classElement.typeParameters.forEach(typeParameters.add);
@@ -899,9 +963,10 @@ class _ReflectorDomain {
             topLevelVariables.add(variable);
           } else {
             await _severe(
-                'This kind of variable is not yet supported'
-                ' (${variable.runtimeType})',
-                variable);
+              'This kind of variable is not yet supported'
+              ' (${variable.runtimeType})',
+              variable,
+            );
           }
         }
       }
@@ -934,8 +999,9 @@ class _ReflectorDomain {
       Future<void> addClass(InterfaceElement classElement) async {
         (await classes).add(classElement);
         LibraryElement classLibrary = classElement.library;
-        if (!libraries.items
-            .any((domain) => domain._libraryElement == classLibrary)) {
+        if (!libraries.items.any(
+          (domain) => domain._libraryElement == classLibrary,
+        )) {
           uncheckedAddLibrary(classLibrary);
         }
       }
@@ -1022,7 +1088,8 @@ class _ReflectorDomain {
     var typeMirrorsList = <String>[];
     if (_capabilities._impliesTypes || _capabilities._impliesInstanceInvoke) {
       for (_ClassDomain classDomain in (await classes).domains) {
-        typeMirrorsList.add(await _classMirrorCode(
+        typeMirrorsList.add(
+          await _classMirrorCode(
             classDomain,
             typeParameters,
             fields,
@@ -1037,11 +1104,18 @@ class _ReflectorDomain {
             libraries,
             libraryMap,
             importCollector,
-            typedefs));
+            typedefs,
+          ),
+        );
       }
       for (TypeParameterElement typeParameterElement in typeParameters.items) {
-        typeMirrorsList.add(await _typeParameterMirrorCode(
-            typeParameterElement, importCollector, objectInterfaceElement));
+        typeMirrorsList.add(
+          await _typeParameterMirrorCode(
+            typeParameterElement,
+            importCollector,
+            objectInterfaceElement,
+          ),
+        );
       }
     }
     String classMirrorsCode = _formatAsList('m.TypeMirror', typeMirrorsList);
@@ -1055,29 +1129,36 @@ class _ReflectorDomain {
     // Generate code for creation of member mirrors.
     var topLevelVariablesList = <String>[];
     for (TopLevelVariableElement element in topLevelVariables.items) {
-      topLevelVariablesList.add(await _topLevelVariableMirrorCode(
+      topLevelVariablesList.add(
+        await _topLevelVariableMirrorCode(
           element,
           reflectedTypes,
           reflectedTypesOffset,
           importCollector,
           typedefs,
-          reflectedTypeRequested));
+          reflectedTypeRequested,
+        ),
+      );
     }
     var fieldsList = <String>[];
     for (FieldElement element in fields.items) {
-      fieldsList.add(await _fieldMirrorCode(
+      fieldsList.add(
+        await _fieldMirrorCode(
           element,
           reflectedTypes,
           reflectedTypesOffset,
           importCollector,
           typedefs,
-          reflectedTypeRequested));
+          reflectedTypeRequested,
+        ),
+      );
     }
     var membersCode = 'null';
     if (_capabilities._impliesDeclarations) {
       var methodsList = <String>[];
       for (ExecutableElement executableElement in members.items) {
-        methodsList.add(await _methodMirrorCode(
+        methodsList.add(
+          await _methodMirrorCode(
             executableElement,
             topLevelVariables,
             fields,
@@ -1087,7 +1168,9 @@ class _ReflectorDomain {
             parameters,
             importCollector,
             typedefs,
-            reflectedTypeRequested));
+            reflectedTypeRequested,
+          ),
+        );
       }
       Iterable<String> membersList = [
         ...topLevelVariablesList,
@@ -1102,7 +1185,8 @@ class _ReflectorDomain {
     if (_capabilities._impliesDeclarations) {
       var parametersList = <String>[];
       for (ParameterElement element in parameters.items) {
-        parametersList.add(await _parameterMirrorCode(
+        parametersList.add(
+          await _parameterMirrorCode(
             element,
             fields,
             members,
@@ -1110,7 +1194,9 @@ class _ReflectorDomain {
             reflectedTypesOffset,
             importCollector,
             typedefs,
-            reflectedTypeRequested));
+            reflectedTypeRequested,
+          ),
+        );
       }
       parameterMirrorsCode = _formatAsList('m.ParameterMirror', parametersList);
     }
@@ -1124,10 +1210,16 @@ class _ReflectorDomain {
       if (erasableDartType.erased) {
         var interfaceType = erasableDartType.dartType as InterfaceType;
         typesCodeList.add(
-            _dynamicTypeCodeOfClass(interfaceType.element, importCollector));
+          _dynamicTypeCodeOfClass(interfaceType.element, importCollector),
+        );
       } else {
-        typesCodeList.add(await _typeCodeOfClass(
-            erasableDartType.dartType, importCollector, typedefs));
+        typesCodeList.add(
+          await _typeCodeOfClass(
+            erasableDartType.dartType,
+            importCollector,
+            typedefs,
+          ),
+        );
       }
     }
     String typesCode = _formatAsList('Type', typesCodeList);
@@ -1139,7 +1231,8 @@ class _ReflectorDomain {
     } else {
       var librariesCodeList = <String>[];
       for (_LibraryDomain library in libraries.items) {
-        librariesCodeList.add(await _libraryMirrorCode(
+        librariesCodeList.add(
+          await _libraryMirrorCode(
             library,
             libraries.indexOf(library)!,
             members,
@@ -1147,14 +1240,16 @@ class _ReflectorDomain {
             parameterListShapeOf,
             topLevelVariables,
             methodsOffset,
-            importCollector));
+            importCollector,
+          ),
+        );
       }
       librariesCode = _formatAsList('m.LibraryMirror', librariesCodeList);
     }
 
-    String parameterListShapesCode = _formatAsDynamicList(parameterListShapes
-        .items
-        .map((ParameterListShape shape) => shape.code));
+    String parameterListShapesCode = _formatAsDynamicList(
+      parameterListShapes.items.map((ParameterListShape shape) => shape.code),
+    );
 
     return 'r.ReflectorData($classMirrorsCode, $membersCode, '
         '$parameterMirrorsCode, $typesCode, $reflectedTypesOffset, '
@@ -1162,8 +1257,13 @@ class _ReflectorDomain {
         '$parameterListShapesCode)';
   }
 
-  Future<int> _computeTypeIndexBase(Element? typeElement, bool isVoid,
-      bool isDynamic, bool isNever, bool isClassType) async {
+  Future<int> _computeTypeIndexBase(
+    Element? typeElement,
+    bool isVoid,
+    bool isDynamic,
+    bool isNever,
+    bool isClassType,
+  ) async {
     if (_capabilities._impliesTypes) {
       if (isDynamic || isVoid || isNever) {
         // The mirror will report 'dynamic', 'void', 'Never',
@@ -1184,16 +1284,19 @@ class _ReflectorDomain {
   }
 
   Future<int> _computeVariableTypeIndex(
-      PropertyInducingElement element, int descriptor) async {
+    PropertyInducingElement element,
+    int descriptor,
+  ) async {
     if (!_capabilities._impliesTypes) return constants.noCapabilityIndex;
     DartType interfaceType = element.type;
     if (interfaceType is! InterfaceType) return constants.noCapabilityIndex;
     return await _computeTypeIndexBase(
-        interfaceType.element,
-        descriptor & constants.voidAttribute != 0,
-        descriptor & constants.dynamicAttribute != 0,
-        descriptor & constants.neverAttribute != 0,
-        descriptor & constants.classTypeAttribute != 0);
+      interfaceType.element,
+      descriptor & constants.voidAttribute != 0,
+      descriptor & constants.dynamicAttribute != 0,
+      descriptor & constants.neverAttribute != 0,
+      descriptor & constants.classTypeAttribute != 0,
+    );
   }
 
   Future<bool> _hasSupportedReflectedTypeArguments(DartType dartType) async {
@@ -1209,18 +1312,21 @@ class _ReflectorDomain {
     } else if (dartType is TypeParameterType || dartType is DynamicType) {
       return false;
     } else {
-      await _severe('`reflectedTypeArguments` where an actual type argument '
-          '(possibly nested) is $dartType');
+      await _severe(
+        '`reflectedTypeArguments` where an actual type argument '
+        '(possibly nested) is $dartType',
+      );
       return false;
     }
   }
 
   Future<String> _computeReflectedTypeArguments(
-      DartType dartType,
-      Enumerator<ErasableDartType> reflectedTypes,
-      int reflectedTypesOffset,
-      _ImportCollector importCollector,
-      Map<FunctionType, int> typedefs) async {
+    DartType dartType,
+    Enumerator<ErasableDartType> reflectedTypes,
+    int reflectedTypesOffset,
+    _ImportCollector importCollector,
+    Map<FunctionType, int> typedefs,
+  ) async {
     if (dartType is InterfaceType) {
       List<TypeParameterElement> typeParameters =
           dartType.element.typeParameters;
@@ -1249,18 +1355,22 @@ class _ReflectorDomain {
             if (actualTypeArgument is InterfaceType ||
                 actualTypeArgument is VoidType ||
                 actualTypeArgument is DynamicType) {
-              typesIndices.add(_dynamicTypeCodeIndex(
+              typesIndices.add(
+                _dynamicTypeCodeIndex(
                   actualTypeArgument,
                   await classes,
                   reflectedTypes,
                   reflectedTypesOffset,
-                  typedefs));
+                  typedefs,
+                ),
+              );
             } else {
               // TODO(eernst) clarify: Are `dynamic` et al `InterfaceType`s?
               // Otherwise this means "a case that we have not it considered".
               await _severe(
-                  '`reflectedTypeArguments` where one actual type argument'
-                  ' is $actualTypeArgument');
+                '`reflectedTypeArguments` where one actual type argument'
+                ' is $actualTypeArgument',
+              );
               typesIndices.add(0);
             }
           }
@@ -1276,21 +1386,26 @@ class _ReflectorDomain {
   }
 
   Future<int> _computeReturnTypeIndex(
-      ExecutableElement element, int descriptor) async {
+    ExecutableElement element,
+    int descriptor,
+  ) async {
     if (!_capabilities._impliesTypes) return constants.noCapabilityIndex;
     DartType interfaceType = element.returnType;
     if (interfaceType is! InterfaceType) return constants.noCapabilityIndex;
     int result = await _computeTypeIndexBase(
-        interfaceType.element,
-        descriptor & constants.voidReturnTypeAttribute != 0,
-        descriptor & constants.dynamicReturnTypeAttribute != 0,
-        descriptor & constants.neverReturnTypeAttribute != 0,
-        descriptor & constants.classReturnTypeAttribute != 0);
+      interfaceType.element,
+      descriptor & constants.voidReturnTypeAttribute != 0,
+      descriptor & constants.dynamicReturnTypeAttribute != 0,
+      descriptor & constants.neverReturnTypeAttribute != 0,
+      descriptor & constants.classReturnTypeAttribute != 0,
+    );
     return result;
   }
 
   Future<int?> _computeOwnerIndex(
-      ExecutableElement element, int descriptor) async {
+    ExecutableElement element,
+    int descriptor,
+  ) async {
     if (element.enclosingElement is InterfaceElement) {
       return (await classes).indexOf(element.enclosingElement);
     } else if (element.enclosingElement is CompilationUnitElement) {
@@ -1301,20 +1416,23 @@ class _ReflectorDomain {
   }
 
   Iterable<ExecutableElement> _gettersOfLibrary(_LibraryDomain library) sync* {
-    yield* library._accessors
-        .where((PropertyAccessorElement accessor) => accessor.isGetter);
+    yield* library._accessors.where(
+      (PropertyAccessorElement accessor) => accessor.isGetter,
+    );
     yield* library._declaredFunctions;
   }
 
   Iterable<PropertyAccessorElement> _settersOfLibrary(_LibraryDomain library) {
-    return library._accessors
-        .where((PropertyAccessorElement accessor) => accessor.isSetter);
+    return library._accessors.where(
+      (PropertyAccessorElement accessor) => accessor.isSetter,
+    );
   }
 
   Future<String> _typeParameterMirrorCode(
-      TypeParameterElement typeParameterElement,
-      _ImportCollector importCollector,
-      InterfaceElement? objectInterfaceElement) async {
+    TypeParameterElement typeParameterElement,
+    _ImportCollector importCollector,
+    InterfaceElement? objectInterfaceElement,
+  ) async {
     int? upperBoundIndex = constants.noCapabilityIndex;
     if (_capabilities._impliesTypeAnnotations) {
       DartType? bound = typeParameterElement.bound;
@@ -1336,8 +1454,9 @@ class _ReflectorDomain {
         }
       }
     }
-    int? ownerIndex =
-        (await classes).indexOf(typeParameterElement.enclosingElement!);
+    int? ownerIndex = (await classes).indexOf(
+      typeParameterElement.enclosingElement!,
+    );
     // TODO(eernst) implement: Update when type variables support metadata.
     var metadataCode = _capabilities._supportsMetadata ? '<Object>[]' : 'null';
     return "r.TypeVariableMirrorImpl(r'${typeParameterElement.name}', "
@@ -1347,27 +1466,29 @@ class _ReflectorDomain {
   }
 
   Future<String> _classMirrorCode(
-      _ClassDomain classDomain,
-      Enumerator<TypeParameterElement> typeParameters,
-      Enumerator<FieldElement> fields,
-      int fieldsOffset,
-      int methodsOffset,
-      int typeParametersOffset,
-      Enumerator<ExecutableElement> members,
-      Enumerator<ParameterListShape> parameterListShapes,
-      Map<ExecutableElement, ParameterListShape> parameterListShapeOf,
-      Enumerator<ErasableDartType> reflectedTypes,
-      int reflectedTypesOffset,
-      Enumerator<_LibraryDomain> libraries,
-      Map<LibraryElement, _LibraryDomain> libraryMap,
-      _ImportCollector importCollector,
-      Map<FunctionType, int> typedefs) async {
+    _ClassDomain classDomain,
+    Enumerator<TypeParameterElement> typeParameters,
+    Enumerator<FieldElement> fields,
+    int fieldsOffset,
+    int methodsOffset,
+    int typeParametersOffset,
+    Enumerator<ExecutableElement> members,
+    Enumerator<ParameterListShape> parameterListShapes,
+    Map<ExecutableElement, ParameterListShape> parameterListShapeOf,
+    Enumerator<ErasableDartType> reflectedTypes,
+    int reflectedTypesOffset,
+    Enumerator<_LibraryDomain> libraries,
+    Map<LibraryElement, _LibraryDomain> libraryMap,
+    _ImportCollector importCollector,
+    Map<FunctionType, int> typedefs,
+  ) async {
     int descriptor = _classDescriptor(classDomain._interfaceElement);
 
     // Fields go first in [memberMirrors], so they will get the
     // same index as in [fields].
-    Iterable<int> fieldsIndices =
-        classDomain._declaredFields.map((FieldElement element) {
+    Iterable<int> fieldsIndices = classDomain._declaredFields.map((
+      FieldElement element,
+    ) {
       return fields.indexOf(element)! + fieldsOffset;
     });
 
@@ -1377,55 +1498,61 @@ class _ReflectorDomain {
     Iterable<int> methodsIndices = classDomain._declarations
         .where(_executableIsntImplicitGetterOrSetter)
         .map((ExecutableElement element) {
-      // TODO(eernst) implement: The "magic" default constructor in `Object`
-      // (the one that ultimately allocates the memory for _every_ new
-      // object) has no index, which creates the need to catch a `null`
-      // here. Search for "magic" to find other occurrences of the same
-      // issue. For now, we use the index [constants.noCapabilityIndex]
-      // for this declaration, because it is not yet supported.
-      // Need to find the correct solution, though!
-      int? index = members.indexOf(element);
-      return index == null
-          ? constants.noCapabilityIndex
-          : index + methodsOffset;
-    });
+          // TODO(eernst) implement: The "magic" default constructor in `Object`
+          // (the one that ultimately allocates the memory for _every_ new
+          // object) has no index, which creates the need to catch a `null`
+          // here. Search for "magic" to find other occurrences of the same
+          // issue. For now, we use the index [constants.noCapabilityIndex]
+          // for this declaration, because it is not yet supported.
+          // Need to find the correct solution, though!
+          int? index = members.indexOf(element);
+          return index == null
+              ? constants.noCapabilityIndex
+              : index + methodsOffset;
+        });
 
-    String declarationsCode = _capabilities._impliesDeclarations
-        ? _formatAsConstList('int', [...fieldsIndices, ...methodsIndices])
-        : 'const <int>[${constants.noCapabilityIndex}]';
+    String declarationsCode =
+        _capabilities._impliesDeclarations
+            ? _formatAsConstList('int', [...fieldsIndices, ...methodsIndices])
+            : 'const <int>[${constants.noCapabilityIndex}]';
 
     // All instance members belong to the behavioral interface, so they
     // also get an offset of `fields.length`.
     var instanceMembersCode = 'null';
     if (_capabilities._impliesDeclarations) {
-      instanceMembersCode = _formatAsConstList('int',
-          classDomain._instanceMembers.map((ExecutableElement element) {
-        // TODO(eernst) implement: The "magic" default constructor has
-        // index: noCapabilityIndex; adjust this when support for it has
-        // been implemented.
-        int? index = members.indexOf(element);
-        return index == null
-            ? constants.noCapabilityIndex
-            : index + methodsOffset;
-      }));
+      instanceMembersCode = _formatAsConstList(
+        'int',
+        classDomain._instanceMembers.map((ExecutableElement element) {
+          // TODO(eernst) implement: The "magic" default constructor has
+          // index: noCapabilityIndex; adjust this when support for it has
+          // been implemented.
+          int? index = members.indexOf(element);
+          return index == null
+              ? constants.noCapabilityIndex
+              : index + methodsOffset;
+        }),
+      );
     }
 
     // All static members belong to the behavioral interface, so they
     // also get an offset of `fields.length`.
     var staticMembersCode = 'null';
     if (_capabilities._impliesDeclarations) {
-      staticMembersCode = _formatAsConstList('int',
-          classDomain._staticMembers.map((ExecutableElement element) {
-        int? index = members.indexOf(element);
-        return index == null
-            ? constants.noCapabilityIndex
-            : index + methodsOffset;
-      }));
+      staticMembersCode = _formatAsConstList(
+        'int',
+        classDomain._staticMembers.map((ExecutableElement element) {
+          int? index = members.indexOf(element);
+          return index == null
+              ? constants.noCapabilityIndex
+              : index + methodsOffset;
+        }),
+      );
     }
 
     InterfaceElement interfaceElement = classDomain._interfaceElement;
-    InterfaceElement? superclass =
-        (await classes).superclassOf(interfaceElement);
+    InterfaceElement? superclass = (await classes).superclassOf(
+      interfaceElement,
+    );
 
     var superclassIndex = '${constants.noCapabilityIndex}';
     if (_capabilities._impliesTypeRelations) {
@@ -1434,10 +1561,11 @@ class _ReflectorDomain {
       // convention we make it supported and report it in the same way as
       // 'dart:mirrors'. Other superclasses use `noCapabilityIndex` to
       // indicate missing support.
-      superclassIndex = (interfaceElement is! MixinApplication &&
-              _typeForReflectable(interfaceElement).isDartCoreObject)
-          ? 'null'
-          : ((await classes).contains(superclass))
+      superclassIndex =
+          (interfaceElement is! MixinApplication &&
+                  _typeForReflectable(interfaceElement).isDartCoreObject)
+              ? 'null'
+              : ((await classes).contains(superclass))
               ? '${(await classes).indexOf(superclass!)}'
               : '${constants.noCapabilityIndex}';
     }
@@ -1470,22 +1598,37 @@ class _ReflectorDomain {
       var staticGettersCodeList = <String>[];
       for (MethodElement method in classDomain._declaredMethods) {
         if (method.isStatic) {
-          staticGettersCodeList.add(await _staticGettingClosure(
-              importCollector, interfaceElement, method.name));
+          staticGettersCodeList.add(
+            await _staticGettingClosure(
+              importCollector,
+              interfaceElement,
+              method.name,
+            ),
+          );
         }
       }
       for (PropertyAccessorElement accessor in classDomain._accessors) {
         if (accessor.isStatic && accessor.isGetter) {
-          staticGettersCodeList.add(await _staticGettingClosure(
-              importCollector, interfaceElement, accessor.name));
+          staticGettersCodeList.add(
+            await _staticGettingClosure(
+              importCollector,
+              interfaceElement,
+              accessor.name,
+            ),
+          );
         }
       }
       staticGettersCode = _formatAsMap(staticGettersCodeList);
       var staticSettersCodeList = <String>[];
       for (PropertyAccessorElement accessor in classDomain._accessors) {
         if (accessor.isStatic && accessor.isSetter) {
-          staticSettersCodeList.add(await _staticSettingClosure(
-              importCollector, interfaceElement, accessor.name));
+          staticSettersCodeList.add(
+            await _staticSettingClosure(
+              importCollector,
+              interfaceElement,
+              accessor.name,
+            ),
+          );
         }
       }
       staticSettersCode = _formatAsMap(staticSettersCodeList);
@@ -1510,24 +1653,30 @@ class _ReflectorDomain {
       mixinIndex ??= constants.noCapabilityIndex;
     }
 
-    int ownerIndex = _capabilities._supportsLibraries
-        ? libraries.indexOf(libraryMap[interfaceElement.library]!)!
-        : constants.noCapabilityIndex;
+    int ownerIndex =
+        _capabilities._supportsLibraries
+            ? libraries.indexOf(libraryMap[interfaceElement.library]!)!
+            : constants.noCapabilityIndex;
 
     var superinterfaceIndices = 'const <int>[${constants.noCapabilityIndex}]';
     if (_capabilities._impliesTypeRelations) {
       superinterfaceIndices = _formatAsConstList(
-          'int',
-          interfaceElement.interfaces
-              .map((InterfaceType type) => type.element)
-              .where((await classes).contains)
-              .map((await classes).indexOf));
+        'int',
+        interfaceElement.interfaces
+            .map((InterfaceType type) => type.element)
+            .where((await classes).contains)
+            .map((await classes).indexOf),
+      );
     }
 
     String classMetadataCode;
     if (_capabilities._supportsMetadata) {
       classMetadataCode = await _extractMetadataCode(
-          interfaceElement, _resolver, importCollector, _generatedLibraryId);
+        interfaceElement,
+        _resolver,
+        importCollector,
+        _generatedLibraryId,
+      );
     } else {
       classMetadataCode = 'null';
     }
@@ -1540,14 +1689,15 @@ class _ReflectorDomain {
         ...classDomain._instanceMembers,
         ...classDomain._staticMembers,
       ];
-      parameterListShapesCode =
-          _formatAsMap(membersList.map((ExecutableElement element) {
-        // shape != null: every method must have its shape in `..shapeOf`.
-        ParameterListShape shape = parameterListShapeOf[element]!;
-        // index != null: every shape must be in `..Shapes`.
-        int index = parameterListShapes.indexOf(shape)!;
-        return "r'${element.name}': $index";
-      }));
+      parameterListShapesCode = _formatAsMap(
+        membersList.map((ExecutableElement element) {
+          // shape != null: every method must have its shape in `..shapeOf`.
+          ParameterListShape shape = parameterListShapeOf[element]!;
+          // index != null: every shape must be in `..Shapes`.
+          int index = parameterListShapes.indexOf(shape)!;
+          return "r'${element.name}': $index";
+        }),
+      );
     }
 
     if (interfaceElement.typeParameters.isEmpty) {
@@ -1576,7 +1726,10 @@ class _ReflectorDomain {
           (interfaceElement is MixinApplication &&
               !interfaceElement.isMixinApplication) ||
           !await _isImportable(
-              interfaceElement, _generatedLibraryId, _resolver)) {
+            interfaceElement,
+            _generatedLibraryId,
+            _resolver,
+          )) {
         // Note that this location is dead code until we get support for
         // anonymous mixin applications using type arguments as generic
         // classes (currently, no classes will pass the tests above). See
@@ -1590,7 +1743,9 @@ class _ReflectorDomain {
 
         // Add 'is checks' to [list], based on [interfaceElement].
         Future<void> helper(
-            List<String> list, InterfaceElement interfaceElement) async {
+          List<String> list,
+          InterfaceElement interfaceElement,
+        ) async {
           Iterable<InterfaceElement> subtypes =
               _world.subtypes[interfaceElement] ?? <InterfaceElement>[];
           for (var subtype in subtypes) {
@@ -1617,18 +1772,20 @@ class _ReflectorDomain {
         int indexOf(TypeParameterElement typeParameter) =>
             typeParameters.indexOf(typeParameter)! + typeParametersOffset;
         typeParameterIndices = _formatAsConstList(
-            'int',
-            interfaceElement.typeParameters
-                .where(typeParameters.items.contains)
-                .map(indexOf));
+          'int',
+          interfaceElement.typeParameters
+              .where(typeParameters.items.contains)
+              .map(indexOf),
+        );
       }
 
       int? dynamicReflectedTypeIndex = _dynamicTypeCodeIndex(
-          _typeForReflectable(interfaceElement),
-          await classes,
-          reflectedTypes,
-          reflectedTypesOffset,
-          typedefs);
+        _typeForReflectable(interfaceElement),
+        await classes,
+        reflectedTypes,
+        reflectedTypesOffset,
+        typedefs,
+      );
 
       return "r.GenericClassMirrorImpl(r'${classDomain._simpleName}', "
           "r'${_qualifiedName(interfaceElement)}', $descriptor, $classIndex, "
@@ -1643,23 +1800,25 @@ class _ReflectorDomain {
   }
 
   Future<String> _methodMirrorCode(
-      ExecutableElement element,
-      Enumerator<TopLevelVariableElement> topLevelVariables,
-      Enumerator<FieldElement> fields,
-      Enumerator<ExecutableElement> members,
-      Enumerator<ErasableDartType> reflectedTypes,
-      int reflectedTypesOffset,
-      Enumerator<ParameterElement> parameters,
-      _ImportCollector importCollector,
-      Map<FunctionType, int> typedefs,
-      bool reflectedTypeRequested) async {
+    ExecutableElement element,
+    Enumerator<TopLevelVariableElement> topLevelVariables,
+    Enumerator<FieldElement> fields,
+    Enumerator<ExecutableElement> members,
+    Enumerator<ErasableDartType> reflectedTypes,
+    int reflectedTypesOffset,
+    Enumerator<ParameterElement> parameters,
+    _ImportCollector importCollector,
+    Map<FunctionType, int> typedefs,
+    bool reflectedTypeRequested,
+  ) async {
     if (element is PropertyAccessorElement && element.isSynthetic) {
       // There is no type propagation, so we declare an `accessorElement`.
       PropertyAccessorElement accessorElement = element;
       PropertyInducingElement? variable = accessorElement.variable2;
-      int variableMirrorIndex = variable is TopLevelVariableElement
-          ? topLevelVariables.indexOf(variable)!
-          : variable is FieldElement
+      int variableMirrorIndex =
+          variable is TopLevelVariableElement
+              ? topLevelVariables.indexOf(variable)!
+              : variable is FieldElement
               ? fields.indexOf(variable)!
               : constants.noCapabilityIndex;
       int selfIndex = members.indexOf(accessorElement)! + fields.length;
@@ -1678,40 +1837,55 @@ class _ReflectorDomain {
       // getter or setter.
       int descriptor = _declarationDescriptor(element);
       int returnTypeIndex = await _computeReturnTypeIndex(element, descriptor);
-      int ownerIndex = (await _computeOwnerIndex(element, descriptor)) ??
+      int ownerIndex =
+          (await _computeOwnerIndex(element, descriptor)) ??
           constants.noCapabilityIndex;
       var reflectedTypeArgumentsOfReturnType = 'null';
       if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
         reflectedTypeArgumentsOfReturnType =
             await _computeReflectedTypeArguments(
-                element.returnType,
-                reflectedTypes,
-                reflectedTypesOffset,
-                importCollector,
-                typedefs);
+              element.returnType,
+              reflectedTypes,
+              reflectedTypesOffset,
+              importCollector,
+              typedefs,
+            );
       }
-      String parameterIndicesCode = _formatAsConstList('int',
-          element.parameters.map((ParameterElement parameterElement) {
-        return parameters.indexOf(parameterElement);
-      }));
+      String parameterIndicesCode = _formatAsConstList(
+        'int',
+        element.parameters.map((ParameterElement parameterElement) {
+          return parameters.indexOf(parameterElement);
+        }),
+      );
       int reflectedReturnTypeIndex = constants.noCapabilityIndex;
       if (reflectedTypeRequested) {
-        reflectedReturnTypeIndex = _typeCodeIndex(element.returnType,
-            await classes, reflectedTypes, reflectedTypesOffset, typedefs);
+        reflectedReturnTypeIndex = _typeCodeIndex(
+          element.returnType,
+          await classes,
+          reflectedTypes,
+          reflectedTypesOffset,
+          typedefs,
+        );
       }
       int dynamicReflectedReturnTypeIndex = constants.noCapabilityIndex;
       if (reflectedTypeRequested) {
         dynamicReflectedReturnTypeIndex = _dynamicTypeCodeIndex(
-            element.returnType,
-            await classes,
-            reflectedTypes,
-            reflectedTypesOffset,
-            typedefs);
+          element.returnType,
+          await classes,
+          reflectedTypes,
+          reflectedTypesOffset,
+          typedefs,
+        );
       }
-      String? metadataCode = _capabilities._supportsMetadata
-          ? await _extractMetadataCode(
-              element, _resolver, importCollector, _generatedLibraryId)
-          : null;
+      String? metadataCode =
+          _capabilities._supportsMetadata
+              ? await _extractMetadataCode(
+                element,
+                _resolver,
+                importCollector,
+                _generatedLibraryId,
+              )
+              : null;
       return "r.MethodMirrorImpl(r'${element.name}', $descriptor, "
           '$ownerIndex, $returnTypeIndex, $reflectedReturnTypeIndex, '
           '$dynamicReflectedReturnTypeIndex, '
@@ -1721,37 +1895,55 @@ class _ReflectorDomain {
   }
 
   Future<String> _topLevelVariableMirrorCode(
-      TopLevelVariableElement element,
-      Enumerator<ErasableDartType> reflectedTypes,
-      int reflectedTypesOffset,
-      _ImportCollector importCollector,
-      Map<FunctionType, int> typedefs,
-      bool reflectedTypeRequested) async {
+    TopLevelVariableElement element,
+    Enumerator<ErasableDartType> reflectedTypes,
+    int reflectedTypesOffset,
+    _ImportCollector importCollector,
+    Map<FunctionType, int> typedefs,
+    bool reflectedTypeRequested,
+  ) async {
     int descriptor = _topLevelVariableDescriptor(element);
     LibraryElement owner = element.library;
     int ownerIndex = _libraries.indexOf(owner) ?? constants.noCapabilityIndex;
     int classMirrorIndex = await _computeVariableTypeIndex(element, descriptor);
-    int? reflectedTypeIndex = reflectedTypeRequested
-        ? _typeCodeIndex(element.type, await classes, reflectedTypes,
-            reflectedTypesOffset, typedefs)
-        : constants.noCapabilityIndex;
-    int? dynamicReflectedTypeIndex = reflectedTypeRequested
-        ? _dynamicTypeCodeIndex(element.type, await classes, reflectedTypes,
-            reflectedTypesOffset, typedefs)
-        : constants.noCapabilityIndex;
+    int? reflectedTypeIndex =
+        reflectedTypeRequested
+            ? _typeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
+    int? dynamicReflectedTypeIndex =
+        reflectedTypeRequested
+            ? _dynamicTypeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
     var reflectedTypeArguments = 'null';
     if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
       reflectedTypeArguments = await _computeReflectedTypeArguments(
-          element.type,
-          reflectedTypes,
-          reflectedTypesOffset,
-          importCollector,
-          typedefs);
+        element.type,
+        reflectedTypes,
+        reflectedTypesOffset,
+        importCollector,
+        typedefs,
+      );
     }
     String? metadataCode;
     if (_capabilities._supportsMetadata) {
       metadataCode = await _extractMetadataCode(
-          element, _resolver, importCollector, _generatedLibraryId);
+        element,
+        _resolver,
+        importCollector,
+        _generatedLibraryId,
+      );
     } else {
       // We encode 'without capability' as `null` for metadata, because
       // it is a `List<Object>`, which has no other natural encoding.
@@ -1765,37 +1957,56 @@ class _ReflectorDomain {
   }
 
   Future<String> _fieldMirrorCode(
-      FieldElement element,
-      Enumerator<ErasableDartType> reflectedTypes,
-      int reflectedTypesOffset,
-      _ImportCollector importCollector,
-      Map<FunctionType, int> typedefs,
-      bool reflectedTypeRequested) async {
+    FieldElement element,
+    Enumerator<ErasableDartType> reflectedTypes,
+    int reflectedTypesOffset,
+    _ImportCollector importCollector,
+    Map<FunctionType, int> typedefs,
+    bool reflectedTypeRequested,
+  ) async {
     int descriptor = _fieldDescriptor(element);
-    int ownerIndex = (await classes).indexOf(element.enclosingElement) ??
+    int ownerIndex =
+        (await classes).indexOf(element.enclosingElement) ??
         constants.noCapabilityIndex;
     int classMirrorIndex = await _computeVariableTypeIndex(element, descriptor);
-    int reflectedTypeIndex = reflectedTypeRequested
-        ? _typeCodeIndex(element.type, await classes, reflectedTypes,
-            reflectedTypesOffset, typedefs)
-        : constants.noCapabilityIndex;
-    int dynamicReflectedTypeIndex = reflectedTypeRequested
-        ? _dynamicTypeCodeIndex(element.type, await classes, reflectedTypes,
-            reflectedTypesOffset, typedefs)
-        : constants.noCapabilityIndex;
+    int reflectedTypeIndex =
+        reflectedTypeRequested
+            ? _typeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
+    int dynamicReflectedTypeIndex =
+        reflectedTypeRequested
+            ? _dynamicTypeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
     var reflectedTypeArguments = 'null';
     if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
       reflectedTypeArguments = await _computeReflectedTypeArguments(
-          element.type,
-          reflectedTypes,
-          reflectedTypesOffset,
-          importCollector,
-          typedefs);
+        element.type,
+        reflectedTypes,
+        reflectedTypesOffset,
+        importCollector,
+        typedefs,
+      );
     }
     String? metadataCode;
     if (_capabilities._supportsMetadata) {
       metadataCode = await _extractMetadataCode(
-          element, _resolver, importCollector, _generatedLibraryId);
+        element,
+        _resolver,
+        importCollector,
+        _generatedLibraryId,
+      );
     } else {
       // We encode 'without capability' as `null` for metadata, because
       // it is a `List<Object>`, which has no other natural encoding.
@@ -1817,11 +2028,12 @@ class _ReflectorDomain {
   /// added to `ReflectorData.types` after the elements of [classes] have been
   /// added.
   int _typeCodeIndex(
-      DartType dartType,
-      _InterfaceElementEnhancedSet classes,
-      Enumerator<ErasableDartType> reflectedTypes,
-      int reflectedTypesOffset,
-      Map<FunctionType, int> typedefs) {
+    DartType dartType,
+    _InterfaceElementEnhancedSet classes,
+    Enumerator<ErasableDartType> reflectedTypes,
+    int reflectedTypesOffset,
+    Map<FunctionType, int> typedefs,
+  ) {
     // The types `dynamic` and `void` are handled via `...Attribute` bits.
     if (dartType is DynamicType) return constants.noCapabilityIndex;
     if (dartType is VoidType) return constants.noCapabilityIndex;
@@ -1869,11 +2081,12 @@ class _ReflectorDomain {
   /// [reflectedTypes], because the elements in there will be added to
   /// `ReflectorData.types` after the elements of [classes] have been added.
   int _dynamicTypeCodeIndex(
-      DartType dartType,
-      _InterfaceElementEnhancedSet classes,
-      Enumerator<ErasableDartType> reflectedTypes,
-      int reflectedTypesOffset,
-      Map<FunctionType, int> typedefs) {
+    DartType dartType,
+    _InterfaceElementEnhancedSet classes,
+    Enumerator<ErasableDartType> reflectedTypes,
+    int reflectedTypesOffset,
+    Map<FunctionType, int> typedefs,
+  ) {
     // The types `void` and `dynamic` are handled via the `...Attribute` bits.
     if (dartType is VoidType || dartType is DynamicType) {
       return constants.noCapabilityIndex;
@@ -1887,8 +2100,10 @@ class _ReflectorDomain {
       // and iff it has type arguments we must specify that it should be erased
       // (if there are no type arguments we will use "not erased": erasure
       // makes no difference and we don't want to have two identical copies).
-      var erasableDartType =
-          ErasableDartType(dartType, erased: dartType.typeArguments.isNotEmpty);
+      var erasableDartType = ErasableDartType(
+        dartType,
+        erased: dartType.typeArguments.isNotEmpty,
+      );
       reflectedTypes.add(erasableDartType);
       return reflectedTypes.indexOf(erasableDartType)! + reflectedTypesOffset;
     } else if (dartType is VoidType) {
@@ -1914,8 +2129,10 @@ class _ReflectorDomain {
   /// Returns true iff the given [type] is not and does not contain a free
   /// type variable. [typeVariablesInScope] gives the names of type variables
   /// which are in scope (and hence not free in the relevant context).
-  bool _hasNoFreeTypeVariables(DartType type,
-      [Set<String>? typeVariablesInScope]) {
+  bool _hasNoFreeTypeVariables(
+    DartType type, [
+    Set<String>? typeVariablesInScope,
+  ]) {
     if (type is TypeParameterType &&
         (typeVariablesInScope == null ||
             !typeVariablesInScope.contains(type.getDisplayString()))) {
@@ -1923,8 +2140,9 @@ class _ReflectorDomain {
     }
     if (type is InterfaceType) {
       if (type.typeArguments.isEmpty) return true;
-      return type.typeArguments
-          .every((type) => _hasNoFreeTypeVariables(type, typeVariablesInScope));
+      return type.typeArguments.every(
+        (type) => _hasNoFreeTypeVariables(type, typeVariablesInScope),
+      );
     }
     // Possible kinds of types at this point (apart from several types
     // indicating an error that we do not expect here): `BottomTypeImpl`,
@@ -1947,20 +2165,24 @@ class _ReflectorDomain {
   /// name or a fully spelled-out generic function type (and it has no
   /// effect when [dartType] is not a generic function type).
   Future<String> _typeCodeOfTypeArgument(
-      DartType dartType,
-      _ImportCollector importCollector,
-      Set<String> typeVariablesInScope,
-      Map<FunctionType, int> typedefs,
-      {bool useNameOfGenericFunctionType = true}) async {
+    DartType dartType,
+    _ImportCollector importCollector,
+    Set<String> typeVariablesInScope,
+    Map<FunctionType, int> typedefs, {
+    bool useNameOfGenericFunctionType = true,
+  }) async {
     Future<String> fail() async {
       InterfaceElement? element =
           dartType is InterfaceType ? dartType.element : null;
-      log.warning(await _formatDiagnosticMessage(
+      log.warning(
+        await _formatDiagnosticMessage(
           'Attempt to generate code for an '
           'unsupported kind of type: $dartType (${dartType.runtimeType}). '
           'Generating `dynamic`.',
           element,
-          _resolver));
+          _resolver,
+        ),
+      );
       return 'dynamic';
     }
 
@@ -1977,12 +2199,19 @@ class _ReflectorDomain {
         return '$prefix${interfaceElement.name}';
       } else {
         if (dartType.typeArguments.every(
-            (type) => _hasNoFreeTypeVariables(type, typeVariablesInScope))) {
+          (type) => _hasNoFreeTypeVariables(type, typeVariablesInScope),
+        )) {
           var argumentList = <String>[];
           for (DartType typeArgument in dartType.typeArguments) {
-            argumentList.add(await _typeCodeOfTypeArgument(
-                typeArgument, importCollector, typeVariablesInScope, typedefs,
-                useNameOfGenericFunctionType: useNameOfGenericFunctionType));
+            argumentList.add(
+              await _typeCodeOfTypeArgument(
+                typeArgument,
+                importCollector,
+                typeVariablesInScope,
+                typedefs,
+                useNameOfGenericFunctionType: useNameOfGenericFunctionType,
+              ),
+            );
           }
           String arguments = argumentList.join(', ');
           return '$prefix${interfaceElement.name}<$arguments>';
@@ -2002,44 +2231,64 @@ class _ReflectorDomain {
         if (dartType.typeFormals.isNotEmpty) {
           if (useNameOfGenericFunctionType) {
             // Requested: just the name of the typedef; get it and return.
-            int dartTypeNumber = typedefs.containsKey(dartType)
-                ? typedefs[dartType]!
-                : typedefNumber++;
+            int dartTypeNumber =
+                typedefs.containsKey(dartType)
+                    ? typedefs[dartType]!
+                    : typedefNumber++;
             return _typedefName(dartTypeNumber);
           } else {
             // Requested: the spelled-out generic function type; continue.
-            typeVariablesInScope
-                .addAll(dartType.typeFormals.map((element) => element.name));
+            typeVariablesInScope.addAll(
+              dartType.typeFormals.map((element) => element.name),
+            );
           }
         }
-        String returnType = await _typeCodeOfTypeArgument(dartType.returnType,
-            importCollector, typeVariablesInScope, typedefs,
-            useNameOfGenericFunctionType: useNameOfGenericFunctionType);
+        String returnType = await _typeCodeOfTypeArgument(
+          dartType.returnType,
+          importCollector,
+          typeVariablesInScope,
+          typedefs,
+          useNameOfGenericFunctionType: useNameOfGenericFunctionType,
+        );
         var typeArguments = '';
         if (dartType.typeFormals.isNotEmpty) {
           Iterable<String> typeArgumentList = dartType.typeFormals.map(
-              (TypeParameterElement typeParameter) => typeParameter.toString());
+            (TypeParameterElement typeParameter) => typeParameter.toString(),
+          );
           typeArguments = '<${typeArgumentList.join(', ')}>';
         }
         var argumentTypes = '';
         if (dartType.normalParameterTypes.isNotEmpty) {
           var normalParameterTypeList = <String>[];
           for (DartType parameterType in dartType.normalParameterTypes) {
-            normalParameterTypeList.add(await _typeCodeOfTypeArgument(
-                parameterType, importCollector, typeVariablesInScope, typedefs,
-                useNameOfGenericFunctionType: useNameOfGenericFunctionType));
+            normalParameterTypeList.add(
+              await _typeCodeOfTypeArgument(
+                parameterType,
+                importCollector,
+                typeVariablesInScope,
+                typedefs,
+                useNameOfGenericFunctionType: useNameOfGenericFunctionType,
+              ),
+            );
           }
           argumentTypes = normalParameterTypeList.join(', ');
         }
         if (dartType.optionalParameterTypes.isNotEmpty) {
           var optionalParameterTypeList = <String>[];
           for (DartType parameterType in dartType.optionalParameterTypes) {
-            optionalParameterTypeList.add(await _typeCodeOfTypeArgument(
-                parameterType, importCollector, typeVariablesInScope, typedefs,
-                useNameOfGenericFunctionType: useNameOfGenericFunctionType));
+            optionalParameterTypeList.add(
+              await _typeCodeOfTypeArgument(
+                parameterType,
+                importCollector,
+                typeVariablesInScope,
+                typedefs,
+                useNameOfGenericFunctionType: useNameOfGenericFunctionType,
+              ),
+            );
           }
           var connector = argumentTypes.isEmpty ? '' : ', ';
-          argumentTypes = '$argumentTypes$connector'
+          argumentTypes =
+              '$argumentTypes$connector'
               '[${optionalParameterTypeList.join(', ')}]';
         }
         if (dartType.namedParameterTypes.isNotEmpty) {
@@ -2048,12 +2297,17 @@ class _ReflectorDomain {
           for (String name in parameterMap.keys) {
             DartType parameterType = parameterMap[name]!;
             String typeCode = await _typeCodeOfTypeArgument(
-                parameterType, importCollector, typeVariablesInScope, typedefs,
-                useNameOfGenericFunctionType: useNameOfGenericFunctionType);
+              parameterType,
+              importCollector,
+              typeVariablesInScope,
+              typedefs,
+              useNameOfGenericFunctionType: useNameOfGenericFunctionType,
+            );
             namedParameterTypeList.add('$typeCode $name');
           }
           var connector = argumentTypes.isEmpty ? '' : ', ';
-          argumentTypes = '$argumentTypes$connector'
+          argumentTypes =
+              '$argumentTypes$connector'
               '{${namedParameterTypeList.join(', ')}}';
         }
         return '$returnType Function$typeArguments($argumentTypes)';
@@ -2071,8 +2325,11 @@ class _ReflectorDomain {
   /// evaluating the [typeDefiningElement] as an expression in the library
   /// where it occurs. [importCollector] is used to find the library prefixes
   /// needed in order to obtain values from other libraries.
-  Future<String> _typeCodeOfClass(DartType dartType,
-      _ImportCollector importCollector, Map<FunctionType, int> typedefs) async {
+  Future<String> _typeCodeOfClass(
+    DartType dartType,
+    _ImportCollector importCollector,
+    Map<FunctionType, int> typedefs,
+  ) async {
     var typeVariablesInScope = <String>{}; // None at this level.
     if (dartType is DynamicType) return 'dynamic';
     if (dartType is InterfaceType) {
@@ -2098,8 +2355,12 @@ class _ReflectorDomain {
       } else {
         if (dartType.typeArguments.every(_hasNoFreeTypeVariables)) {
           String typeArgumentCode = await _typeCodeOfTypeArgument(
-              dartType, importCollector, typeVariablesInScope, typedefs,
-              useNameOfGenericFunctionType: true);
+            dartType,
+            importCollector,
+            typeVariablesInScope,
+            typedefs,
+            useNameOfGenericFunctionType: true,
+          );
           return 'const m.TypeValue<$typeArgumentCode>().type';
         } else {
           String arguments = dartType.typeArguments
@@ -2124,23 +2385,34 @@ class _ReflectorDomain {
           // `dartType` is a generic function type, so we must use a
           // separately generated `typedef` to obtain a `Type` for it.
           return await _typeCodeOfTypeArgument(
-              dartType, importCollector, typeVariablesInScope, typedefs,
-              useNameOfGenericFunctionType: true);
+            dartType,
+            importCollector,
+            typeVariablesInScope,
+            typedefs,
+            useNameOfGenericFunctionType: true,
+          );
         } else {
           String typeArgumentCode = await _typeCodeOfTypeArgument(
-              dartType, importCollector, typeVariablesInScope, typedefs);
+            dartType,
+            importCollector,
+            typeVariablesInScope,
+            typedefs,
+          );
           return 'const m.TypeValue<$typeArgumentCode>().type';
         }
       }
     } else {
       InterfaceElement? element =
           dartType is InterfaceType ? dartType.element : null;
-      log.warning(await _formatDiagnosticMessage(
+      log.warning(
+        await _formatDiagnosticMessage(
           'Attempt to generate code for an '
           'unsupported kind of type: $dartType (${dartType.runtimeType}). '
           'Generating `dynamic`.',
           element,
-          _resolver));
+          _resolver,
+        ),
+      );
       return 'dynamic';
     }
   }
@@ -2152,11 +2424,14 @@ class _ReflectorDomain {
   /// that we get the fully dynamic instantiation if it is a generic class.
   /// [importCollector] is used to find the library prefixes needed in order
   /// to obtain values from other libraries.
-  String _dynamicTypeCodeOfClass(TypeDefiningElement typeDefiningElement,
-      _ImportCollector importCollector) {
-    DartType? type = typeDefiningElement is InterfaceElement
-        ? _typeForReflectable(typeDefiningElement)
-        : null;
+  String _dynamicTypeCodeOfClass(
+    TypeDefiningElement typeDefiningElement,
+    _ImportCollector importCollector,
+  ) {
+    DartType? type =
+        typeDefiningElement is InterfaceElement
+            ? _typeForReflectable(typeDefiningElement)
+            : null;
     if (type is DynamicType) return 'dynamic';
     if (type is InterfaceType) {
       InterfaceElement interfaceElement = type.element;
@@ -2180,34 +2455,38 @@ class _ReflectorDomain {
   }
 
   Future<String> _libraryMirrorCode(
-      _LibraryDomain libraryDomain,
-      int libraryIndex,
-      Enumerator<ExecutableElement> members,
-      Enumerator<ParameterListShape> parameterListShapes,
-      Map<ExecutableElement, ParameterListShape> parameterListShapeOf,
-      Enumerator<TopLevelVariableElement> variables,
-      int methodsOffset,
-      _ImportCollector importCollector) async {
+    _LibraryDomain libraryDomain,
+    int libraryIndex,
+    Enumerator<ExecutableElement> members,
+    Enumerator<ParameterListShape> parameterListShapes,
+    Map<ExecutableElement, ParameterListShape> parameterListShapeOf,
+    Enumerator<TopLevelVariableElement> variables,
+    int methodsOffset,
+    _ImportCollector importCollector,
+  ) async {
     LibraryElement library = libraryDomain._libraryElement;
 
     var gettersCodeList = <String>[];
     for (ExecutableElement getter in _gettersOfLibrary(libraryDomain)) {
       gettersCodeList.add(
-          await _topLevelGettingClosure(importCollector, library, getter.name));
+        await _topLevelGettingClosure(importCollector, library, getter.name),
+      );
     }
     String gettersCode = _formatAsMap(gettersCodeList);
 
     var settersCodeList = <String>[];
     for (PropertyAccessorElement setter in _settersOfLibrary(libraryDomain)) {
       settersCodeList.add(
-          await _topLevelSettingClosure(importCollector, library, setter.name));
+        await _topLevelSettingClosure(importCollector, library, setter.name),
+      );
     }
     String settersCode = _formatAsMap(settersCodeList);
 
     // Fields go first in [memberMirrors], so they will get the
     // same index as in [fields].
-    Iterable<int> variableIndices =
-        libraryDomain._declaredVariables.map((TopLevelVariableElement element) {
+    Iterable<int> variableIndices = libraryDomain._declaredVariables.map((
+      TopLevelVariableElement element,
+    ) {
       return variables.indexOf(element)!;
     });
 
@@ -2217,9 +2496,9 @@ class _ReflectorDomain {
     Iterable<int> methodIndices = libraryDomain._declarations
         .where(_executableIsntImplicitGetterOrSetter)
         .map((ExecutableElement element) {
-      int index = members.indexOf(element)!;
-      return index + methodsOffset;
-    });
+          int index = members.indexOf(element)!;
+          return index + methodsOffset;
+        });
 
     var declarationsCode = 'const <int>[${constants.noCapabilityIndex}]';
     if (_capabilities._impliesDeclarations) {
@@ -2252,7 +2531,11 @@ class _ReflectorDomain {
     String metadataCode;
     if (_capabilities._supportsMetadata) {
       metadataCode = await _extractMetadataCode(
-          library, _resolver, importCollector, _generatedLibraryId);
+        library,
+        _resolver,
+        importCollector,
+        _generatedLibraryId,
+      );
     } else {
       metadataCode = 'null';
     }
@@ -2260,13 +2543,14 @@ class _ReflectorDomain {
     var parameterListShapesCode = 'null';
     if (_capabilities._impliesParameterListShapes) {
       parameterListShapesCode = _formatAsMap(
-          libraryDomain._declarations.map((ExecutableElement element) {
-        // shape != null: every method has a shape in `..shapeOf`.
-        ParameterListShape shape = parameterListShapeOf[element]!;
-        // index != null: every shape is in `..Shapes`.
-        int index = parameterListShapes.indexOf(shape)!;
-        return "r'${element.name}': $index";
-      }));
+        libraryDomain._declarations.map((ExecutableElement element) {
+          // shape != null: every method has a shape in `..shapeOf`.
+          ParameterListShape shape = parameterListShapeOf[element]!;
+          // index != null: every shape is in `..Shapes`.
+          int index = parameterListShapes.indexOf(shape)!;
+          return "r'${element.name}': $index";
+        }),
+      );
     }
 
     return "r.LibraryMirrorImpl(r'${library.name}', $uriCode, "
@@ -2276,14 +2560,15 @@ class _ReflectorDomain {
   }
 
   Future<String> _parameterMirrorCode(
-      ParameterElement element,
-      Enumerator<FieldElement> fields,
-      Enumerator<ExecutableElement> members,
-      Enumerator<ErasableDartType> reflectedTypes,
-      int reflectedTypesOffset,
-      _ImportCollector importCollector,
-      Map<FunctionType, int> typedefs,
-      bool reflectedTypeRequested) async {
+    ParameterElement element,
+    Enumerator<FieldElement> fields,
+    Enumerator<ExecutableElement> members,
+    Enumerator<ErasableDartType> reflectedTypes,
+    int reflectedTypesOffset,
+    _ImportCollector importCollector,
+    Map<FunctionType, int> typedefs,
+    bool reflectedTypeRequested,
+  ) async {
     int descriptor = _parameterDescriptor(element);
     int ownerIndex =
         members.indexOf(element.enclosingElement!)! + fields.length;
@@ -2301,30 +2586,44 @@ class _ReflectorDomain {
         DartType elementType = element.type;
         if (elementType is InterfaceType) {
           InterfaceElement elementTypeElement = elementType.element;
-          classMirrorIndex = (await classes).contains(elementTypeElement)
-              ? (await classes).indexOf(elementTypeElement)!
-              : constants.noCapabilityIndex;
+          classMirrorIndex =
+              (await classes).contains(elementTypeElement)
+                  ? (await classes).indexOf(elementTypeElement)!
+                  : constants.noCapabilityIndex;
         } else {
           classMirrorIndex = constants.noCapabilityIndex;
         }
       }
     }
-    int reflectedTypeIndex = reflectedTypeRequested
-        ? _typeCodeIndex(element.type, await classes, reflectedTypes,
-            reflectedTypesOffset, typedefs)
-        : constants.noCapabilityIndex;
-    int dynamicReflectedTypeIndex = reflectedTypeRequested
-        ? _dynamicTypeCodeIndex(element.type, await classes, reflectedTypes,
-            reflectedTypesOffset, typedefs)
-        : constants.noCapabilityIndex;
+    int reflectedTypeIndex =
+        reflectedTypeRequested
+            ? _typeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
+    int dynamicReflectedTypeIndex =
+        reflectedTypeRequested
+            ? _dynamicTypeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
     var reflectedTypeArguments = 'null';
     if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
       reflectedTypeArguments = await _computeReflectedTypeArguments(
-          element.type,
-          reflectedTypes,
-          reflectedTypesOffset,
-          importCollector,
-          typedefs);
+        element.type,
+        reflectedTypes,
+        reflectedTypesOffset,
+        importCollector,
+        typedefs,
+      );
     }
     var metadataCode = 'null';
     if (_capabilities._supportsMetadata) {
@@ -2341,15 +2640,20 @@ class _ReflectorDomain {
           metadataCode = 'const []';
         } else {
           metadataCode = await _extractMetadataCode(
-              element, _resolver, importCollector, _generatedLibraryId);
+            element,
+            _resolver,
+            importCollector,
+            _generatedLibraryId,
+          );
         }
       }
     }
     String code = await _extractDefaultValueCode(importCollector, element);
     var defaultValueCode = code.isEmpty ? 'null' : code;
-    var parameterSymbolCode = descriptor & constants.namedAttribute != 0
-        ? '#${element.name}'
-        : 'null';
+    var parameterSymbolCode =
+        descriptor & constants.namedAttribute != 0
+            ? '#${element.name}'
+            : 'null';
 
     return "r.ParameterMirrorImpl(r'${element.name}', $descriptor, "
         '$ownerIndex, ${await _constConstructionCode(importCollector)}, '
@@ -2361,24 +2665,35 @@ class _ReflectorDomain {
   /// Given an [importCollector] and a [parameterElement], returns '' if there
   /// is no default value, otherwise returns code for an expression that
   /// evaluates to said default value.
-  Future<String> _extractDefaultValueCode(_ImportCollector importCollector,
-      ParameterElement parameterElement) async {
+  Future<String> _extractDefaultValueCode(
+    _ImportCollector importCollector,
+    ParameterElement parameterElement,
+  ) async {
     // TODO(eernst): 'dart:*' is not considered valid. To survive, we return
     // '' for all declarations from there. Issue 173.
     if (_isPlatformLibrary(parameterElement.library!)) return '';
-    var parameterNode = await _getDeclarationAst(parameterElement, _resolver)
-        as FormalParameter?;
+    var parameterNode =
+        await _getDeclarationAst(parameterElement, _resolver)
+            as FormalParameter?;
     // The node can be null because the declaration is synthetic, e.g.,
     // the parameter of an induced setter; they have no default value.
     if (parameterNode is DefaultFormalParameter &&
         parameterNode.defaultValue != null) {
-      return await _extractConstantCode(parameterNode.defaultValue!,
-          importCollector, _generatedLibraryId, _resolver);
+      return await _extractConstantCode(
+        parameterNode.defaultValue!,
+        importCollector,
+        _generatedLibraryId,
+        _resolver,
+      );
     } else if (parameterElement is DefaultFieldFormalParameterElementImpl) {
       Expression? defaultValue = parameterElement.constantInitializer;
       if (defaultValue != null) {
         return await _extractConstantCode(
-            defaultValue, importCollector, _generatedLibraryId, _resolver);
+          defaultValue,
+          importCollector,
+          _generatedLibraryId,
+          _resolver,
+        );
       }
     }
     return '';
@@ -2390,10 +2705,13 @@ DartType _typeForReflectable(InterfaceElement interfaceElement) {
   // so there is no need to handle type parameters/arguments. So we might
   // be able to improve performance by working on classes as such.
   var typeArguments = List<DartType>.filled(
-      interfaceElement.typeParameters.length,
-      interfaceElement.library.typeProvider.dynamicType);
+    interfaceElement.typeParameters.length,
+    interfaceElement.library.typeProvider.dynamicType,
+  );
   return interfaceElement.instantiate(
-      typeArguments: typeArguments, nullabilitySuffix: NullabilitySuffix.star);
+    typeArguments: typeArguments,
+    nullabilitySuffix: NullabilitySuffix.star,
+  );
 }
 
 /// Auxiliary class used by `classes`. Its `expand` method expands
@@ -2406,7 +2724,8 @@ class _SubtypesFixedPoint extends FixedPoint<InterfaceElement> {
   /// Returns all the immediate subtypes of the given [classMirror].
   @override
   Future<Iterable<InterfaceElement>> successors(
-      final InterfaceElement interfaceElement) async {
+    final InterfaceElement interfaceElement,
+  ) async {
     Iterable<InterfaceElement>? interfaceElements = subtypes[interfaceElement];
     return interfaceElements ?? <InterfaceElement>[];
   }
@@ -2433,7 +2752,8 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement> {
   /// we may or may not wish to enforce the bounds even for mixins.
   @override
   Future<Iterable<InterfaceElement>> successors(
-      InterfaceElement element) async {
+    InterfaceElement element,
+  ) async {
     // A mixin application is handled by its regular subclasses.
     if (element is MixinApplication) return [];
     // If upper bounds not satisfied then there are no successors.
@@ -2467,13 +2787,19 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement> {
       if (mixinsRequested) result.add(mixinClass);
       InterfaceElement? subClass =
           mixin == element.mixins.last ? element : null;
-      String? name = subClass == null
-          ? null
-          : (element is MixinApplication && element.isMixinApplication
-              ? element.name
-              : null);
+      String? name =
+          subClass == null
+              ? null
+              : (element is MixinApplication && element.isMixinApplication
+                  ? element.name
+                  : null);
       InterfaceElement mixinApplication = MixinApplication(
-          name, superclass, mixinClass, element.library, subClass);
+        name,
+        superclass,
+        mixinClass,
+        element.library,
+        subClass,
+      );
       // We have already ensured that `workingSuperclass` is a
       // subclass of a bound (if any); the value of `superclass` is
       // either `workingSuperclass` or one of its superclasses created
@@ -2511,7 +2837,8 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement> {
 /// Auxiliary function used by `classes`. Its `expand` method
 /// expands its argument to a fixed point, based on the `successors` method.
 Set<InterfaceElement> _mixinApplicationsOfClasses(
-    Set<InterfaceElement> classes) {
+  Set<InterfaceElement> classes,
+) {
   var mixinApplications = <InterfaceElement>{};
   for (InterfaceElement interfaceElement in classes) {
     // Mixin-applications are handled when they are created.
@@ -2529,14 +2856,20 @@ Set<InterfaceElement> _mixinApplicationsOfClasses(
       InterfaceElement mixinClass = mixin.element;
       InterfaceElement? subClass =
           mixin == interfaceElement.mixins.last ? interfaceElement : null;
-      String? name = subClass == null
-          ? null
-          : (interfaceElement is MixinApplication &&
-                  interfaceElement.isMixinApplication
-              ? interfaceElement.name
-              : null);
+      String? name =
+          subClass == null
+              ? null
+              : (interfaceElement is MixinApplication &&
+                      interfaceElement.isMixinApplication
+                  ? interfaceElement.name
+                  : null);
       InterfaceElement mixinApplication = MixinApplication(
-          name, superclass, mixinClass, interfaceElement.library, subClass);
+        name,
+        superclass,
+        mixinClass,
+        interfaceElement.library,
+        subClass,
+      );
       mixinApplications.add(mixinApplication);
       superclass = mixinApplication;
     }
@@ -2559,13 +2892,17 @@ class _AnnotationClassFixedPoint extends FixedPoint<InterfaceElement> {
   final _ElementToDomain elementToDomain;
 
   _AnnotationClassFixedPoint(
-      this.resolver, this.generatedLibraryId, this.elementToDomain);
+    this.resolver,
+    this.generatedLibraryId,
+    this.elementToDomain,
+  );
 
   /// Returns the classes that occur as return types of covered methods or in
   /// type annotations of covered variables and parameters of covered methods,
   @override
   Future<Iterable<InterfaceElement>> successors(
-      InterfaceElement interfaceElement) async {
+    InterfaceElement interfaceElement,
+  ) async {
     if (!await _isImportable(interfaceElement, generatedLibraryId, resolver)) {
       return [];
     }
@@ -2643,8 +2980,11 @@ String _settingClosure(String setterName) {
 }
 
 // Auxiliary function used by `_generateCode`.
-Future<String> _staticGettingClosure(_ImportCollector importCollector,
-    InterfaceElement interfaceElement, String getterName) async {
+Future<String> _staticGettingClosure(
+  _ImportCollector importCollector,
+  InterfaceElement interfaceElement,
+  String getterName,
+) async {
   String className = interfaceElement.name;
   String prefix = importCollector._getPrefix(interfaceElement.library);
   // Operators cannot be static.
@@ -2658,8 +2998,11 @@ Future<String> _staticGettingClosure(_ImportCollector importCollector,
 }
 
 // Auxiliary function used by `_generateCode`.
-Future<String> _staticSettingClosure(_ImportCollector importCollector,
-    InterfaceElement interfaceElement, String setterName) async {
+Future<String> _staticSettingClosure(
+  _ImportCollector importCollector,
+  InterfaceElement interfaceElement,
+  String setterName,
+) async {
   assert(setterName.substring(setterName.length - 1) == '=');
   // The [setterName] includes the '=', remove it.
   String name = setterName.substring(0, setterName.length - 1);
@@ -2675,8 +3018,11 @@ Future<String> _staticSettingClosure(_ImportCollector importCollector,
 }
 
 // Auxiliary function used by `_generateCode`.
-Future<String> _topLevelGettingClosure(_ImportCollector importCollector,
-    LibraryElement library, String getterName) async {
+Future<String> _topLevelGettingClosure(
+  _ImportCollector importCollector,
+  LibraryElement library,
+  String getterName,
+) async {
   String prefix = importCollector._getPrefix(library);
   // Operators cannot be top-level.
   if (_isPrivateName(getterName)) {
@@ -2686,8 +3032,11 @@ Future<String> _topLevelGettingClosure(_ImportCollector importCollector,
 }
 
 // Auxiliary function used by `_generateCode`.
-Future<String> _topLevelSettingClosure(_ImportCollector importCollector,
-    LibraryElement library, String setterName) async {
+Future<String> _topLevelSettingClosure(
+  _ImportCollector importCollector,
+  LibraryElement library,
+  String setterName,
+) async {
   assert(setterName.substring(setterName.length - 1) == '=');
   // The [setterName] includes the '=', remove it.
   String name = setterName.substring(0, setterName.length - 1);
@@ -2731,12 +3080,13 @@ class _LibraryDomain {
   final _ReflectorDomain _reflectorDomain;
 
   _LibraryDomain(
-      this._libraryElement,
-      this._declaredVariables,
-      this._declaredFunctions,
-      this._declaredParameters,
-      this._accessors,
-      this._reflectorDomain);
+    this._libraryElement,
+    this._declaredVariables,
+    this._declaredFunctions,
+    this._declaredParameters,
+    this._accessors,
+    this._reflectorDomain,
+  );
 
   /// Returns the declared methods, accessors and constructors in
   /// [_interfaceElement]. Note that this includes synthetic getters and
@@ -2744,9 +3094,9 @@ class _LibraryDomain {
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
   Iterable<ExecutableElement> get _declarations => [
-        ..._declaredFunctions,
-        ..._accessors,
-      ];
+    ..._declaredFunctions,
+    ..._accessors,
+  ];
 
   @override
   String toString() {
@@ -2802,13 +3152,14 @@ class _ClassDomain {
   final _ReflectorDomain _reflectorDomain;
 
   _ClassDomain(
-      this._interfaceElement,
-      this._declaredFields,
-      this._declaredMethods,
-      this._declaredParameters,
-      this._accessors,
-      this._constructors,
-      this._reflectorDomain);
+    this._interfaceElement,
+    this._declaredFields,
+    this._declaredMethods,
+    this._declaredParameters,
+    this._accessors,
+    this._constructors,
+    this._reflectorDomain,
+  );
 
   String get _simpleName {
     // TODO(eernst) clarify: Decide whether this should be simplified
@@ -2847,11 +3198,11 @@ class _ClassDomain {
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
   Iterable<ExecutableElement> get _declarations => [
-        // TODO(sigurdm) feature: Include type variables (if we keep them).
-        ..._declaredMethods,
-        ..._accessors,
-        ..._constructors,
-      ];
+    // TODO(sigurdm) feature: Include type variables (if we keep them).
+    ..._declaredMethods,
+    ..._accessors,
+    ..._constructors,
+  ];
 
   /// Finds all instance members by going through the class hierarchy.
   Iterable<ExecutableElement> get _instanceMembers {
@@ -2879,7 +3230,11 @@ class _ClassDomain {
           getterMetadata = correspondingGetter?.metadata;
         }
         if (_reflectorDomain._capabilities.supportsInstanceInvoke(
-            member.library.typeSystem, member.name, metadata, getterMetadata)) {
+          member.library.typeSystem,
+          member.name,
+          metadata,
+          getterMetadata,
+        )) {
           result[name] = member;
         }
       }
@@ -2895,7 +3250,8 @@ class _ClassDomain {
       }
 
       Map<String, ExecutableElement> cacheResult(
-          Map<String, ExecutableElement> result) {
+        Map<String, ExecutableElement> result,
+      ) {
         result = Map.unmodifiable(result);
         _reflectorDomain._instanceMemberCache[interfaceElement] = result;
         return result;
@@ -2941,7 +3297,11 @@ class _ClassDomain {
       if (method.isStatic &&
           !method.isPrivate &&
           _reflectorDomain._capabilities.supportsStaticInvoke(
-              method.library.typeSystem, method.name, method.metadata, null)) {
+            method.library.typeSystem,
+            method.name,
+            method.metadata,
+            null,
+          )) {
         result.add(method);
       }
     }
@@ -2950,9 +3310,10 @@ class _ClassDomain {
       if (!accessor.isStatic || accessor.isPrivate) return;
       // If [member] is a synthetic accessor created from a field, search for
       // the metadata on the original field.
-      List<ElementAnnotation> metadata = accessor.isSynthetic
-          ? (accessor.variable2?.metadata ?? const <ElementAnnotation>[])
-          : accessor.metadata;
+      List<ElementAnnotation> metadata =
+          accessor.isSynthetic
+              ? (accessor.variable2?.metadata ?? const <ElementAnnotation>[])
+              : accessor.metadata;
       List<ElementAnnotation>? getterMetadata;
       if (_reflectorDomain._capabilities._impliesCorrespondingSetters &&
           accessor.isSetter &&
@@ -2962,10 +3323,11 @@ class _ClassDomain {
         getterMetadata = correspondingGetter?.metadata;
       }
       if (_reflectorDomain._capabilities.supportsStaticInvoke(
-          accessor.library.typeSystem,
-          accessor.name,
-          metadata,
-          getterMetadata)) {
+        accessor.library.typeSystem,
+        accessor.name,
+        metadata,
+        getterMetadata,
+      )) {
         result.add(accessor);
       }
     }
@@ -2993,9 +3355,10 @@ class _Capabilities {
   }
 
   bool _supportsMeta(
-      TypeSystem typeSystem,
-      ec.MetadataQuantifiedCapability capability,
-      Iterable<DartObject>? metadata) {
+    TypeSystem typeSystem,
+    ec.MetadataQuantifiedCapability capability,
+    Iterable<DartObject>? metadata,
+  ) {
     if (metadata == null) return false;
     var result = false;
     DartType capabilityType = _typeForReflectable(capability.metadataType);
@@ -3009,11 +3372,12 @@ class _Capabilities {
   }
 
   bool _supportsInstanceInvoke(
-      TypeSystem typeSystem,
-      List<ec.ReflectCapability> capabilities,
-      String methodName,
-      Iterable<DartObject> metadata,
-      Iterable<DartObject>? getterMetadata) {
+    TypeSystem typeSystem,
+    List<ec.ReflectCapability> capabilities,
+    String methodName,
+    Iterable<DartObject> metadata,
+    Iterable<DartObject>? getterMetadata,
+  ) {
     for (ec.ReflectCapability capability in capabilities) {
       // Handle API based capabilities.
       if (capability is ec.InstanceInvokeCapability &&
@@ -3031,8 +3395,13 @@ class _Capabilities {
 
     // Check if we can retry, using the corresponding getter.
     if (_isSetterName(methodName) && getterMetadata != null) {
-      return _supportsInstanceInvoke(typeSystem, capabilities,
-          _setterNameToGetterName(methodName), getterMetadata, null);
+      return _supportsInstanceInvoke(
+        typeSystem,
+        capabilities,
+        _setterNameToGetterName(methodName),
+        getterMetadata,
+        null,
+      );
     }
 
     // All options exhausted, give up.
@@ -3040,10 +3409,11 @@ class _Capabilities {
   }
 
   bool _supportsNewInstance(
-      TypeSystem typeSystem,
-      Iterable<ec.ReflectCapability> capabilities,
-      String constructorName,
-      Iterable<DartObject> metadata) {
+    TypeSystem typeSystem,
+    Iterable<ec.ReflectCapability> capabilities,
+    String constructorName,
+    Iterable<DartObject> metadata,
+  ) {
     for (ec.ReflectCapability capability in capabilities) {
       // Handle API based capabilities.
       if (capability is ec.NamePatternCapability) {
@@ -3072,34 +3442,42 @@ class _Capabilities {
   // TODO(sigurdm) future: Find a way to cache these. Perhaps take an
   // element instead of name+metadata.
   bool supportsInstanceInvoke(
-      TypeSystem typeSystem,
-      String methodName,
-      Iterable<ElementAnnotation> metadata,
-      Iterable<ElementAnnotation>? getterMetadata) {
+    TypeSystem typeSystem,
+    String methodName,
+    Iterable<ElementAnnotation> metadata,
+    Iterable<ElementAnnotation>? getterMetadata,
+  ) {
     return _supportsInstanceInvoke(
-        typeSystem,
-        _capabilities,
-        methodName,
-        _getEvaluatedMetadata(metadata),
-        getterMetadata == null ? null : _getEvaluatedMetadata(getterMetadata));
+      typeSystem,
+      _capabilities,
+      methodName,
+      _getEvaluatedMetadata(metadata),
+      getterMetadata == null ? null : _getEvaluatedMetadata(getterMetadata),
+    );
   }
 
   bool supportsNewInstance(
-      TypeSystem typeSystem,
-      String constructorName,
-      Iterable<ElementAnnotation> metadata,
-      LibraryElement libraryElement,
-      Resolver resolver) {
-    return _supportsNewInstance(typeSystem, _capabilities, constructorName,
-        _getEvaluatedMetadata(metadata));
+    TypeSystem typeSystem,
+    String constructorName,
+    Iterable<ElementAnnotation> metadata,
+    LibraryElement libraryElement,
+    Resolver resolver,
+  ) {
+    return _supportsNewInstance(
+      typeSystem,
+      _capabilities,
+      constructorName,
+      _getEvaluatedMetadata(metadata),
+    );
   }
 
   bool _supportsTopLevelInvoke(
-      TypeSystem typeSystem,
-      List<ec.ReflectCapability> capabilities,
-      String methodName,
-      Iterable<DartObject> metadata,
-      Iterable<DartObject>? getterMetadata) {
+    TypeSystem typeSystem,
+    List<ec.ReflectCapability> capabilities,
+    String methodName,
+    Iterable<DartObject> metadata,
+    Iterable<DartObject>? getterMetadata,
+  ) {
     for (ec.ReflectCapability capability in capabilities) {
       // Handle API based capabilities.
       if ((capability is ec.TopLevelInvokeCapability) &&
@@ -3116,8 +3494,13 @@ class _Capabilities {
 
     // Check if we can retry, using the corresponding getter.
     if (_isSetterName(methodName) && getterMetadata != null) {
-      return _supportsTopLevelInvoke(typeSystem, capabilities,
-          _setterNameToGetterName(methodName), getterMetadata, null);
+      return _supportsTopLevelInvoke(
+        typeSystem,
+        capabilities,
+        _setterNameToGetterName(methodName),
+        getterMetadata,
+        null,
+      );
     }
 
     // All options exhausted, give up.
@@ -3125,11 +3508,12 @@ class _Capabilities {
   }
 
   bool _supportsStaticInvoke(
-      TypeSystem typeSystem,
-      List<ec.ReflectCapability> capabilities,
-      String methodName,
-      Iterable<DartObject> metadata,
-      Iterable<DartObject>? getterMetadata) {
+    TypeSystem typeSystem,
+    List<ec.ReflectCapability> capabilities,
+    String methodName,
+    Iterable<DartObject> metadata,
+    Iterable<DartObject>? getterMetadata,
+  ) {
     for (ec.ReflectCapability capability in capabilities) {
       // Handle API based capabilities.
       if (capability is ec.StaticInvokeCapability &&
@@ -3147,8 +3531,13 @@ class _Capabilities {
 
     // Check if we can retry, using the corresponding getter.
     if (_isSetterName(methodName) && getterMetadata != null) {
-      return _supportsStaticInvoke(typeSystem, capabilities,
-          _setterNameToGetterName(methodName), getterMetadata, null);
+      return _supportsStaticInvoke(
+        typeSystem,
+        capabilities,
+        _setterNameToGetterName(methodName),
+        getterMetadata,
+        null,
+      );
     }
 
     // All options exhausted, give up.
@@ -3156,36 +3545,42 @@ class _Capabilities {
   }
 
   bool supportsTopLevelInvoke(
-      TypeSystem typeSystem,
-      String methodName,
-      Iterable<ElementAnnotation> metadata,
-      Iterable<ElementAnnotation>? getterMetadata) {
+    TypeSystem typeSystem,
+    String methodName,
+    Iterable<ElementAnnotation> metadata,
+    Iterable<ElementAnnotation>? getterMetadata,
+  ) {
     return _supportsTopLevelInvoke(
-        typeSystem,
-        _capabilities,
-        methodName,
-        _getEvaluatedMetadata(metadata),
-        getterMetadata == null ? null : _getEvaluatedMetadata(getterMetadata));
+      typeSystem,
+      _capabilities,
+      methodName,
+      _getEvaluatedMetadata(metadata),
+      getterMetadata == null ? null : _getEvaluatedMetadata(getterMetadata),
+    );
   }
 
   bool supportsStaticInvoke(
-      TypeSystem typeSystem,
-      String methodName,
-      Iterable<ElementAnnotation> metadata,
-      Iterable<ElementAnnotation>? getterMetadata) {
+    TypeSystem typeSystem,
+    String methodName,
+    Iterable<ElementAnnotation> metadata,
+    Iterable<ElementAnnotation>? getterMetadata,
+  ) {
     return _supportsStaticInvoke(
-        typeSystem,
-        _capabilities,
-        methodName,
-        _getEvaluatedMetadata(metadata),
-        getterMetadata == null ? null : _getEvaluatedMetadata(getterMetadata));
+      typeSystem,
+      _capabilities,
+      methodName,
+      _getEvaluatedMetadata(metadata),
+      getterMetadata == null ? null : _getEvaluatedMetadata(getterMetadata),
+    );
   }
 
   late final bool _supportsMetadata = _capabilities.any(
-      (ec.ReflectCapability capability) => capability is ec.MetadataCapability);
+    (ec.ReflectCapability capability) => capability is ec.MetadataCapability,
+  );
 
-  late final bool _supportsUri = _capabilities
-      .any((ec.ReflectCapability capability) => capability is ec.UriCapability);
+  late final bool _supportsUri = _capabilities.any(
+    (ec.ReflectCapability capability) => capability is ec.UriCapability,
+  );
 
   /// Returns [true] iff these [Capabilities] specify reflection support
   /// where the set of classes must be downwards closed, i.e., extra classes
@@ -3193,16 +3588,18 @@ class _Capabilities {
   /// metadata and global quantifiers, such that coverage on a class `C`
   /// implies coverage of every class `D` such that `D` is a subtype of `C`.
   late final bool _impliesDownwardsClosure = _capabilities.any(
-      (ec.ReflectCapability capability) =>
-          capability == ec.subtypeQuantifyCapability);
+    (ec.ReflectCapability capability) =>
+        capability == ec.subtypeQuantifyCapability,
+  );
 
   /// Returns [true] iff these [Capabilities] specify reflection support where
   /// the set of included classes must be upwards closed, i.e., extra classes
   /// must be added beyond the ones that are directly included as reflectable
   /// because we must support operations like `superclass`.
   late final bool _impliesUpwardsClosure = _capabilities.any(
-      (ec.ReflectCapability capability) =>
-          capability is ec.SuperclassQuantifyCapability);
+    (ec.ReflectCapability capability) =>
+        capability is ec.SuperclassQuantifyCapability,
+  );
 
   /// Returns [true] iff these [Capabilities] specify that classes which have
   /// been used for mixin application for an included class must themselves
@@ -3215,8 +3612,9 @@ class _Capabilities {
   /// be included (if you have `class B extends A with M ..` then the class `M`
   /// will be included if `_impliesMixins`).
   late final bool _impliesTypeRelations = _capabilities.any(
-      (ec.ReflectCapability capability) =>
-          capability is ec.TypeRelationsCapability);
+    (ec.ReflectCapability capability) =>
+        capability is ec.TypeRelationsCapability,
+  );
 
   /// Returns [true] iff these [Capabilities] specify that type annotations
   /// modeled by mirrors should also get support for their base level [Type]
@@ -3224,8 +3622,9 @@ class _Capabilities {
   /// The relevant kinds of mirrors are variable mirrors, parameter mirrors,
   /// and (for the return type) method mirrors.
   late final bool _impliesReflectedType = _capabilities.any(
-      (ec.ReflectCapability capability) =>
-          capability == ec.reflectedTypeCapability);
+    (ec.ReflectCapability capability) =>
+        capability == ec.reflectedTypeCapability,
+  );
 
   /// Maps each upper bound specified for the upwards closure to whether the
   /// bound itself is excluded, as indicated by `excludeUpperBound` in the
@@ -3242,21 +3641,25 @@ class _Capabilities {
         if (element is InterfaceElement) {
           result[element] = capability.excludeUpperBound;
         } else {
-          await _severe('Unexpected kind of upper bound specified '
-              'for a `SuperclassQuantifyCapability`: $element.');
+          await _severe(
+            'Unexpected kind of upper bound specified '
+            'for a `SuperclassQuantifyCapability`: $element.',
+          );
         }
       }
     }
     return result;
   }
 
-  late final bool _impliesDeclarations =
-      _capabilities.any((ec.ReflectCapability capability) {
+  late final bool _impliesDeclarations = _capabilities.any((
+    ec.ReflectCapability capability,
+  ) {
     return capability is ec.DeclarationsCapability;
   });
 
-  late final bool _impliesMemberSymbols =
-      _capabilities.any((ec.ReflectCapability capability) {
+  late final bool _impliesMemberSymbols = _capabilities.any((
+    ec.ReflectCapability capability,
+  ) {
     return capability == ec.delegateCapability;
   });
 
@@ -3270,8 +3673,9 @@ class _Capabilities {
     return !_impliesDeclarations;
   }
 
-  late final bool _impliesTypes =
-      _capabilities.any((ec.ReflectCapability capability) {
+  late final bool _impliesTypes = _capabilities.any((
+    ec.ReflectCapability capability,
+  ) {
     return capability is ec.TypeCapability;
   });
 
@@ -3283,27 +3687,32 @@ class _Capabilities {
   /// they are simply absent if there are no class mirrors (so we cannot call
   /// them and then get a "cannot do this without a class mirror" error in the
   /// implementation).
-  late final bool _impliesInstanceInvoke =
-      _capabilities.any((ec.ReflectCapability capability) {
+  late final bool _impliesInstanceInvoke = _capabilities.any((
+    ec.ReflectCapability capability,
+  ) {
     return capability is ec.InstanceInvokeCapability ||
         capability is ec.InstanceInvokeMetaCapability;
   });
 
   late final bool _impliesTypeAnnotations = _capabilities.any(
-      (ec.ReflectCapability capability) =>
-          capability is ec.TypeAnnotationQuantifyCapability);
+    (ec.ReflectCapability capability) =>
+        capability is ec.TypeAnnotationQuantifyCapability,
+  );
 
   late final bool _impliesTypeAnnotationClosure = _capabilities.any(
-      (ec.ReflectCapability capability) =>
-          capability is ec.TypeAnnotationQuantifyCapability &&
-          capability.transitive == true);
+    (ec.ReflectCapability capability) =>
+        capability is ec.TypeAnnotationQuantifyCapability &&
+        capability.transitive == true,
+  );
 
   late final bool _impliesCorrespondingSetters = _capabilities.any(
-      (ec.ReflectCapability capability) =>
-          capability == ec.correspondingSetterQuantifyCapability);
+    (ec.ReflectCapability capability) =>
+        capability == ec.correspondingSetterQuantifyCapability,
+  );
 
   late final bool _supportsLibraries = _capabilities.any(
-      (ec.ReflectCapability capability) => capability is ec.LibraryCapability);
+    (ec.ReflectCapability capability) => capability is ec.LibraryCapability,
+  );
 }
 
 /// Collects the libraries that needs to be imported, and gives each library
@@ -3403,7 +3812,8 @@ class BuilderImplementation {
   /// Returns the InterfaceElement in the target program which corresponds to class
   /// [Reflectable].
   Future<InterfaceElement?> _findReflectableInterfaceElement(
-      LibraryElement reflectableLibrary) async {
+    LibraryElement reflectableLibrary,
+  ) async {
     for (CompilationUnitElement unit in reflectableLibrary.units) {
       for (InterfaceElement type in unit.classes) {
         if (type.name == reflectable_class_constants.name &&
@@ -3419,7 +3829,9 @@ class BuilderImplementation {
 
   /// Returns true iff [possibleSubtype] is a direct subclass of [type].
   bool _isDirectSubclassOf(
-      ParameterizedType possibleSubtype, InterfaceType type) {
+    ParameterizedType possibleSubtype,
+    InterfaceType type,
+  ) {
     if (possibleSubtype is InterfaceType) {
       InterfaceType? superclass = possibleSubtype.superclass;
       // Even if `superclass == null` (superclass of Object), the equality
@@ -3446,7 +3858,9 @@ class BuilderImplementation {
   /// of [focusClass] which is not a direct subclass of [focusClass],
   /// because such a class is not supported as a Reflector.
   Future<InterfaceElement?> _getReflectableAnnotation(
-      ElementAnnotation elementAnnotation, InterfaceElement focusClass) async {
+    ElementAnnotation elementAnnotation,
+    InterfaceElement focusClass,
+  ) async {
     if (elementAnnotation.element == null) {
       // This behavior is based on the assumption that a `null` element means
       // "there is no annotation here".
@@ -3458,7 +3872,9 @@ class BuilderImplementation {
     /// which is intended to refer to the class Reflectable defined
     /// in package:reflectable/reflectable.dart.
     Future<bool> checkInheritance(
-        ParameterizedType type, InterfaceType classReflectable) async {
+      ParameterizedType type,
+      InterfaceType classReflectable,
+    ) async {
       if (!_isSubclassOf(type, classReflectable)) {
         // Not a subclass of [classReflectable] at all.
         return false;
@@ -3467,7 +3883,9 @@ class BuilderImplementation {
         // Instance of [classReflectable], or of indirect subclass
         // of [classReflectable]: Not supported, report an error.
         await _severe(
-            errors.metadataNotDirectSubclass, elementAnnotation.element);
+          errors.metadataNotDirectSubclass,
+          elementAnnotation.element,
+        );
         return false;
       }
       // A direct subclass of [classReflectable], all OK.
@@ -3478,7 +3896,8 @@ class BuilderImplementation {
     if (element is ConstructorElement) {
       DartType enclosingType = _typeForReflectable(element.enclosingElement);
       DartType focusClassType = _typeForReflectable(focusClass);
-      bool isOk = enclosingType is ParameterizedType &&
+      bool isOk =
+          enclosingType is ParameterizedType &&
           focusClassType is InterfaceType &&
           await checkInheritance(enclosingType, focusClassType);
       if (isOk) {
@@ -3503,7 +3922,8 @@ class BuilderImplementation {
       if (constantValue == null) return null;
       DartType? constantValueType = constantValue.type;
       DartType focusClassType = _typeForReflectable(focusClass);
-      bool isOk = constantValueType is ParameterizedType &&
+      bool isOk =
+          constantValueType is ParameterizedType &&
           focusClassType is InterfaceType &&
           await checkInheritance(constantValueType, focusClassType);
       // When `isOK` is true, result.value.type.element is a InterfaceElement.
@@ -3519,16 +3939,20 @@ class BuilderImplementation {
     }
     // Otherwise [element] is some other construct which is not supported.
     await _fine(
-        'Ignoring metadata in a form ($elementAnnotation) '
-        'which is not yet supported.',
-        elementAnnotation.element);
+      'Ignoring metadata in a form ($elementAnnotation) '
+      'which is not yet supported.',
+      elementAnnotation.element,
+    );
     return null;
   }
 
   /// Adds a warning to the log, using the source code location of `target`
   /// to identify the relevant location where the error occurs.
-  Future<void> _warn(WarningKind kind, String message,
-      [Element? target]) async {
+  Future<void> _warn(
+    WarningKind kind,
+    String message, [
+    Element? target,
+  ]) async {
     if (_warningEnabled(kind)) {
       if (target != null) {
         log.warning(await _formatDiagnosticMessage(message, target, _resolver));
@@ -3542,8 +3966,9 @@ class BuilderImplementation {
   /// annotations on imports of [reflectableLibrary], and record the arguments
   /// of these annotations by modifying [globalPatterns] and [globalMetadata].
   Future<void> _findGlobalQuantifyAnnotations(
-      Map<RegExp, List<InterfaceElement>> globalPatterns,
-      Map<InterfaceElement, List<InterfaceElement>> globalMetadata) async {
+    Map<RegExp, List<InterfaceElement>> globalPatterns,
+    Map<InterfaceElement, List<InterfaceElement>> globalMetadata,
+  ) async {
     LibraryElement reflectableLibrary =
         _librariesByName['reflectable.reflectable']!;
     LibraryElement capabilityLibrary =
@@ -3552,9 +3977,10 @@ class BuilderImplementation {
     InterfaceType typeType = reflectableLibrary.typeProvider.typeType;
     InterfaceElement typeTypeClass = typeType.element;
 
-    ConstructorElement globalQuantifyCapabilityConstructor = capabilityLibrary
-        .getClass('GlobalQuantifyCapability')!
-        .getNamedConstructor('')!;
+    ConstructorElement globalQuantifyCapabilityConstructor =
+        capabilityLibrary
+            .getClass('GlobalQuantifyCapability')!
+            .getNamedConstructor('')!;
     ConstructorElement globalQuantifyMetaCapabilityConstructor =
         capabilityLibrary
             .getClass('GlobalQuantifyMetaCapability')!
@@ -3577,25 +4003,29 @@ class BuilderImplementation {
                   valueType is InterfaceType ? valueType.element : null;
               if (reflector == null) {
                 await _warn(
-                    WarningKind.badSuperclass,
-                    'The reflector must be a direct subclass of Reflectable.',
-                    metadatumElement);
+                  WarningKind.badSuperclass,
+                  'The reflector must be a direct subclass of Reflectable.',
+                  metadatumElement,
+                );
                 continue;
               } else {
                 InterfaceType? reflectorSupertype = reflector.supertype;
                 if (reflectorSupertype is InterfaceType &&
                     reflectorSupertype.element != reflectableClass) {
                   await _warn(
-                      WarningKind.badSuperclass,
-                      'The reflector must be a direct subclass of '
-                      'Reflectable. Found ${reflector.name}.',
-                      metadatumElement);
+                    WarningKind.badSuperclass,
+                    'The reflector must be a direct subclass of '
+                    'Reflectable. Found ${reflector.name}.',
+                    metadatumElement,
+                  );
                   continue;
                 }
               }
               globalPatterns
                   .putIfAbsent(
-                      RegExp(pattern ?? ''), () => <InterfaceElement>[])
+                    RegExp(pattern ?? ''),
+                    () => <InterfaceElement>[],
+                  )
                   .add(reflector);
             }
           } else if (metadatumElement ==
@@ -3620,17 +4050,19 @@ class BuilderImplementation {
                 await _warn(WarningKind.badMetadata, message, metadatumElement);
                 continue;
               }
-              DartType? reflectorType = constantValue
-                  .getField('(super)')
-                  ?.getField('reflector')
-                  ?.type;
+              DartType? reflectorType =
+                  constantValue
+                      .getField('(super)')
+                      ?.getField('reflector')
+                      ?.type;
               InterfaceElement? reflector =
                   reflectorType is InterfaceType ? reflectorType.element : null;
               if (reflector == null) {
                 await _warn(
-                    WarningKind.badSuperclass,
-                    'The reflector must be a direct subclass of Reflectable.',
-                    metadatumElement);
+                  WarningKind.badSuperclass,
+                  'The reflector must be a direct subclass of Reflectable.',
+                  metadatumElement,
+                );
                 continue;
               } else {
                 InterfaceType? reflectorSupertype = reflector.supertype;
@@ -3638,10 +4070,11 @@ class BuilderImplementation {
                     reflectorSupertype is InterfaceType &&
                     reflectorSupertype.element != reflectableClass) {
                   await _warn(
-                      WarningKind.badSuperclass,
-                      'The reflector must be a direct subclass of '
-                      'Reflectable. Found ${reflector.name}.',
-                      metadatumElement);
+                    WarningKind.badSuperclass,
+                    'The reflector must be a direct subclass of '
+                    'Reflectable. Found ${reflector.name}.',
+                    metadatumElement,
+                  );
                   continue;
                 }
               }
@@ -3663,11 +4096,14 @@ class BuilderImplementation {
   /// update accordingly. The rest of the builder can then rely on every
   /// reflector class to be well-formed, and just have assertions rather than
   /// emitting error messages about it.
-  Future<bool> _isReflectorClass(InterfaceElement potentialReflectorClass,
-      InterfaceElement reflectableClass) async {
+  Future<bool> _isReflectorClass(
+    InterfaceElement potentialReflectorClass,
+    InterfaceElement reflectableClass,
+  ) async {
     if (potentialReflectorClass == reflectableClass) return false;
-    DartType potentialReflectorType =
-        _typeForReflectable(potentialReflectorClass);
+    DartType potentialReflectorType = _typeForReflectable(
+      potentialReflectorClass,
+    );
     DartType reflectableType = _typeForReflectable(reflectableClass);
     if (potentialReflectorType is! ParameterizedType ||
         reflectableType is! InterfaceType) {
@@ -3683,21 +4119,23 @@ class BuilderImplementation {
       // of [classReflectable]: Not supported, warn about having such a class
       // at all, even though we don't know for sure it is used as a reflector.
       await _warn(
-          WarningKind.badReflectorClass,
-          'An indirect subclass of `Reflectable` will not work as a reflector.'
-          '\nIt is not recommended to have such a class at all.',
-          potentialReflectorClass);
+        WarningKind.badReflectorClass,
+        'An indirect subclass of `Reflectable` will not work as a reflector.'
+        '\nIt is not recommended to have such a class at all.',
+        potentialReflectorClass,
+      );
       return false;
     }
 
     Future<void> constructorFail() async {
       await _severe(
-          'A reflector class must have exactly one '
-          'constructor which is `const`, has \n'
-          'the empty name, takes zero arguments, and '
-          'uses at most one superinitializer.\n'
-          'Please correct `$potentialReflectorClass` to match this.',
-          potentialReflectorClass);
+        'A reflector class must have exactly one '
+        'constructor which is `const`, has \n'
+        'the empty name, takes zero arguments, and '
+        'uses at most one superinitializer.\n'
+        'Please correct `$potentialReflectorClass` to match this.',
+        potentialReflectorClass,
+      );
     }
 
     if (potentialReflectorClass.constructors.length != 1) {
@@ -3713,8 +4151,10 @@ class BuilderImplementation {
       return false;
     }
 
-    AstNode? constructorDeclarationNode =
-        await _getDeclarationAst(constructor, _resolver);
+    AstNode? constructorDeclarationNode = await _getDeclarationAst(
+      constructor,
+      _resolver,
+    );
     if (constructorDeclarationNode == null ||
         constructorDeclarationNode is! ConstructorDeclaration) {
       return false;
@@ -3742,16 +4182,21 @@ class BuilderImplementation {
   /// and it is used to decide whether it is possible to import other libraries
   /// from the entry point. If the transformation is guaranteed to have no
   /// effect the return value is [null].
-  Future<_ReflectionWorld?> _computeWorld(LibraryElement reflectableLibrary,
-      LibraryElement entryPoint, AssetId dataId) async {
+  Future<_ReflectionWorld?> _computeWorld(
+    LibraryElement reflectableLibrary,
+    LibraryElement entryPoint,
+    AssetId dataId,
+  ) async {
     final InterfaceElement? classReflectable =
         await _findReflectableInterfaceElement(reflectableLibrary);
     final allReflectors = <InterfaceElement>{};
 
     // If class `Reflectable` is absent the transformation must be a no-op.
     if (classReflectable == null) {
-      log.info('Ignoring entry point $entryPoint that does not '
-          'include the class `Reflectable`.');
+      log.info(
+        'Ignoring entry point $entryPoint that does not '
+        'include the class `Reflectable`.',
+      );
       return null;
     }
 
@@ -3771,20 +4216,25 @@ class BuilderImplementation {
         _librariesByName['reflectable.capability'];
 
     if (capabilityLibrary == null) {
-      log.info('Ignoring entry point $entryPoint that does not '
-          'include the library reflectable.capability');
+      log.info(
+        'Ignoring entry point $entryPoint that does not '
+        'include the library reflectable.capability',
+      );
       return null;
     }
 
     /// Gets the [ReflectorDomain] associated with [reflector], or creates
     /// it if none exists.
     Future<_ReflectorDomain> getReflectorDomain(
-        InterfaceElement reflector) async {
+      InterfaceElement reflector,
+    ) async {
       _ReflectorDomain? domain = domains[reflector];
       if (domain == null) {
         LibraryElement reflectorLibrary = reflector.library;
-        _Capabilities capabilities =
-            await _capabilitiesOf(capabilityLibrary, reflector);
+        _Capabilities capabilities = await _capabilitiesOf(
+          capabilityLibrary,
+          reflector,
+        );
         assert(await _isImportableLibrary(reflectorLibrary, dataId, _resolver));
         importCollector._addLibrary(reflectorLibrary);
         domain = _ReflectorDomain(_resolver, dataId, reflector, capabilities);
@@ -3795,7 +4245,9 @@ class BuilderImplementation {
 
     /// Adds [library] to the supported libraries of [reflector].
     Future<void> addLibrary(
-        LibraryElement library, InterfaceElement reflector) async {
+      LibraryElement library,
+      InterfaceElement reflector,
+    ) async {
       _ReflectorDomain domain = await getReflectorDomain(reflector);
       if (domain._capabilities._supportsLibraries) {
         assert(await _isImportableLibrary(library, dataId, _resolver));
@@ -3808,7 +4260,9 @@ class BuilderImplementation {
     /// [reflector]; also adds the enclosing library of [type] to the
     /// supported libraries.
     Future<void> addClassDomain(
-        InterfaceElement type, InterfaceElement reflector) async {
+      InterfaceElement type,
+      InterfaceElement reflector,
+    ) async {
       if (!await _isImportable(type, dataId, _resolver)) {
         await _fine('Ignoring unrepresentable class ${type.name}', type);
       } else {
@@ -3856,7 +4310,9 @@ class BuilderImplementation {
     /// [qualifiedName] is the name of the library or class annotated by
     /// [metadata].
     Future<Iterable<InterfaceElement>> getReflectors(
-        String? qualifiedName, List<ElementAnnotation> metadata) async {
+      String? qualifiedName,
+      List<ElementAnnotation> metadata,
+    ) async {
       var result = <InterfaceElement>[];
 
       for (ElementAnnotation metadatum in metadata) {
@@ -3878,16 +4334,20 @@ class BuilderImplementation {
         }
 
         // Test if the annotation is a reflector.
-        InterfaceElement? reflector =
-            await _getReflectableAnnotation(metadatum, classReflectable);
+        InterfaceElement? reflector = await _getReflectableAnnotation(
+          metadatum,
+          classReflectable,
+        );
         if (reflector != null) result.add(reflector);
       }
 
       // Add All reflectors associated with a
       // pattern, via GlobalQuantifyCapability, that matches the qualified
       // name of the class or library.
-      globalPatterns
-          .forEach((RegExp pattern, List<InterfaceElement> reflectors) {
+      globalPatterns.forEach((
+        RegExp pattern,
+        List<InterfaceElement> reflectors,
+      ) {
         if (qualifiedName != null && pattern.hasMatch(qualifiedName)) {
           for (InterfaceElement reflector in reflectors) {
             result.add(reflector);
@@ -3904,16 +4364,20 @@ class BuilderImplementation {
     // gets their reflectors, and adds them to the domain of that
     // reflector.
     for (LibraryElement library in _libraries) {
-      for (InterfaceElement reflector
-          in await getReflectors(library.name, library.metadata)) {
+      for (InterfaceElement reflector in await getReflectors(
+        library.name,
+        library.metadata,
+      )) {
         assert(await _isImportableLibrary(library, dataId, _resolver));
         await addLibrary(library, reflector);
       }
 
       for (CompilationUnitElement unit in library.units) {
         for (InterfaceElement type in unit.classes) {
-          for (InterfaceElement reflector
-              in await getReflectors(_qualifiedName(type), type.metadata)) {
+          for (InterfaceElement reflector in await getReflectors(
+            _qualifiedName(type),
+            type.metadata,
+          )) {
             await addClassDomain(type, reflector);
           }
           if (!allReflectors.contains(type) &&
@@ -3922,15 +4386,19 @@ class BuilderImplementation {
           }
         }
         for (EnumElement type in unit.enums) {
-          for (InterfaceElement reflector
-              in await getReflectors(_qualifiedName(type), type.metadata)) {
+          for (InterfaceElement reflector in await getReflectors(
+            _qualifiedName(type),
+            type.metadata,
+          )) {
             await addClassDomain(type, reflector);
           }
           // An enum is never a reflector class, hence no `_isReflectorClass`.
         }
         for (FunctionElement function in unit.functions) {
           for (InterfaceElement reflector in await getReflectors(
-              _qualifiedFunctionName(function), function.metadata)) {
+            _qualifiedFunctionName(function),
+            function.metadata,
+          )) {
             // We just add the library here, the function itself will be
             // supported using `invoke` and `declarations` of that library
             // mirror.
@@ -3944,10 +4412,14 @@ class BuilderImplementation {
     for (_ReflectorDomain domain in domains.values) {
       usedReflectors.add(domain._reflector);
     }
-    for (InterfaceElement reflector
-        in allReflectors.difference(usedReflectors)) {
-      await _warn(WarningKind.unusedReflector,
-          'This reflector does not match anything', reflector);
+    for (InterfaceElement reflector in allReflectors.difference(
+      usedReflectors,
+    )) {
+      await _warn(
+        WarningKind.unusedReflector,
+        'This reflector does not match anything',
+        reflector,
+      );
       // Ensure that there is an empty domain for `reflector` in `domains`.
       await getReflectorDomain(reflector);
     }
@@ -3957,13 +4429,14 @@ class BuilderImplementation {
     // defined during construction, so `_world` is non-final and left unset by
     // the constructor, and we need to close the cycle here.
     var world = _ReflectionWorld(
-        _resolver,
-        _libraries,
-        dataId,
-        domains.values.toList(),
-        reflectableLibrary,
-        entryPoint,
-        importCollector);
+      _resolver,
+      _libraries,
+      dataId,
+      domains.values.toList(),
+      reflectableLibrary,
+      entryPoint,
+      importCollector,
+    );
     for (_ReflectorDomain domain in domains.values) {
       domain._world = world;
     }
@@ -3973,12 +4446,15 @@ class BuilderImplementation {
   /// Returns the [ReflectCapability] denoted by the given initializer
   /// [expression] reporting diagnostic messages for [messageTarget].
   Future<ec.ReflectCapability?> _capabilityOfExpression(
-      LibraryElement capabilityLibrary,
-      Expression expression,
-      LibraryElement containingLibrary,
-      Element messageTarget) async {
-    DartObject? constant =
-        await _evaluateConstant(containingLibrary, expression);
+    LibraryElement capabilityLibrary,
+    Expression expression,
+    LibraryElement containingLibrary,
+    Element messageTarget,
+  ) async {
+    DartObject? constant = await _evaluateConstant(
+      containingLibrary,
+      expression,
+    );
 
     if (constant is! DartObject) {
       await _severe(
@@ -4009,16 +4485,21 @@ class BuilderImplementation {
     if (dartTypeElement is! ClassElement) {
       String typeString = dartType.getDisplayString();
       await _severe(
-          errors.applyTemplate(
-              errors.superArgumentNonClass, {'type': typeString}),
-          dartTypeElement);
+        errors.applyTemplate(errors.superArgumentNonClass, {
+          'type': typeString,
+        }),
+        dartTypeElement,
+      );
       return null; // Error default.
     }
     if (dartTypeElement.library != capabilityLibrary) {
       await _severe(
-          errors.applyTemplate(errors.superArgumentWrongLibrary,
-              {'library': '$capabilityLibrary', 'element': '$dartTypeElement'}),
-          dartTypeElement);
+        errors.applyTemplate(errors.superArgumentWrongLibrary, {
+          'library': '$capabilityLibrary',
+          'element': '$dartTypeElement',
+        }),
+        dartTypeElement,
+      );
       return null; // Error default.
     }
 
@@ -4026,15 +4507,19 @@ class BuilderImplementation {
     /// NamePatternCapability.
     Future<String?> extractNamePattern(DartObject constant) async {
       DartObject? constantSuper = constant.getField('(super)');
-      DartObject? constantSuperNamePattern =
-          constantSuper?.getField('namePattern');
+      DartObject? constantSuperNamePattern = constantSuper?.getField(
+        'namePattern',
+      );
       String? constantSuperNamePatternString =
           constantSuperNamePattern?.toStringValue();
       if (constantSuper == null ||
           constantSuperNamePattern == null ||
           constantSuperNamePatternString == null) {
-        await _warn(WarningKind.badNamePattern,
-            'Could not extract namePattern from capability.', messageTarget);
+        await _warn(
+          WarningKind.badNamePattern,
+          'Could not extract namePattern from capability.',
+          messageTarget,
+        );
         return null;
       }
       return constantSuperNamePatternString;
@@ -4045,11 +4530,15 @@ class BuilderImplementation {
     /// messages as referring to [messageTarget].
     Future<InterfaceElement?> extractMetadata(DartObject constant) async {
       DartObject? constantSuper = constant.getField('(super)');
-      DartObject? constantSuperMetadataType =
-          constantSuper?.getField('metadataType');
+      DartObject? constantSuperMetadataType = constantSuper?.getField(
+        'metadataType',
+      );
       if (constantSuper == null || constantSuperMetadataType == null) {
-        await _warn(WarningKind.badMetadata,
-            'Could not extract metadata type from capability.', messageTarget);
+        await _warn(
+          WarningKind.badMetadata,
+          'Could not extract metadata type from capability.',
+          messageTarget,
+        );
         return null;
       }
       DartType? metadataFieldType = constantSuperMetadataType.toTypeValue();
@@ -4057,9 +4546,10 @@ class BuilderImplementation {
           metadataFieldType is InterfaceType ? metadataFieldType.element : null;
       if (metadataFieldValue is InterfaceElement) return metadataFieldValue;
       await _warn(
-          WarningKind.badMetadata,
-          'Metadata specification in capability must be a class `Type`.',
-          messageTarget);
+        WarningKind.badMetadata,
+        'Metadata specification in capability must be a class `Type`.',
+        messageTarget,
+      );
       return null;
     }
 
@@ -4132,26 +4622,32 @@ class BuilderImplementation {
         return ec.subtypeQuantifyCapability;
       case 'SuperclassQuantifyCapability':
         DartObject? constantUpperBound = constant.getField('upperBound');
-        DartObject? constantExcludeUpperBound =
-            constant.getField('excludeUpperBound');
+        DartObject? constantExcludeUpperBound = constant.getField(
+          'excludeUpperBound',
+        );
         if (constantUpperBound == null || constantExcludeUpperBound == null) {
           return null;
         }
         DartType constantUpperBoundType = constantUpperBound.toTypeValue()!;
         if (constantUpperBoundType is! InterfaceType) return null;
-        return ec.SuperclassQuantifyCapability(constantUpperBoundType.element,
-            excludeUpperBound: constantExcludeUpperBound.toBoolValue()!);
+        return ec.SuperclassQuantifyCapability(
+          constantUpperBoundType.element,
+          excludeUpperBound: constantExcludeUpperBound.toBoolValue()!,
+        );
       case 'TypeAnnotationQuantifyCapability':
         DartObject? constantTransitive = constant.getField('transitive');
         if (constantTransitive == null) return null;
         return ec.TypeAnnotationQuantifyCapability(
-            transitive: constantTransitive.toBoolValue()!);
+          transitive: constantTransitive.toBoolValue()!,
+        );
       case '_CorrespondingSetterQuantifyCapability':
         return ec.correspondingSetterQuantifyCapability;
       case '_AdmitSubtypeCapability':
         // TODO(eernst) implement: support for the admit subtype feature.
         await _severe(
-            '_AdmitSubtypeCapability not yet supported!', messageTarget);
+          '_AdmitSubtypeCapability not yet supported!',
+          messageTarget,
+        );
         return ec.admitSubtypeCapability;
       default:
         // We have checked that [element] is declared in 'capability.dart',
@@ -4167,7 +4663,9 @@ class BuilderImplementation {
   /// Returns the list of Capabilities given as a superinitializer by the
   /// reflector.
   Future<_Capabilities> _capabilitiesOf(
-      LibraryElement capabilityLibrary, InterfaceElement reflector) async {
+    LibraryElement capabilityLibrary,
+    InterfaceElement reflector,
+  ) async {
     List<ConstructorElement> constructors = reflector.constructors;
 
     // Well-formedness for each reflector class is checked by
@@ -4200,9 +4698,11 @@ class BuilderImplementation {
       return _Capabilities(<ec.ReflectCapability>[]);
     }
     if (initializers.length != 1) {
-      await _severe('Encountered a reflector whose constructor has '
-          'an unexpected initializer list. It must be of the form '
-          '`super(...)` or `super.fromList(...)`');
+      await _severe(
+        'Encountered a reflector whose constructor has '
+        'an unexpected initializer list. It must be of the form '
+        '`super(...)` or `super.fromList(...)`',
+      );
       return _Capabilities(<ec.ReflectCapability>[]);
     }
 
@@ -4215,19 +4715,27 @@ class BuilderImplementation {
     }
 
     Future<ec.ReflectCapability?> capabilityOfExpression(
-        Expression expression) async {
+      Expression expression,
+    ) async {
       return await _capabilityOfExpression(
-          capabilityLibrary, expression, reflector.library, constructorElement);
+        capabilityLibrary,
+        expression,
+        reflector.library,
+        constructorElement,
+      );
     }
 
     Future<ec.ReflectCapability?> capabilityOfCollectionElement(
-        CollectionElement collectionElement) async {
+      CollectionElement collectionElement,
+    ) async {
       if (collectionElement is Expression) {
         return await capabilityOfExpression(collectionElement);
       } else {
-        await _severe('Not supported! '
-            'Encountered a collection element which is not an expression: '
-            '$collectionElement');
+        await _severe(
+          'Not supported! '
+          'Encountered a collection element which is not an expression: '
+          '$collectionElement',
+        );
         return null;
       }
     }
@@ -4253,9 +4761,11 @@ class BuilderImplementation {
     Expression listLiteral = arguments[0];
     var capabilities = <ec.ReflectCapability>[];
     if (listLiteral is! ListLiteral) {
-      await _severe('Encountered a reflector using super.fromList(...) '
-          'with an argument that is not a list literal, '
-          'which is not supported');
+      await _severe(
+        'Encountered a reflector using super.fromList(...) '
+        'with an argument that is not a list literal, '
+        'which is not supported',
+      );
     } else {
       for (CollectionElement collectionElement in listLiteral.elements) {
         ec.ReflectCapability? currentCapability =
@@ -4270,21 +4780,26 @@ class BuilderImplementation {
   /// reflection data according to [world], and invoke the main of
   /// [entrypointLibrary] located at [originalEntryPointFilename]. The code is
   /// generated to be located at [generatedLibraryId].
-  Future<String> _generateNewEntryPoint(_ReflectionWorld world,
-      AssetId generatedLibraryId, String originalEntryPointFilename) async {
+  Future<String> _generateNewEntryPoint(
+    _ReflectionWorld world,
+    AssetId generatedLibraryId,
+    String originalEntryPointFilename,
+  ) async {
     // Notice it is important to generate the code before printing the
     // imports because generating the code can add further imports.
     String code = await world.generateCode();
 
     var imports = <String>[];
     for (LibraryElement library in world.importCollector._libraries) {
-      Uri uri = library == world.entryPointLibrary
-          ? Uri.parse(originalEntryPointFilename)
-          : await _getImportUri(library, _resolver, generatedLibraryId);
+      Uri uri =
+          library == world.entryPointLibrary
+              ? Uri.parse(originalEntryPointFilename)
+              : await _getImportUri(library, _resolver, generatedLibraryId);
       String prefix = world.importCollector._getPrefix(library);
       if (prefix.isNotEmpty) {
-        imports
-            .add("import '$uri' as ${prefix.substring(0, prefix.length - 1)};");
+        imports.add(
+          "import '$uri' as ${prefix.substring(0, prefix.length - 1)};",
+        );
       }
     }
     imports.sort();
@@ -4325,13 +4840,14 @@ void initializeReflectable() {
   /// Perform the build which produces a set of statically generated
   /// mirror classes, as requested using reflectable capabilities.
   Future<String> buildMirrorLibrary(
-      Resolver resolver,
-      AssetId inputId,
-      AssetId generatedLibraryId,
-      LibraryElement inputLibrary,
-      List<LibraryElement> visibleLibraries,
-      bool formatted,
-      List<WarningKind> suppressedWarnings) async {
+    Resolver resolver,
+    AssetId inputId,
+    AssetId generatedLibraryId,
+    LibraryElement inputLibrary,
+    List<LibraryElement> visibleLibraries,
+    bool formatted,
+    List<WarningKind> suppressedWarnings,
+  ) async {
     _formatted = formatted;
     _suppressedWarnings = suppressedWarnings;
 
@@ -4347,8 +4863,10 @@ void initializeReflectable() {
 
     if (reflectableLibrary == null) {
       // Stop and let the original source pass through without changes.
-      log.info('Ignoring entry point $inputId that does not '
-          "include the library 'package:reflectable/reflectable.dart'");
+      log.info(
+        'Ignoring entry point $inputId that does not '
+        "include the library 'package:reflectable/reflectable.dart'",
+      );
       if (const bool.fromEnvironment('reflectable.pause.at.exit')) {
         _processedEntryPointCount++;
       }
@@ -4361,8 +4879,11 @@ void initializeReflectable() {
         print("Starting build for '$inputId'.");
       }
 
-      _ReflectionWorld? world =
-          await _computeWorld(reflectableLibrary, inputLibrary, inputId);
+      _ReflectionWorld? world = await _computeWorld(
+        reflectableLibrary,
+        inputLibrary,
+        inputId,
+      );
       if (world == null) {
         // Errors have already been reported during `_computeWorld`.
         if (const bool.fromEnvironment('reflectable.pause.at.exit')) {
@@ -4378,7 +4899,10 @@ void initializeReflectable() {
           return '// No output from reflectable, there is no `main`.';
         } else {
           String outputContents = await _generateNewEntryPoint(
-              world, generatedLibraryId, path.basename(inputId.path));
+            world,
+            generatedLibraryId,
+            path.basename(inputId.path),
+          );
           if (const bool.fromEnvironment('reflectable.pause.at.exit')) {
             _processedEntryPointCount++;
           }
@@ -4397,7 +4921,8 @@ void initializeReflectable() {
 
   /// Returns a constant resolved version of the given [libraryElement].
   Future<LibraryElement> _resolvedLibraryOf(
-      LibraryElement libraryElement) async {
+    LibraryElement libraryElement,
+  ) async {
     for (LibraryElement libraryElement2 in _libraries) {
       if (libraryElement.identifier == libraryElement2.identifier) {
         return libraryElement2;
@@ -4624,9 +5149,10 @@ int _declarationDescriptor(ExecutableElement element) {
 }
 
 Future<String> _nameOfConstructor(ConstructorElement element) async {
-  String name = element.name == ''
-      ? element.enclosingElement.name
-      : '${element.enclosingElement.name}.${element.name}';
+  String name =
+      element.name == ''
+          ? element.enclosingElement.name
+          : '${element.enclosingElement.name}.${element.name}';
   if (_isPrivateName(name)) {
     await _severe('Cannot access private name $name', element);
   }
@@ -4649,10 +5175,11 @@ String _formatAsMap(Iterable parts) => '{${parts.join(', ')}}';
 /// value when evaluated in the generated file as the given [expression]
 /// would evaluate to in [originatingLibrary].
 Future<String> _extractConstantCode(
-    Expression expression,
-    _ImportCollector importCollector,
-    AssetId generatedLibraryId,
-    Resolver resolver) async {
+  Expression expression,
+  _ImportCollector importCollector,
+  AssetId generatedLibraryId,
+  Resolver resolver,
+) async {
   Future<String> typeAnnotationHelper(TypeAnnotation typeName) async {
     DartType? interfaceType = typeName.type;
     if (interfaceType is InterfaceType) {
@@ -4678,9 +5205,11 @@ Future<String> _extractConstantCode(
           elements.add(await helper(subExpression));
         } else {
           // TODO(eernst) implement: `if` and `spread` elements of list.
-          await _severe('Not yet supported! '
-              'Encountered list literal element which is not an expression: '
-              '$collectionElement');
+          await _severe(
+            'Not yet supported! '
+            'Encountered list literal element which is not an expression: '
+            '$collectionElement',
+          );
           elements.add('');
         }
       }
@@ -4690,8 +5219,9 @@ Future<String> _extractConstantCode(
         return 'const ${_formatAsDynamicList(elements)}';
       } else {
         assert(expressionTypeArguments.arguments.length == 1);
-        String typeArgument =
-            await typeAnnotationHelper(expressionTypeArguments.arguments[0]);
+        String typeArgument = await typeAnnotationHelper(
+          expressionTypeArguments.arguments[0],
+        );
         return 'const <$typeArgument>${_formatAsDynamicList(elements)}';
       }
     } else if (expression is SetOrMapLiteral) {
@@ -4704,9 +5234,11 @@ Future<String> _extractConstantCode(
             elements.add('$key: $value');
           } else {
             // TODO(eernst) implement: `if` and `spread` elements of a map.
-            await _severe('Not yet supported! '
-                'Encountered map literal element which is not a map entry: '
-                '$collectionElement');
+            await _severe(
+              'Not yet supported! '
+              'Encountered map literal element which is not a map entry: '
+              '$collectionElement',
+            );
             elements.add('');
           }
         }
@@ -4716,10 +5248,12 @@ Future<String> _extractConstantCode(
           return 'const ${_formatAsMap(elements)}';
         } else {
           assert(expressionTypeArguments.arguments.length == 2);
-          String keyType =
-              await typeAnnotationHelper(expressionTypeArguments.arguments[0]);
-          String valueType =
-              await typeAnnotationHelper(expressionTypeArguments.arguments[1]);
+          String keyType = await typeAnnotationHelper(
+            expressionTypeArguments.arguments[0],
+          );
+          String valueType = await typeAnnotationHelper(
+            expressionTypeArguments.arguments[1],
+          );
           return 'const <$keyType, $valueType>${_formatAsMap(elements)}';
         }
       } else if (expression.isSet) {
@@ -4730,9 +5264,11 @@ Future<String> _extractConstantCode(
             elements.add(await helper(subExpression));
           } else {
             // TODO(eernst) implement: `if` and `spread` elements of a set.
-            await _severe('Not yet supported! '
-                'Encountered set literal element which is not an expression: '
-                '$collectionElement');
+            await _severe(
+              'Not yet supported! '
+              'Encountered set literal element which is not an expression: '
+              '$collectionElement',
+            );
             elements.add('');
           }
         }
@@ -4742,8 +5278,9 @@ Future<String> _extractConstantCode(
           return 'const ${_formatAsDynamicSet(elements)}';
         } else {
           assert(expressionTypeArguments.arguments.length == 1);
-          String typeArgument =
-              await typeAnnotationHelper(expressionTypeArguments.arguments[0]);
+          String typeArgument = await typeAnnotationHelper(
+            expressionTypeArguments.arguments[0],
+          );
           return 'const <$typeArgument>${_formatAsDynamicSet(elements)}';
         }
       } else {
@@ -4752,14 +5289,19 @@ Future<String> _extractConstantCode(
     } else if (expression is InstanceCreationExpression) {
       String constructor = expression.constructorName.toSource();
       if (_isPrivateName(constructor)) {
-        await _severe('Cannot access private name $constructor, '
-            'needed for expression $expression');
+        await _severe(
+          'Cannot access private name $constructor, '
+          'needed for expression $expression',
+        );
         return '';
       }
       LibraryElement libraryOfConstructor =
           expression.constructorName.staticElement!.library;
       if (await _isImportableLibrary(
-          libraryOfConstructor, generatedLibraryId, resolver)) {
+        libraryOfConstructor,
+        generatedLibraryId,
+        resolver,
+      )) {
         importCollector._addLibrary(libraryOfConstructor);
         String prefix = importCollector._getPrefix(libraryOfConstructor);
         // TODO(sigurdm) implement: Named arguments.
@@ -4770,14 +5312,18 @@ Future<String> _extractConstantCode(
         String arguments = argumentList.join(', ');
         // TODO(sigurdm) feature: Type arguments.
         if (_isPrivateName(constructor)) {
-          await _severe('Cannot access private name $constructor, '
-              'needed for expression $expression');
+          await _severe(
+            'Cannot access private name $constructor, '
+            'needed for expression $expression',
+          );
           return '';
         }
         return 'const $prefix$constructor($arguments)';
       } else {
-        await _severe('Cannot access library $libraryOfConstructor, '
-            'needed for expression $expression');
+        await _severe(
+          'Cannot access library $libraryOfConstructor, '
+          'needed for expression $expression',
+        );
         return '';
       }
     } else if (expression is Identifier) {
@@ -4785,9 +5331,10 @@ Future<String> _extractConstantCode(
         Element? staticElement = expression.staticElement;
         if (staticElement is PropertyAccessorElement) {
           VariableElement? variable = staticElement.variable2;
-          AstNode? variableDeclaration = variable != null
-              ? await _getDeclarationAst(variable, resolver)
-              : null;
+          AstNode? variableDeclaration =
+              variable != null
+                  ? await _getDeclarationAst(variable, resolver)
+                  : null;
           if (variableDeclaration == null ||
               variableDeclaration is! VariableDeclaration) {
             await _severe('Cannot handle private identifier $expression');
@@ -4804,8 +5351,10 @@ Future<String> _extractConstantCode(
         if (element == null) {
           // TODO(eernst): This can occur; but how could `expression` be
           // unresolved? Issue 173.
-          await _fine('Encountered unresolved identifier $expression'
-              ' in constant; using null');
+          await _fine(
+            'Encountered unresolved identifier $expression'
+            ' in constant; using null',
+          );
           return 'null';
         } else if (element.library == null) {
           return '${element.name}';
@@ -4813,7 +5362,10 @@ Future<String> _extractConstantCode(
           LibraryElement? elementLibrary = element.library;
           if (elementLibrary != null &&
               await _isImportableLibrary(
-                  elementLibrary, generatedLibraryId, resolver)) {
+                elementLibrary,
+                generatedLibraryId,
+                resolver,
+              )) {
             importCollector._addLibrary(elementLibrary);
             String prefix = importCollector._getPrefix(elementLibrary);
             Element? enclosingElement = element.enclosingElement;
@@ -4822,13 +5374,17 @@ Future<String> _extractConstantCode(
             }
             String? elementName = element.name;
             if (elementName != null && _isPrivateName(elementName)) {
-              await _severe('Cannot access private name $elementName, '
-                  'needed for expression $expression');
+              await _severe(
+                'Cannot access private name $elementName, '
+                'needed for expression $expression',
+              );
             }
             return '$prefix$elementName';
           } else {
-            await _severe('Cannot access library $elementLibrary, '
-                'needed for expression $expression');
+            await _severe(
+              'Cannot access library $elementLibrary, '
+              'needed for expression $expression',
+            );
             return '';
           }
         }
@@ -4861,11 +5417,19 @@ Future<String> _extractConstantCode(
       return 'identical($a, $b)';
     } else if (expression is NamedExpression) {
       String value = await _extractConstantCode(
-          expression.expression, importCollector, generatedLibraryId, resolver);
+        expression.expression,
+        importCollector,
+        generatedLibraryId,
+        resolver,
+      );
       return '${expression.name} $value';
     } else if (expression is FunctionReference) {
       String function = await _extractConstantCode(
-          expression.function, importCollector, generatedLibraryId, resolver);
+        expression.function,
+        importCollector,
+        generatedLibraryId,
+        resolver,
+      );
       TypeArgumentList? expressionTypeArguments = expression.typeArguments;
       if (expressionTypeArguments == null) {
         return function;
@@ -4873,20 +5437,23 @@ Future<String> _extractConstantCode(
         var typeArguments = <String>[];
         for (TypeAnnotation expressionTypeArgument
             in expressionTypeArguments.arguments) {
-          String typeArgument =
-              await typeAnnotationHelper(expressionTypeArgument);
+          String typeArgument = await typeAnnotationHelper(
+            expressionTypeArgument,
+          );
           typeArguments.add(typeArgument);
         }
         return '$function<${typeArguments.join(', ')}>';
       }
     } else {
-      assert(expression is IntegerLiteral ||
-          expression is BooleanLiteral ||
-          expression is StringLiteral ||
-          expression is NullLiteral ||
-          expression is SymbolLiteral ||
-          expression is DoubleLiteral ||
-          expression is TypedLiteral);
+      assert(
+        expression is IntegerLiteral ||
+            expression is BooleanLiteral ||
+            expression is StringLiteral ||
+            expression is NullLiteral ||
+            expression is SymbolLiteral ||
+            expression is DoubleLiteral ||
+            expression is TypedLiteral,
+      );
       return expression.toSource();
     }
   }
@@ -4913,12 +5480,13 @@ const Set<String> sdkLibraryNames = <String>{
   'ui',
   'web_audio',
   'web_gl',
-  'web_sql'
+  'web_sql',
 };
 
 // Helper for _extractMetadataCode.
 CompilationUnit? _definingCompilationUnit(
-    ResolvedLibraryResult resolvedLibrary) {
+  ResolvedLibraryResult resolvedLibrary,
+) {
   CompilationUnitElement definingUnit =
       resolvedLibrary.element.definingCompilationUnit;
   List<ResolvedUnitResult> units = resolvedLibrary.units;
@@ -4979,8 +5547,12 @@ NodeList<Annotation>? _getOtherMetadata(AstNode? node, Element element) {
 /// Returns a String with the code used to build the metadata of [element].
 ///
 /// Also adds any necessary imports to [importCollector].
-Future<String> _extractMetadataCode(Element element, Resolver resolver,
-    _ImportCollector importCollector, AssetId dataId) async {
+Future<String> _extractMetadataCode(
+  Element element,
+  Resolver resolver,
+  _ImportCollector importCollector,
+  AssetId dataId,
+) async {
   // Synthetic accessors do not have metadata. Only their associated fields.
   if ((element is PropertyAccessorElement ||
           element is ConstructorElement ||
@@ -4996,14 +5568,18 @@ Future<String> _extractMetadataCode(Element element, Resolver resolver,
   }
 
   NodeList<Annotation>? metadata;
-  ResolvedLibraryResult? resolvedLibrary =
-      await _getResolvedLibrary(element.library!, resolver);
+  ResolvedLibraryResult? resolvedLibrary = await _getResolvedLibrary(
+    element.library!,
+    resolver,
+  );
   if (element is LibraryElement && resolvedLibrary != null) {
     metadata = _getLibraryMetadata(_definingCompilationUnit(resolvedLibrary));
   } else {
     // The declaration is null if the element is synthetic.
     metadata = _getOtherMetadata(
-        resolvedLibrary?.getElementDeclaration(element)?.node, element);
+      resolvedLibrary?.getElementDeclaration(element)?.node,
+      element,
+    );
   }
   if (metadata == null || metadata.isEmpty) return 'const []';
 
@@ -5036,12 +5612,20 @@ Future<String> _extractMetadataCode(Element element, Resolver resolver,
     ArgumentList? annotationNodeArguments = annotationNode.arguments;
     if (annotationNodeArguments != null) {
       // A const constructor.
-      String name =
-          await _extractNameWithoutPrefix(annotationNode.name, element);
+      String name = await _extractNameWithoutPrefix(
+        annotationNode.name,
+        element,
+      );
       var argumentList = <String>[];
       for (Expression argument in annotationNodeArguments.arguments) {
-        argumentList.add(await _extractConstantCode(
-            argument, importCollector, dataId, resolver));
+        argumentList.add(
+          await _extractConstantCode(
+            argument,
+            importCollector,
+            dataId,
+            resolver,
+          ),
+        );
       }
       String arguments = argumentList.join(', ');
       if (_isPrivateName(name)) {
@@ -5052,10 +5636,14 @@ Future<String> _extractMetadataCode(Element element, Resolver resolver,
       // A field reference.
       if (_isPrivateName(annotationNode.name.name)) {
         await _severe(
-            'Cannot access private name ${annotationNode.name}', element);
+          'Cannot access private name ${annotationNode.name}',
+          element,
+        );
       }
-      String name =
-          await _extractNameWithoutPrefix(annotationNode.name, element);
+      String name = await _extractNameWithoutPrefix(
+        annotationNode.name,
+        element,
+      );
       if (_isPrivateName(name)) {
         await _severe('Cannot access private name $name', element);
       }
@@ -5069,7 +5657,9 @@ Future<String> _extractMetadataCode(Element element, Resolver resolver,
 /// Extract the plain name from [identifier] by stripping off the
 /// library import prefix at front, if any.
 Future<String> _extractNameWithoutPrefix(
-    Identifier identifier, Element errorTarget) async {
+  Identifier identifier,
+  Element errorTarget,
+) async {
   String name;
   if (identifier is SimpleIdentifier) {
     name = identifier.token.lexeme;
@@ -5087,8 +5677,10 @@ Future<String> _extractNameWithoutPrefix(
       name = identifier.name;
     }
   } else {
-    await _severe('This kind of identifier is not yet supported: $identifier',
-        errorTarget);
+    await _severe(
+      'This kind of identifier is not yet supported: $identifier',
+      errorTarget,
+    );
     name = identifier.name;
   }
   return name;
@@ -5097,14 +5689,21 @@ Future<String> _extractNameWithoutPrefix(
 /// Returns the top level variables declared in the given [libraryElement],
 /// filtering them such that the returned ones are those that are supported
 /// by [capabilities].
-Iterable<TopLevelVariableElement> _extractDeclaredVariables(Resolver resolver,
-    LibraryElement libraryElement, _Capabilities capabilities) sync* {
+Iterable<TopLevelVariableElement> _extractDeclaredVariables(
+  Resolver resolver,
+  LibraryElement libraryElement,
+  _Capabilities capabilities,
+) sync* {
   for (CompilationUnitElement unit in libraryElement.units) {
     for (TopLevelVariableElement variable in unit.topLevelVariables) {
       if (variable.isPrivate || variable.isSynthetic) continue;
       // TODO(eernst) clarify: Do we want to subsume variables under invoke?
-      if (capabilities.supportsTopLevelInvoke(variable.library.typeSystem,
-          variable.name, variable.metadata, null)) {
+      if (capabilities.supportsTopLevelInvoke(
+        variable.library.typeSystem,
+        variable.name,
+        variable.metadata,
+        null,
+      )) {
         yield variable;
       }
     }
@@ -5114,13 +5713,20 @@ Iterable<TopLevelVariableElement> _extractDeclaredVariables(Resolver resolver,
 /// Returns the top level functions declared in the given [libraryElement],
 /// filtering them such that the returned ones are those that are supported
 /// by [capabilities].
-Iterable<FunctionElement> _extractDeclaredFunctions(Resolver resolver,
-    LibraryElement libraryElement, _Capabilities capabilities) sync* {
+Iterable<FunctionElement> _extractDeclaredFunctions(
+  Resolver resolver,
+  LibraryElement libraryElement,
+  _Capabilities capabilities,
+) sync* {
   for (CompilationUnitElement unit in libraryElement.units) {
     for (FunctionElement function in unit.functions) {
       if (function.isPrivate) continue;
-      if (capabilities.supportsTopLevelInvoke(function.library.typeSystem,
-          function.name, function.metadata, null)) {
+      if (capabilities.supportsTopLevelInvoke(
+        function.library.typeSystem,
+        function.name,
+        function.metadata,
+        null,
+      )) {
         yield function;
       }
     }
@@ -5130,9 +5736,10 @@ Iterable<FunctionElement> _extractDeclaredFunctions(Resolver resolver,
 /// Returns the parameters declared in the given [declaredFunctions] as well
 /// as the setters from the given [accessors].
 Iterable<ParameterElement> _extractDeclaredFunctionParameters(
-    Resolver resolver,
-    Iterable<FunctionElement> declaredFunctions,
-    Iterable<ExecutableElement> accessors) {
+  Resolver resolver,
+  Iterable<FunctionElement> declaredFunctions,
+  Iterable<ExecutableElement> accessors,
+) {
   var result = <ParameterElement>[];
   for (FunctionElement declaredFunction in declaredFunctions) {
     result.addAll(declaredFunction.parameters);
@@ -5145,38 +5752,56 @@ Iterable<ParameterElement> _extractDeclaredFunctionParameters(
   return result;
 }
 
-typedef CapabilityChecker = bool Function(
-    TypeSystem,
-    String methodName,
-    Iterable<ElementAnnotation> metadata,
-    Iterable<ElementAnnotation>? getterMetadata);
+typedef CapabilityChecker =
+    bool Function(
+      TypeSystem,
+      String methodName,
+      Iterable<ElementAnnotation> metadata,
+      Iterable<ElementAnnotation>? getterMetadata,
+    );
 
 /// Returns the declared fields in the given [interfaceElement], filtered such
 /// that the returned ones are the ones that are supported by [capabilities].
-Iterable<FieldElement> _extractDeclaredFields(Resolver resolver,
-    InterfaceElement interfaceElement, _Capabilities capabilities) {
+Iterable<FieldElement> _extractDeclaredFields(
+  Resolver resolver,
+  InterfaceElement interfaceElement,
+  _Capabilities capabilities,
+) {
   return interfaceElement.fields.where((FieldElement field) {
     if (field.isPrivate) return false;
-    CapabilityChecker capabilityChecker = field.isStatic
-        ? capabilities.supportsStaticInvoke
-        : capabilities.supportsInstanceInvoke;
+    CapabilityChecker capabilityChecker =
+        field.isStatic
+            ? capabilities.supportsStaticInvoke
+            : capabilities.supportsInstanceInvoke;
     return !field.isSynthetic &&
-        capabilityChecker(interfaceElement.library.typeSystem, field.name,
-            field.metadata, null);
+        capabilityChecker(
+          interfaceElement.library.typeSystem,
+          field.name,
+          field.metadata,
+          null,
+        );
   });
 }
 
 /// Returns the declared methods in the given [interfaceElement], filtered such
 /// that the returned ones are the ones that are supported by [capabilities].
-Iterable<MethodElement> _extractDeclaredMethods(Resolver resolver,
-    InterfaceElement interfaceElement, _Capabilities capabilities) {
+Iterable<MethodElement> _extractDeclaredMethods(
+  Resolver resolver,
+  InterfaceElement interfaceElement,
+  _Capabilities capabilities,
+) {
   return interfaceElement.methods.where((MethodElement method) {
     if (method.isPrivate) return false;
-    CapabilityChecker capabilityChecker = method.isStatic
-        ? capabilities.supportsStaticInvoke
-        : capabilities.supportsInstanceInvoke;
+    CapabilityChecker capabilityChecker =
+        method.isStatic
+            ? capabilities.supportsStaticInvoke
+            : capabilities.supportsInstanceInvoke;
     return capabilityChecker(
-        method.library.typeSystem, method.name, method.metadata, null);
+      method.library.typeSystem,
+      method.name,
+      method.metadata,
+      null,
+    );
   });
 }
 
@@ -5184,9 +5809,10 @@ Iterable<MethodElement> _extractDeclaredMethods(Resolver resolver,
 /// [declaredConstructors], as well as the ones from the setters in
 /// [accessors].
 List<ParameterElement> _extractDeclaredParameters(
-    Iterable<MethodElement> declaredMethods,
-    Iterable<ConstructorElement> declaredConstructors,
-    Iterable<PropertyAccessorElement> accessors) {
+  Iterable<MethodElement> declaredMethods,
+  Iterable<ConstructorElement> declaredConstructors,
+  Iterable<PropertyAccessorElement> accessors,
+) {
   var result = <ParameterElement>[];
   for (MethodElement declaredMethod in declaredMethods) {
     result.addAll(declaredMethod.parameters);
@@ -5204,8 +5830,11 @@ List<ParameterElement> _extractDeclaredParameters(
 
 /// Returns the accessors from the given [libraryElement], filtered such that
 /// the returned ones are the ones that are supported by [capabilities].
-Iterable<PropertyAccessorElement> _extractLibraryAccessors(Resolver resolver,
-    LibraryElement libraryElement, _Capabilities capabilities) sync* {
+Iterable<PropertyAccessorElement> _extractLibraryAccessors(
+  Resolver resolver,
+  LibraryElement libraryElement,
+  _Capabilities capabilities,
+) sync* {
   for (CompilationUnitElement unit in libraryElement.units) {
     for (PropertyAccessorElement accessor in unit.accessors) {
       if (accessor.isPrivate) continue;
@@ -5224,8 +5853,12 @@ Iterable<PropertyAccessorElement> _extractLibraryAccessors(Resolver resolver,
           getterMetadata = correspondingGetter?.metadata;
         }
       }
-      if (capabilities.supportsTopLevelInvoke(accessor.library.typeSystem,
-          accessor.name, metadata, getterMetadata)) {
+      if (capabilities.supportsTopLevelInvoke(
+        accessor.library.typeSystem,
+        accessor.name,
+        metadata,
+        getterMetadata,
+      )) {
         yield accessor;
       }
     }
@@ -5240,20 +5873,25 @@ Iterable<PropertyAccessorElement> _extractLibraryAccessors(Resolver resolver,
 /// interface, e.g., `declarations`. But the latter can be computed from
 /// here, by filtering out the accessors whose `isSynthetic` is true
 /// and adding the fields.
-Iterable<PropertyAccessorElement> _extractAccessors(Resolver resolver,
-    InterfaceElement interfaceElement, _Capabilities capabilities) {
+Iterable<PropertyAccessorElement> _extractAccessors(
+  Resolver resolver,
+  InterfaceElement interfaceElement,
+  _Capabilities capabilities,
+) {
   return interfaceElement.accessors.where((PropertyAccessorElement accessor) {
     if (accessor.isPrivate) return false;
     // TODO(eernst) implement: refactor treatment of `getterMetadata`
     // such that we avoid passing in `null` at all call sites except one,
     // when we might as well move the processing to that single call site (such
     // as here, but also in `_extractLibraryAccessors()`, etc).
-    CapabilityChecker capabilityChecker = accessor.isStatic
-        ? capabilities.supportsStaticInvoke
-        : capabilities.supportsInstanceInvoke;
-    List<ElementAnnotation> metadata = accessor.isSynthetic
-        ? (accessor.variable2?.metadata ?? const <ElementAnnotation>[])
-        : accessor.metadata;
+    CapabilityChecker capabilityChecker =
+        accessor.isStatic
+            ? capabilities.supportsStaticInvoke
+            : capabilities.supportsInstanceInvoke;
+    List<ElementAnnotation> metadata =
+        accessor.isSynthetic
+            ? (accessor.variable2?.metadata ?? const <ElementAnnotation>[])
+            : accessor.metadata;
     List<ElementAnnotation>? getterMetadata;
     if (capabilities._impliesCorrespondingSetters &&
         accessor.isSetter &&
@@ -5263,116 +5901,173 @@ Iterable<PropertyAccessorElement> _extractAccessors(Resolver resolver,
       getterMetadata = correspondingGetter?.metadata;
     }
     return capabilityChecker(
-        accessor.library.typeSystem, accessor.name, metadata, getterMetadata);
+      accessor.library.typeSystem,
+      accessor.name,
+      metadata,
+      getterMetadata,
+    );
   });
 }
 
 /// Returns the declared constructors from [interfaceElement], filtered such that
 /// the returned ones are the ones that are supported by [capabilities].
 Iterable<ConstructorElement> _extractDeclaredConstructors(
-    Resolver resolver,
-    LibraryElement libraryElement,
-    InterfaceElement interfaceElement,
-    _Capabilities capabilities) {
+  Resolver resolver,
+  LibraryElement libraryElement,
+  InterfaceElement interfaceElement,
+  _Capabilities capabilities,
+) {
   return interfaceElement.constructors.where((ConstructorElement constructor) {
     if (constructor.isPrivate) return false;
-    return capabilities.supportsNewInstance(constructor.library.typeSystem,
-        constructor.name, constructor.metadata, libraryElement, resolver);
+    return capabilities.supportsNewInstance(
+      constructor.library.typeSystem,
+      constructor.name,
+      constructor.metadata,
+      libraryElement,
+      resolver,
+    );
   });
 }
 
 _LibraryDomain _createLibraryDomain(
-    LibraryElement library, _ReflectorDomain domain) {
+  LibraryElement library,
+  _ReflectorDomain domain,
+) {
   Iterable<TopLevelVariableElement> declaredVariablesOfLibrary =
-      _extractDeclaredVariables(domain._resolver, library, domain._capabilities)
-          .toList();
+      _extractDeclaredVariables(
+        domain._resolver,
+        library,
+        domain._capabilities,
+      ).toList();
   Iterable<FunctionElement> declaredFunctionsOfLibrary =
-      _extractDeclaredFunctions(domain._resolver, library, domain._capabilities)
-          .toList();
+      _extractDeclaredFunctions(
+        domain._resolver,
+        library,
+        domain._capabilities,
+      ).toList();
   Iterable<PropertyAccessorElement> accessorsOfLibrary =
-      _extractLibraryAccessors(domain._resolver, library, domain._capabilities)
-          .toList();
+      _extractLibraryAccessors(
+        domain._resolver,
+        library,
+        domain._capabilities,
+      ).toList();
   Iterable<ParameterElement> declaredParametersOfLibrary =
       _extractDeclaredFunctionParameters(
-              domain._resolver, declaredFunctionsOfLibrary, accessorsOfLibrary)
-          .toList();
+        domain._resolver,
+        declaredFunctionsOfLibrary,
+        accessorsOfLibrary,
+      ).toList();
   return _LibraryDomain(
-      library,
-      declaredVariablesOfLibrary,
-      declaredFunctionsOfLibrary,
-      declaredParametersOfLibrary,
-      accessorsOfLibrary,
-      domain);
+    library,
+    declaredVariablesOfLibrary,
+    declaredFunctionsOfLibrary,
+    declaredParametersOfLibrary,
+    accessorsOfLibrary,
+    domain,
+  );
 }
 
 _ClassDomain _createClassDomain(
-    InterfaceElement type, _ReflectorDomain domain) {
+  InterfaceElement type,
+  _ReflectorDomain domain,
+) {
   if (type is MixinApplication) {
-    Iterable<FieldElement> declaredFieldsOfClass = _extractDeclaredFields(
-            domain._resolver, type.mixin, domain._capabilities)
-        .where((FieldElement e) => !e.isStatic)
-        .toList();
-    Iterable<MethodElement> declaredMethodsOfClass = _extractDeclaredMethods(
-            domain._resolver, type.mixin, domain._capabilities)
-        .where((MethodElement e) => !e.isStatic)
-        .toList();
+    Iterable<FieldElement> declaredFieldsOfClass =
+        _extractDeclaredFields(
+          domain._resolver,
+          type.mixin,
+          domain._capabilities,
+        ).where((FieldElement e) => !e.isStatic).toList();
+    Iterable<MethodElement> declaredMethodsOfClass =
+        _extractDeclaredMethods(
+          domain._resolver,
+          type.mixin,
+          domain._capabilities,
+        ).where((MethodElement e) => !e.isStatic).toList();
     Iterable<PropertyAccessorElement> declaredAndImplicitAccessorsOfClass =
-        _extractAccessors(domain._resolver, type.mixin, domain._capabilities)
-            .toList();
+        _extractAccessors(
+          domain._resolver,
+          type.mixin,
+          domain._capabilities,
+        ).toList();
     Iterable<ConstructorElement> declaredConstructorsOfClass =
         <ConstructorElement>[];
     Iterable<ParameterElement> declaredParametersOfClass =
-        _extractDeclaredParameters(declaredMethodsOfClass,
-            declaredConstructorsOfClass, declaredAndImplicitAccessorsOfClass);
+        _extractDeclaredParameters(
+          declaredMethodsOfClass,
+          declaredConstructorsOfClass,
+          declaredAndImplicitAccessorsOfClass,
+        );
 
     return _ClassDomain(
-        type,
-        declaredFieldsOfClass,
-        declaredMethodsOfClass,
-        declaredParametersOfClass,
-        declaredAndImplicitAccessorsOfClass,
-        declaredConstructorsOfClass,
-        domain);
-  }
-
-  List<FieldElement> declaredFieldsOfClass =
-      _extractDeclaredFields(domain._resolver, type, domain._capabilities)
-          .toList();
-  List<MethodElement> declaredMethodsOfClass =
-      _extractDeclaredMethods(domain._resolver, type, domain._capabilities)
-          .toList();
-  List<PropertyAccessorElement> declaredAndImplicitAccessorsOfClass =
-      _extractAccessors(domain._resolver, type, domain._capabilities).toList();
-  List<ConstructorElement> declaredConstructorsOfClass =
-      _extractDeclaredConstructors(
-              domain._resolver, type.library, type, domain._capabilities)
-          .toList();
-  List<ParameterElement> declaredParametersOfClass = _extractDeclaredParameters(
-      declaredMethodsOfClass,
-      declaredConstructorsOfClass,
-      declaredAndImplicitAccessorsOfClass);
-  return _ClassDomain(
       type,
       declaredFieldsOfClass,
       declaredMethodsOfClass,
       declaredParametersOfClass,
       declaredAndImplicitAccessorsOfClass,
       declaredConstructorsOfClass,
-      domain);
+      domain,
+    );
+  }
+
+  List<FieldElement> declaredFieldsOfClass =
+      _extractDeclaredFields(
+        domain._resolver,
+        type,
+        domain._capabilities,
+      ).toList();
+  List<MethodElement> declaredMethodsOfClass =
+      _extractDeclaredMethods(
+        domain._resolver,
+        type,
+        domain._capabilities,
+      ).toList();
+  List<PropertyAccessorElement> declaredAndImplicitAccessorsOfClass =
+      _extractAccessors(domain._resolver, type, domain._capabilities).toList();
+  List<ConstructorElement> declaredConstructorsOfClass =
+      _extractDeclaredConstructors(
+        domain._resolver,
+        type.library,
+        type,
+        domain._capabilities,
+      ).toList();
+  List<ParameterElement> declaredParametersOfClass = _extractDeclaredParameters(
+    declaredMethodsOfClass,
+    declaredConstructorsOfClass,
+    declaredAndImplicitAccessorsOfClass,
+  );
+  return _ClassDomain(
+    type,
+    declaredFieldsOfClass,
+    declaredMethodsOfClass,
+    declaredParametersOfClass,
+    declaredAndImplicitAccessorsOfClass,
+    declaredConstructorsOfClass,
+    domain,
+  );
 }
 
 /// Answers true iff [element] can be imported into [generatedLibraryId].
 // TODO(sigurdm) implement: Make a test that tries to reflect on native/private
 // classes.
 Future<bool> _isImportable(
-    Element element, AssetId generatedLibraryId, Resolver resolver) async {
+  Element element,
+  AssetId generatedLibraryId,
+  Resolver resolver,
+) async {
   return await _isImportableLibrary(
-      element.library!, generatedLibraryId, resolver);
+    element.library!,
+    generatedLibraryId,
+    resolver,
+  );
 }
 
 /// Answers true iff [library] can be imported into [generatedLibraryId].
-Future<bool> _isImportableLibrary(LibraryElement library,
-    AssetId generatedLibraryId, Resolver resolver) async {
+Future<bool> _isImportableLibrary(
+  LibraryElement library,
+  AssetId generatedLibraryId,
+  Resolver resolver,
+) async {
   Uri importUri = await _getImportUri(library, resolver, generatedLibraryId);
   return importUri.scheme != 'dart' || sdkLibraryNames.contains(importUri.path);
 }
@@ -5381,29 +6076,39 @@ Future<bool> _isImportableLibrary(LibraryElement library,
 /// [assetId]. This function returns null if we cannot determine a uri for
 /// [assetId]. Note that [assetId] may represent a non-importable file such as
 /// a part.
-Future<String?> _assetIdToUri(AssetId assetId, AssetId from,
-    Element messageTarget, Resolver resolver) async {
+Future<String?> _assetIdToUri(
+  AssetId assetId,
+  AssetId from,
+  Element messageTarget,
+  Resolver resolver,
+) async {
   if (!assetId.path.startsWith('lib/')) {
     // Cannot do absolute imports of non lib-based assets.
     if (assetId.package != from.package) {
-      await _severe(await _formatDiagnosticMessage(
+      await _severe(
+        await _formatDiagnosticMessage(
           'Attempt to generate non-lib import from different package',
           messageTarget,
-          resolver));
+          resolver,
+        ),
+      );
       return null;
     }
     return Uri(
-            path: path.url
-                .relative(assetId.path, from: path.url.dirname(from.path)))
-        .toString();
+      path: path.url.relative(assetId.path, from: path.url.dirname(from.path)),
+    ).toString();
   }
 
-  return Uri.parse('package:${assetId.package}/${assetId.path.substring(4)}')
-      .toString();
+  return Uri.parse(
+    'package:${assetId.package}/${assetId.path.substring(4)}',
+  ).toString();
 }
 
 Future<Uri> _getImportUri(
-    LibraryElement lib, Resolver resolver, AssetId from) async {
+  LibraryElement lib,
+  Resolver resolver,
+  AssetId from,
+) async {
   Source source = lib.source;
   Uri uri = source.uri;
   if (uri.scheme == 'asset') {
@@ -5414,7 +6119,8 @@ Future<Uri> _getImportUri(
     String package = uri.pathSegments[0];
     String path = uri.path.substring(package.length + 1);
     return Uri(
-        path: await _assetIdToUri(AssetId(package, path), from, lib, resolver));
+      path: await _assetIdToUri(AssetId(package, path), from, lib, resolver),
+    );
   }
   if (source is FileSource || source is InSummarySource) {
     return uri;
@@ -5452,8 +6158,13 @@ class MixinApplication implements ClassElement {
   @override
   final LibraryElement library;
 
-  MixinApplication(this.declaredName, this.superclass, this.mixin, this.library,
-      this.subclass);
+  MixinApplication(
+    this.declaredName,
+    this.superclass,
+    this.mixin,
+    this.library,
+    this.subclass,
+  );
 
   @override
   String get name {
@@ -5484,11 +6195,11 @@ class MixinApplication implements ClassElement {
   InterfaceType instantiate({
     required List<DartType> typeArguments,
     required NullabilitySuffix nullabilitySuffix,
-  }) =>
-      InterfaceTypeImpl(
-          element: this,
-          typeArguments: typeArguments,
-          nullabilitySuffix: nullabilitySuffix);
+  }) => InterfaceTypeImpl(
+    element: this,
+    typeArguments: typeArguments,
+    nullabilitySuffix: nullabilitySuffix,
+  );
 
   @override
   InterfaceType? get supertype {
@@ -5602,7 +6313,9 @@ bool _isPrivateName(String name) {
 }
 
 Future<DartObject?> _evaluateConstant(
-    LibraryElement library, Expression expression) async {
+  LibraryElement library,
+  Expression expression,
+) async {
   AstNode? currentUnit = expression.parent;
   var levels = 0;
   while (currentUnit != null &&
@@ -5611,8 +6324,10 @@ Future<DartObject?> _evaluateConstant(
     currentUnit = currentUnit.parent;
   }
   if (currentUnit is! CompilationUnit) {
-    await _severe('Expression `$expression` '
-        'has no enclosing compilation unit.');
+    await _severe(
+      'Expression `$expression` '
+      'has no enclosing compilation unit.',
+    );
     return null;
   }
 
@@ -5621,10 +6336,7 @@ Future<DartObject?> _evaluateConstant(
   var libraryElement = unitElement.library as LibraryElementImpl;
 
   var errorListener = RecordingErrorListener();
-  var errorReporter = ErrorReporter(
-    errorListener,
-    source,
-  );
+  var errorReporter = ErrorReporter(errorListener, source);
   var declaredVariables = DeclaredVariables(); // No variables.
 
   var evaluationEngine = ConstantEvaluationEngine(
@@ -5671,7 +6383,8 @@ DartObject? _getEvaluatedMetadatum(ElementAnnotation elementAnnotation) =>
 /// Returns the result of evaluating each of the element annotations
 /// in [metadata] using [_getEvaluatedMetadatum].
 Iterable<DartObject> _getEvaluatedMetadata(
-    Iterable<ElementAnnotation>? metadata) {
+  Iterable<ElementAnnotation>? metadata,
+) {
   if (metadata == null) return [];
   var result = <DartObject>[];
   for (ElementAnnotation annotation in metadata) {
@@ -5692,8 +6405,11 @@ bool _isPlatformLibrary(LibraryElement? libraryElement) =>
 
 /// Adds a severe error to the log, using the source code location of `target`
 /// to identify the relevant location where the error occurs.
-Future<void> _severe(String message,
-    [Element? target, Resolver? resolver]) async {
+Future<void> _severe(
+  String message, [
+  Element? target,
+  Resolver? resolver,
+]) async {
   if (target != null && resolver != null) {
     log.severe(await _formatDiagnosticMessage(message, target, resolver));
   } else {
@@ -5703,8 +6419,11 @@ Future<void> _severe(String message,
 
 /// Adds a 'fine' message to the log, using the source code location of `target`
 /// to identify the relevant location where the issue occurs.
-Future<void> _fine(String message,
-    [Element? target, Resolver? resolver]) async {
+Future<void> _fine(
+  String message, [
+  Element? target,
+  Resolver? resolver,
+]) async {
   if (target != null && resolver != null) {
     log.fine(await _formatDiagnosticMessage(message, target, resolver));
   } else {
@@ -5715,7 +6434,10 @@ Future<void> _fine(String message,
 /// Returns a string containing the given [message] and identifying the
 /// associated source code location as the location of the given [target].
 Future<String> _formatDiagnosticMessage(
-    String message, Element? target, Resolver resolver) async {
+  String message,
+  Element? target,
+  Resolver resolver,
+) async {
   Source? source = target?.source;
   if (source == null) return message;
   var locationString = '';
@@ -5726,14 +6448,17 @@ Future<String> _formatDiagnosticMessage(
   if (targetLibrary != null &&
       nameOffset != null &&
       !_isPlatformLibrary(targetLibrary)) {
-    final ResolvedLibraryResult? resolvedLibrary =
-        await _getResolvedLibrary(targetLibrary, resolver);
+    final ResolvedLibraryResult? resolvedLibrary = await _getResolvedLibrary(
+      targetLibrary,
+      resolver,
+    );
     if (resolvedLibrary != null) {
-      final ElementDeclarationResult? targetDeclaration =
-          resolvedLibrary.getElementDeclaration(target!);
+      final ElementDeclarationResult? targetDeclaration = resolvedLibrary
+          .getElementDeclaration(target!);
       final CompilationUnit? unit = targetDeclaration?.resolvedUnit?.unit;
-      final CharacterLocation? location =
-          unit?.lineInfo.getLocation(nameOffset);
+      final CharacterLocation? location = unit?.lineInfo.getLocation(
+        nameOffset,
+      );
       if (location != null) {
         locationString = '${location.lineNumber}:${location.columnNumber}';
       }
@@ -5746,11 +6471,15 @@ Future<String> _formatDiagnosticMessage(
 // (as opposed to stdout and stderr which are swallowed). If given, [target]
 // is used to indicate a source code location.
 // ignore:unused_element
-Future<void> _emitMessage(String message,
-    [Element? target, Resolver? resolver]) async {
-  String formattedMessage = (target != null && resolver != null)
-      ? await _formatDiagnosticMessage(message, target, resolver)
-      : message;
+Future<void> _emitMessage(
+  String message, [
+  Element? target,
+  Resolver? resolver,
+]) async {
+  String formattedMessage =
+      (target != null && resolver != null)
+          ? await _formatDiagnosticMessage(message, target, resolver)
+          : message;
   log.warning(formattedMessage);
 }
 
@@ -5764,12 +6493,15 @@ Future<AstNode?> _getDeclarationAst(Element element, Resolver resolver) =>
 /// given [library], thus avoiding an `InconsistentAnalysisException`
 /// which will be thrown if we use `library.session` directly.
 Future<ResolvedLibraryResult?> _getResolvedLibrary(
-    LibraryElement library, Resolver resolver) async {
-  final LibraryElement freshLibrary =
-      await resolver.libraryFor(await resolver.assetIdForElement(library));
+  LibraryElement library,
+  Resolver resolver,
+) async {
+  final LibraryElement freshLibrary = await resolver.libraryFor(
+    await resolver.assetIdForElement(library),
+  );
   final AnalysisSession freshSession = freshLibrary.session;
-  final SomeResolvedLibraryResult someResult =
-      await freshSession.getResolvedLibraryByElement(freshLibrary);
+  final SomeResolvedLibraryResult someResult = await freshSession
+      .getResolvedLibraryByElement(freshLibrary);
   if (someResult is ResolvedLibraryResult) {
     return someResult;
   } else {

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -2798,7 +2798,7 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement2> {
           subClass == null
               ? null
               : (element is MixinApplication && element.isMixinApplication
-                  ? element.name
+                  ? element.name3
                   : null);
       InterfaceElement2 mixinApplication = MixinApplication(
         name,
@@ -2868,7 +2868,7 @@ Set<InterfaceElement2> _mixinApplicationsOfClasses(
               ? null
               : (interfaceElement is MixinApplication &&
                       interfaceElement.isMixinApplication
-                  ? interfaceElement.name
+                  ? interfaceElement.name3
                   : null);
       InterfaceElement2 mixinApplication = MixinApplication(
         name,
@@ -3194,7 +3194,7 @@ class _ClassDomain {
     if (interfaceElement is MixinApplication &&
         interfaceElement.isMixinApplication) {
       // This is the case `class B = A with M;`.
-      return interfaceElement.name;
+      return interfaceElement.name3!;
     } else if (interfaceElement is MixinApplication) {
       // This is the case `class B extends A with M1, .. Mk {..}`
       // where `interfaceElement` denotes one of the mixin applications
@@ -4307,7 +4307,7 @@ class BuilderImplementation {
               InterfaceElement2 mixinElement = mixin.element3;
               MixinApplication? subClass =
                   mixin == type.mixins.last ? type : null;
-              String? name = subClass == null ? null : type.name;
+              String? name = subClass == null ? null : type.name3!;
               var mixinApplication = MixinApplication(
                 name,
                 superclass,

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -2197,7 +2197,7 @@ class _ReflectorDomain {
     if (dartType is InterfaceType) {
       InterfaceElement2 interfaceElement = dartType.element3;
       if ((interfaceElement is MixinApplication &&
-              interfaceElement.declaredName == null) ||
+              interfaceElement.firstFragment.name2 == null) ||
           interfaceElement.isPrivate) {
         return await fail();
       }
@@ -2342,7 +2342,7 @@ class _ReflectorDomain {
     if (dartType is InterfaceType) {
       InterfaceElement2 interfaceElement = dartType.element3;
       if ((interfaceElement is MixinApplication &&
-              interfaceElement.declaredName == null) ||
+              interfaceElement.firstFragment.name2 == null) ||
           interfaceElement.isPrivate) {
         // The test for an anonymous mixin application above may be dead code:
         // Currently no test uses an anonymous mixin application to reach this

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -2443,7 +2443,7 @@ class _ReflectorDomain {
     if (type is InterfaceType) {
       InterfaceElement2 interfaceElement = type.element3;
       if ((interfaceElement is MixinApplication &&
-              interfaceElement.declaredName == null) ||
+              interfaceElement.firstFragment.name2 == null) ||
           interfaceElement.isPrivate) {
         return "const r.FakeType(r'${_qualifiedName(interfaceElement)}')";
       }

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -127,13 +127,12 @@ class _ReflectionWorld {
             InterfaceElement2 mixinElement = mixin.element3;
             InterfaceElement2? subClass =
                 mixin == interfaceElement.mixins.last ? interfaceElement : null;
-            String? name =
-                subClass == null
-                    ? null
-                    : (interfaceElement is MixinApplication &&
-                            interfaceElement.isMixinApplication
-                        ? interfaceElement.name
-                        : null);
+            String? name = subClass == null
+                ? null
+                : (interfaceElement is MixinApplication &&
+                        interfaceElement.isMixinApplication
+                    ? interfaceElement.name
+                    : null);
             var mixinApplication = MixinApplication(
               name,
               superclass,
@@ -628,16 +627,14 @@ class ParameterListShape {
   );
 
   @override
-  bool operator ==(other) =>
-      other is ParameterListShape
-          ? numberOfPositionalParameters ==
-                  other.numberOfPositionalParameters &&
-              numberOfOptionalPositionalParameters ==
-                  other.numberOfOptionalPositionalParameters &&
-              namesOfNamedParameters
-                  .difference(other.namesOfNamedParameters)
-                  .isEmpty
-          : false;
+  bool operator ==(other) => other is ParameterListShape
+      ? numberOfPositionalParameters == other.numberOfPositionalParameters &&
+          numberOfOptionalPositionalParameters ==
+              other.numberOfOptionalPositionalParameters &&
+          namesOfNamedParameters
+              .difference(other.namesOfNamedParameters)
+              .isEmpty
+      : false;
 
   @override
   int get hashCode =>
@@ -753,10 +750,9 @@ class _ReflectorDomain {
     int requiredPositionalCount = type.normalParameterTypes.length;
     int optionalPositionalCount = type.optionalParameterTypes.length;
 
-    List<String> parameterNames =
-        type.formalParameters
-            .map((FormalParameterElement parameter) => parameter.name3!)
-            .toList();
+    List<String> parameterNames = type.formalParameters
+        .map((FormalParameterElement parameter) => parameter.name3!)
+        .toList();
 
     List<String> namedParameterNames = type.namedParameterTypes.keys.toList();
 
@@ -823,9 +819,8 @@ class _ReflectorDomain {
       optionalPositionalCount,
       (int i) => parameterNames[i + requiredPositionalCount],
     ).join(', ');
-    String namedArguments = namedParameterNames
-        .map((String name) => '$name: $name')
-        .join(', ');
+    String namedArguments =
+        namedParameterNames.map((String name) => '$name: $name').join(', ');
 
     var parameterParts = <String>[];
     var argumentParts = <String>[];
@@ -1506,23 +1501,22 @@ class _ReflectorDomain {
     Iterable<int> methodsIndices = classDomain._declarations
         .where(_executableIsntImplicitGetterOrSetter)
         .map((ExecutableElement2 element) {
-          // TODO(eernst) implement: The "magic" default constructor in `Object`
-          // (the one that ultimately allocates the memory for _every_ new
-          // object) has no index, which creates the need to catch a `null`
-          // here. Search for "magic" to find other occurrences of the same
-          // issue. For now, we use the index [constants.noCapabilityIndex]
-          // for this declaration, because it is not yet supported.
-          // Need to find the correct solution, though!
-          int? index = members.indexOf(element);
-          return index == null
-              ? constants.noCapabilityIndex
-              : index + methodsOffset;
-        });
+      // TODO(eernst) implement: The "magic" default constructor in `Object`
+      // (the one that ultimately allocates the memory for _every_ new
+      // object) has no index, which creates the need to catch a `null`
+      // here. Search for "magic" to find other occurrences of the same
+      // issue. For now, we use the index [constants.noCapabilityIndex]
+      // for this declaration, because it is not yet supported.
+      // Need to find the correct solution, though!
+      int? index = members.indexOf(element);
+      return index == null
+          ? constants.noCapabilityIndex
+          : index + methodsOffset;
+    });
 
-    String declarationsCode =
-        _capabilities._impliesDeclarations
-            ? _formatAsConstList('int', [...fieldsIndices, ...methodsIndices])
-            : 'const <int>[${constants.noCapabilityIndex}]';
+    String declarationsCode = _capabilities._impliesDeclarations
+        ? _formatAsConstList('int', [...fieldsIndices, ...methodsIndices])
+        : 'const <int>[${constants.noCapabilityIndex}]';
 
     // All instance members belong to the behavioral interface, so they
     // also get an offset of `fields.length`.
@@ -1569,11 +1563,10 @@ class _ReflectorDomain {
       // convention we make it supported and report it in the same way as
       // 'dart:mirrors'. Other superclasses use `noCapabilityIndex` to
       // indicate missing support.
-      superclassIndex =
-          (interfaceElement is! MixinApplication &&
-                  _typeForReflectable(interfaceElement).isDartCoreObject)
-              ? 'null'
-              : ((await classes).contains(superclass))
+      superclassIndex = (interfaceElement is! MixinApplication &&
+              _typeForReflectable(interfaceElement).isDartCoreObject)
+          ? 'null'
+          : ((await classes).contains(superclass))
               ? '${(await classes).indexOf(superclass!)}'
               : '${constants.noCapabilityIndex}';
     }
@@ -1661,10 +1654,9 @@ class _ReflectorDomain {
       mixinIndex ??= constants.noCapabilityIndex;
     }
 
-    int ownerIndex =
-        _capabilities._supportsLibraries
-            ? libraries.indexOf(libraryMap[interfaceElement.library2]!)!
-            : constants.noCapabilityIndex;
+    int ownerIndex = _capabilities._supportsLibraries
+        ? libraries.indexOf(libraryMap[interfaceElement.library2]!)!
+        : constants.noCapabilityIndex;
 
     var superinterfaceIndices = 'const <int>[${constants.noCapabilityIndex}]';
     if (_capabilities._impliesTypeRelations) {
@@ -1823,10 +1815,9 @@ class _ReflectorDomain {
       // There is no type propagation, so we declare an `accessorElement`.
       PropertyAccessorElement2 accessorElement = element;
       PropertyInducingElement2? variable = accessorElement.variable3;
-      int variableMirrorIndex =
-          variable is TopLevelVariableElement2
-              ? topLevelVariables.indexOf(variable)!
-              : variable is FieldElement2
+      int variableMirrorIndex = variable is TopLevelVariableElement2
+          ? topLevelVariables.indexOf(variable)!
+          : variable is FieldElement2
               ? fields.indexOf(variable)!
               : constants.noCapabilityIndex;
       int selfIndex = members.indexOf(accessorElement)! + fields.length;
@@ -1845,19 +1836,18 @@ class _ReflectorDomain {
       // getter or setter.
       int descriptor = _declarationDescriptor(element);
       int returnTypeIndex = await _computeReturnTypeIndex(element, descriptor);
-      int ownerIndex =
-          (await _computeOwnerIndex(element, descriptor)) ??
+      int ownerIndex = (await _computeOwnerIndex(element, descriptor)) ??
           constants.noCapabilityIndex;
       var reflectedTypeArgumentsOfReturnType = 'null';
       if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
         reflectedTypeArgumentsOfReturnType =
             await _computeReflectedTypeArguments(
-              element.returnType,
-              reflectedTypes,
-              reflectedTypesOffset,
-              importCollector,
-              typedefs,
-            );
+          element.returnType,
+          reflectedTypes,
+          reflectedTypesOffset,
+          importCollector,
+          typedefs,
+        );
       }
       String parameterIndicesCode = _formatAsConstList(
         'int',
@@ -1885,15 +1875,14 @@ class _ReflectorDomain {
           typedefs,
         );
       }
-      String? metadataCode =
-          _capabilities._supportsMetadata
-              ? await _extractMetadataCode(
-                element,
-                _resolver,
-                importCollector,
-                _generatedLibraryId,
-              )
-              : null;
+      String? metadataCode = _capabilities._supportsMetadata
+          ? await _extractMetadataCode(
+              element,
+              _resolver,
+              importCollector,
+              _generatedLibraryId,
+            )
+          : null;
       return "r.MethodMirrorImpl(r'${element.name3}', $descriptor, "
           '$ownerIndex, $returnTypeIndex, $reflectedReturnTypeIndex, '
           '$dynamicReflectedReturnTypeIndex, '
@@ -1914,26 +1903,24 @@ class _ReflectorDomain {
     LibraryElement2 owner = element.library2;
     int ownerIndex = _libraries.indexOf(owner) ?? constants.noCapabilityIndex;
     int classMirrorIndex = await _computeVariableTypeIndex(element, descriptor);
-    int? reflectedTypeIndex =
-        reflectedTypeRequested
-            ? _typeCodeIndex(
-              element.type,
-              await classes,
-              reflectedTypes,
-              reflectedTypesOffset,
-              typedefs,
-            )
-            : constants.noCapabilityIndex;
-    int? dynamicReflectedTypeIndex =
-        reflectedTypeRequested
-            ? _dynamicTypeCodeIndex(
-              element.type,
-              await classes,
-              reflectedTypes,
-              reflectedTypesOffset,
-              typedefs,
-            )
-            : constants.noCapabilityIndex;
+    int? reflectedTypeIndex = reflectedTypeRequested
+        ? _typeCodeIndex(
+            element.type,
+            await classes,
+            reflectedTypes,
+            reflectedTypesOffset,
+            typedefs,
+          )
+        : constants.noCapabilityIndex;
+    int? dynamicReflectedTypeIndex = reflectedTypeRequested
+        ? _dynamicTypeCodeIndex(
+            element.type,
+            await classes,
+            reflectedTypes,
+            reflectedTypesOffset,
+            typedefs,
+          )
+        : constants.noCapabilityIndex;
     var reflectedTypeArguments = 'null';
     if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
       reflectedTypeArguments = await _computeReflectedTypeArguments(
@@ -1973,30 +1960,27 @@ class _ReflectorDomain {
     bool reflectedTypeRequested,
   ) async {
     int descriptor = _fieldDescriptor(element);
-    int ownerIndex =
-        (await classes).indexOf(element.enclosingElement2) ??
+    int ownerIndex = (await classes).indexOf(element.enclosingElement2) ??
         constants.noCapabilityIndex;
     int classMirrorIndex = await _computeVariableTypeIndex(element, descriptor);
-    int reflectedTypeIndex =
-        reflectedTypeRequested
-            ? _typeCodeIndex(
-              element.type,
-              await classes,
-              reflectedTypes,
-              reflectedTypesOffset,
-              typedefs,
-            )
-            : constants.noCapabilityIndex;
-    int dynamicReflectedTypeIndex =
-        reflectedTypeRequested
-            ? _dynamicTypeCodeIndex(
-              element.type,
-              await classes,
-              reflectedTypes,
-              reflectedTypesOffset,
-              typedefs,
-            )
-            : constants.noCapabilityIndex;
+    int reflectedTypeIndex = reflectedTypeRequested
+        ? _typeCodeIndex(
+            element.type,
+            await classes,
+            reflectedTypes,
+            reflectedTypesOffset,
+            typedefs,
+          )
+        : constants.noCapabilityIndex;
+    int dynamicReflectedTypeIndex = reflectedTypeRequested
+        ? _dynamicTypeCodeIndex(
+            element.type,
+            await classes,
+            reflectedTypes,
+            reflectedTypesOffset,
+            typedefs,
+          )
+        : constants.noCapabilityIndex;
     var reflectedTypeArguments = 'null';
     if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
       reflectedTypeArguments = await _computeReflectedTypeArguments(
@@ -2239,10 +2223,9 @@ class _ReflectorDomain {
         if (dartType.typeFormals.isNotEmpty) {
           if (useNameOfGenericFunctionType) {
             // Requested: just the name of the typedef; get it and return.
-            int dartTypeNumber =
-                typedefs.containsKey(dartType)
-                    ? typedefs[dartType]!
-                    : typedefNumber++;
+            int dartTypeNumber = typedefs.containsKey(dartType)
+                ? typedefs[dartType]!
+                : typedefNumber++;
             return _typedefName(dartTypeNumber);
           } else {
             // Requested: the spelled-out generic function type; continue.
@@ -2295,8 +2278,7 @@ class _ReflectorDomain {
             );
           }
           var connector = argumentTypes.isEmpty ? '' : ', ';
-          argumentTypes =
-              '$argumentTypes$connector'
+          argumentTypes = '$argumentTypes$connector'
               '[${optionalParameterTypeList.join(', ')}]';
         }
         if (dartType.namedParameterTypes.isNotEmpty) {
@@ -2314,8 +2296,7 @@ class _ReflectorDomain {
             namedParameterTypeList.add('$typeCode $name');
           }
           var connector = argumentTypes.isEmpty ? '' : ', ';
-          argumentTypes =
-              '$argumentTypes$connector'
+          argumentTypes = '$argumentTypes$connector'
               '{${namedParameterTypeList.join(', ')}}';
         }
         return '$returnType Function$typeArguments($argumentTypes)';
@@ -2436,10 +2417,9 @@ class _ReflectorDomain {
     TypeDefiningElement2 typeDefiningElement,
     _ImportCollector importCollector,
   ) {
-    DartType? type =
-        typeDefiningElement is InterfaceElement2
-            ? _typeForReflectable(typeDefiningElement)
-            : null;
+    DartType? type = typeDefiningElement is InterfaceElement2
+        ? _typeForReflectable(typeDefiningElement)
+        : null;
     if (type is DynamicType) return 'dynamic';
     if (type is InterfaceType) {
       InterfaceElement2 interfaceElement = type.element3;
@@ -2504,9 +2484,9 @@ class _ReflectorDomain {
     Iterable<int> methodIndices = libraryDomain._declarations
         .where(_executableIsntImplicitGetterOrSetter)
         .map((ExecutableElement2 element) {
-          int index = members.indexOf(element)!;
-          return index + methodsOffset;
-        });
+      int index = members.indexOf(element)!;
+      return index + methodsOffset;
+    });
 
     var declarationsCode = 'const <int>[${constants.noCapabilityIndex}]';
     if (_capabilities._impliesDeclarations) {
@@ -2594,35 +2574,32 @@ class _ReflectorDomain {
         DartType elementType = element.type;
         if (elementType is InterfaceType) {
           InterfaceElement2 elementTypeElement = elementType.element3;
-          classMirrorIndex =
-              (await classes).contains(elementTypeElement)
-                  ? (await classes).indexOf(elementTypeElement)!
-                  : constants.noCapabilityIndex;
+          classMirrorIndex = (await classes).contains(elementTypeElement)
+              ? (await classes).indexOf(elementTypeElement)!
+              : constants.noCapabilityIndex;
         } else {
           classMirrorIndex = constants.noCapabilityIndex;
         }
       }
     }
-    int reflectedTypeIndex =
-        reflectedTypeRequested
-            ? _typeCodeIndex(
-              element.type,
-              await classes,
-              reflectedTypes,
-              reflectedTypesOffset,
-              typedefs,
-            )
-            : constants.noCapabilityIndex;
-    int dynamicReflectedTypeIndex =
-        reflectedTypeRequested
-            ? _dynamicTypeCodeIndex(
-              element.type,
-              await classes,
-              reflectedTypes,
-              reflectedTypesOffset,
-              typedefs,
-            )
-            : constants.noCapabilityIndex;
+    int reflectedTypeIndex = reflectedTypeRequested
+        ? _typeCodeIndex(
+            element.type,
+            await classes,
+            reflectedTypes,
+            reflectedTypesOffset,
+            typedefs,
+          )
+        : constants.noCapabilityIndex;
+    int dynamicReflectedTypeIndex = reflectedTypeRequested
+        ? _dynamicTypeCodeIndex(
+            element.type,
+            await classes,
+            reflectedTypes,
+            reflectedTypesOffset,
+            typedefs,
+          )
+        : constants.noCapabilityIndex;
     var reflectedTypeArguments = 'null';
     if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
       reflectedTypeArguments = await _computeReflectedTypeArguments(
@@ -2658,10 +2635,9 @@ class _ReflectorDomain {
     }
     String code = await _extractDefaultValueCode(importCollector, element);
     var defaultValueCode = code.isEmpty ? 'null' : code;
-    var parameterSymbolCode =
-        descriptor & constants.namedAttribute != 0
-            ? '#${element.name3}'
-            : 'null';
+    var parameterSymbolCode = descriptor & constants.namedAttribute != 0
+        ? '#${element.name3}'
+        : 'null';
 
     return "r.ParameterMirrorImpl(r'${element.name3}', $descriptor, "
         '$ownerIndex, ${await _constConstructionCode(importCollector)}, '
@@ -2680,9 +2656,8 @@ class _ReflectorDomain {
     // TODO(eernst): 'dart:*' is not considered valid. To survive, we return
     // '' for all declarations from there. Issue 173.
     if (_isPlatformLibrary(parameterElement.library2!)) return '';
-    var parameterNode =
-        await _getDeclarationAst(parameterElement, _resolver)
-            as FormalParameter?;
+    var parameterNode = await _getDeclarationAst(parameterElement, _resolver)
+        as FormalParameter?;
     // The node can be null because the declaration is synthetic, e.g.,
     // the parameter of an induced setter; they have no default value.
     if (parameterNode is DefaultFormalParameter &&
@@ -2795,12 +2770,11 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement2> {
       if (mixinsRequested) result.add(mixinClass);
       InterfaceElement2? subClass =
           mixin == element.mixins.last ? element : null;
-      String? name =
-          subClass == null
-              ? null
-              : (element is MixinApplication && element.isMixinApplication
-                  ? element.name
-                  : null);
+      String? name = subClass == null
+          ? null
+          : (element is MixinApplication && element.isMixinApplication
+              ? element.name
+              : null);
       InterfaceElement2 mixinApplication = MixinApplication(
         name,
         superclass,
@@ -2864,13 +2838,12 @@ Set<InterfaceElement2> _mixinApplicationsOfClasses(
       InterfaceElement2 mixinClass = mixin.element3;
       InterfaceElement2? subClass =
           mixin == interfaceElement.mixins.last ? interfaceElement : null;
-      String? name =
-          subClass == null
-              ? null
-              : (interfaceElement is MixinApplication &&
-                      interfaceElement.isMixinApplication
-                  ? interfaceElement.name
-                  : null);
+      String? name = subClass == null
+          ? null
+          : (interfaceElement is MixinApplication &&
+                  interfaceElement.isMixinApplication
+              ? interfaceElement.name
+              : null);
       InterfaceElement2 mixinApplication = MixinApplication(
         name,
         superclass,
@@ -3112,10 +3085,10 @@ class _LibraryDomain {
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
   Iterable<ExecutableElement2> get _declarations => [
-    ..._declaredFunctions,
-    ..._getters,
-    ..._setters,
-  ];
+        ..._declaredFunctions,
+        ..._getters,
+        ..._setters,
+      ];
 
   @override
   String toString() {
@@ -3225,12 +3198,12 @@ class _ClassDomain {
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
   Iterable<ExecutableElement2> get _declarations => [
-    // TODO(sigurdm) feature: Include type variables (if we keep them).
-    ..._declaredMethods,
-    ..._getters,
-    ..._setters,
-    ..._constructors,
-  ];
+        // TODO(sigurdm) feature: Include type variables (if we keep them).
+        ..._declaredMethods,
+        ..._getters,
+        ..._setters,
+        ..._constructors,
+      ];
 
   /// Finds all instance members by going through the class hierarchy.
   Iterable<ExecutableElement2> get _instanceMembers {
@@ -3337,10 +3310,9 @@ class _ClassDomain {
       if (!accessor.isStatic || accessor.isPrivate) return;
       // If [member] is a synthetic accessor created from a field, search for
       // the metadata on the original field.
-      List<ElementAnnotation> metadata =
-          accessor.isSynthetic
-              ? (accessor.variable3?.metadata2.annotations ?? const [])
-              : accessor.metadata2.annotations;
+      List<ElementAnnotation> metadata = accessor.isSynthetic
+          ? (accessor.variable3?.metadata2.annotations ?? const [])
+          : accessor.metadata2.annotations;
       List<ElementAnnotation>? getterMetadata;
       if (_reflectorDomain._capabilities._impliesCorrespondingSetters &&
           accessor is SetterElement &&
@@ -3925,8 +3897,7 @@ class BuilderImplementation {
     if (element is ConstructorElement2) {
       DartType enclosingType = _typeForReflectable(element.enclosingElement2);
       DartType focusClassType = _typeForReflectable(focusClass);
-      bool isOk =
-          enclosingType is ParameterizedType &&
+      bool isOk = enclosingType is ParameterizedType &&
           focusClassType is InterfaceType &&
           await checkInheritance(enclosingType, focusClassType);
       if (isOk) {
@@ -3951,8 +3922,7 @@ class BuilderImplementation {
       if (constantValue == null) return null;
       DartType? constantValueType = constantValue.type;
       DartType focusClassType = _typeForReflectable(focusClass);
-      bool isOk =
-          constantValueType is ParameterizedType &&
+      bool isOk = constantValueType is ParameterizedType &&
           focusClassType is InterfaceType &&
           await checkInheritance(constantValueType, focusClassType);
       // When `isOK` is true, result.value.type.element is a InterfaceElement2.
@@ -4007,10 +3977,9 @@ class BuilderImplementation {
     InterfaceType typeType = reflectableLibrary.typeProvider.typeType;
     InterfaceElement2 typeTypeClass = typeType.element3;
 
-    ConstructorElement2 globalQuantifyCapabilityConstructor =
-        capabilityLibrary
-            .getClass('GlobalQuantifyCapability')!
-            .getNamedConstructor('')!;
+    ConstructorElement2 globalQuantifyCapabilityConstructor = capabilityLibrary
+        .getClass('GlobalQuantifyCapability')!
+        .getNamedConstructor('')!;
     ConstructorElement2 globalQuantifyMetaCapabilityConstructor =
         capabilityLibrary
             .getClass('GlobalQuantifyMetaCapability')!
@@ -4080,15 +4049,13 @@ class BuilderImplementation {
                 await _warn(WarningKind.badMetadata, message, metadatumElement);
                 continue;
               }
-              DartType? reflectorType =
-                  constantValue
-                      .getField('(super)')
-                      ?.getField('reflector')
-                      ?.type;
-              InterfaceElement2? reflector =
-                  reflectorType is InterfaceType
-                      ? reflectorType.element3
-                      : null;
+              DartType? reflectorType = constantValue
+                  .getField('(super)')
+                  ?.getField('reflector')
+                  ?.type;
+              InterfaceElement2? reflector = reflectorType is InterfaceType
+                  ? reflectorType.element3
+                  : null;
               if (reflector == null) {
                 await _warn(
                   WarningKind.badSuperclass,
@@ -4826,10 +4793,9 @@ class BuilderImplementation {
 
     var imports = <String>[];
     for (LibraryElement2 library in world.importCollector._libraries) {
-      Uri uri =
-          library == world.entryPointLibrary
-              ? Uri.parse(originalEntryPointFilename)
-              : await _getImportUri(library, _resolver, generatedLibraryId);
+      Uri uri = library == world.entryPointLibrary
+          ? Uri.parse(originalEntryPointFilename)
+          : await _getImportUri(library, _resolver, generatedLibraryId);
       String prefix = world.importCollector._getPrefix(library);
       if (prefix.isNotEmpty) {
         imports.add(
@@ -5185,10 +5151,9 @@ int _declarationDescriptor(ExecutableElement2 element) {
 }
 
 Future<String> _nameOfConstructor(ConstructorElement2 element) async {
-  String name =
-      element.name3 == ''
-          ? element.enclosingElement2.name3!
-          : '${element.enclosingElement2.name3}.${element.name3}';
+  String name = element.name3 == ''
+      ? element.enclosingElement2.name3!
+      : '${element.enclosingElement2.name3}.${element.name3}';
   if (_isPrivateName(name)) {
     await _severe('Cannot access private name $name', element);
   }
@@ -5367,10 +5332,9 @@ Future<String> _extractConstantCode(
         Element2? staticElement = expression.element;
         if (staticElement is PropertyAccessorElement2) {
           VariableElement2? variable = staticElement.variable3;
-          AstNode? variableDeclaration =
-              variable != null
-                  ? await _getDeclarationAst(variable, resolver)
-                  : null;
+          AstNode? variableDeclaration = variable != null
+              ? await _getDeclarationAst(variable, resolver)
+              : null;
           if (variableDeclaration == null ||
               variableDeclaration is! VariableDeclaration) {
             await _severe('Cannot handle private identifier $expression');
@@ -5789,13 +5753,12 @@ Iterable<FormalParameterElement> _extractDeclaredFunctionParameters(
   return result;
 }
 
-typedef CapabilityChecker =
-    bool Function(
-      TypeSystem,
-      String methodName,
-      Iterable<ElementAnnotation> metadata,
-      Iterable<ElementAnnotation>? getterMetadata,
-    );
+typedef CapabilityChecker = bool Function(
+  TypeSystem,
+  String methodName,
+  Iterable<ElementAnnotation> metadata,
+  Iterable<ElementAnnotation>? getterMetadata,
+);
 
 /// Returns the declared fields in the given [interfaceElement], filtered such
 /// that the returned ones are the ones that are supported by [capabilities].
@@ -5806,10 +5769,9 @@ Iterable<FieldElement2> _extractDeclaredFields(
 ) {
   return interfaceElement.fields2.where((FieldElement2 field) {
     if (field.isPrivate) return false;
-    CapabilityChecker capabilityChecker =
-        field.isStatic
-            ? capabilities.supportsStaticInvoke
-            : capabilities.supportsInstanceInvoke;
+    CapabilityChecker capabilityChecker = field.isStatic
+        ? capabilities.supportsStaticInvoke
+        : capabilities.supportsInstanceInvoke;
     return !field.isSynthetic &&
         capabilityChecker(
           interfaceElement.library2.typeSystem,
@@ -5829,10 +5791,9 @@ Iterable<MethodElement2> _extractDeclaredMethods(
 ) {
   return interfaceElement.methods2.where((MethodElement2 method) {
     if (method.isPrivate) return false;
-    CapabilityChecker capabilityChecker =
-        method.isStatic
-            ? capabilities.supportsStaticInvoke
-            : capabilities.supportsInstanceInvoke;
+    CapabilityChecker capabilityChecker = method.isStatic
+        ? capabilities.supportsStaticInvoke
+        : capabilities.supportsInstanceInvoke;
     return capabilityChecker(
       method.library2.typeSystem,
       method.name3!,
@@ -5952,15 +5913,13 @@ Iterable<GetterElement> _extractGetters(
     // such that we avoid passing in `null` at all call sites except one,
     // when we might as well move the processing to that single call site (such
     // as here, but also in `_extractLibraryAccessors()`, etc).
-    CapabilityChecker capabilityChecker =
-        getter.isStatic
-            ? capabilities.supportsStaticInvoke
-            : capabilities.supportsInstanceInvoke;
-    List<ElementAnnotation> metadata =
-        getter.isSynthetic
-            ? (getter.variable3?.metadata2.annotations ??
-                const <ElementAnnotation>[])
-            : getter.metadata2.annotations;
+    CapabilityChecker capabilityChecker = getter.isStatic
+        ? capabilities.supportsStaticInvoke
+        : capabilities.supportsInstanceInvoke;
+    List<ElementAnnotation> metadata = getter.isSynthetic
+        ? (getter.variable3?.metadata2.annotations ??
+            const <ElementAnnotation>[])
+        : getter.metadata2.annotations;
     List<ElementAnnotation>? getterMetadata;
     return capabilityChecker(
       getter.library2.typeSystem,
@@ -5986,15 +5945,13 @@ Iterable<SetterElement> _extractSetters(
 ) {
   return interfaceElement.setters2.where((SetterElement setter) {
     if (setter.isPrivate) return false;
-    CapabilityChecker capabilityChecker =
-        setter.isStatic
-            ? capabilities.supportsStaticInvoke
-            : capabilities.supportsInstanceInvoke;
-    List<ElementAnnotation> metadata =
-        setter.isSynthetic
-            ? (setter.variable3?.metadata2.annotations ??
-                const <ElementAnnotation>[])
-            : setter.metadata2.annotations;
+    CapabilityChecker capabilityChecker = setter.isStatic
+        ? capabilities.supportsStaticInvoke
+        : capabilities.supportsInstanceInvoke;
+    List<ElementAnnotation> metadata = setter.isSynthetic
+        ? (setter.variable3?.metadata2.annotations ??
+            const <ElementAnnotation>[])
+        : setter.metadata2.annotations;
     List<ElementAnnotation>? getterMetadata;
     if (capabilities._impliesCorrespondingSetters && !setter.isSynthetic) {
       GetterElement? correspondingGetter = setter.correspondingGetter;
@@ -6037,34 +5994,32 @@ _LibraryDomain _createLibraryDomain(
 ) {
   Iterable<TopLevelVariableElement2> declaredVariablesOfLibrary =
       _extractDeclaredVariables(
-        domain._resolver,
-        library,
-        domain._capabilities,
-      ).toList();
+    domain._resolver,
+    library,
+    domain._capabilities,
+  ).toList();
   Iterable<TopLevelFunctionElement> declaredFunctionsOfLibrary =
       _extractDeclaredFunctions(
-        domain._resolver,
-        library,
-        domain._capabilities,
-      ).toList();
-  Iterable<GetterElement> gettersOfLibrary =
-      _extractLibraryGetters(
-        domain._resolver,
-        library,
-        domain._capabilities,
-      ).toList();
-  Iterable<SetterElement> settersOfLibrary =
-      _extractLibrarySetters(
-        domain._resolver,
-        library,
-        domain._capabilities,
-      ).toList();
+    domain._resolver,
+    library,
+    domain._capabilities,
+  ).toList();
+  Iterable<GetterElement> gettersOfLibrary = _extractLibraryGetters(
+    domain._resolver,
+    library,
+    domain._capabilities,
+  ).toList();
+  Iterable<SetterElement> settersOfLibrary = _extractLibrarySetters(
+    domain._resolver,
+    library,
+    domain._capabilities,
+  ).toList();
   Iterable<FormalParameterElement> declaredParametersOfLibrary =
       _extractDeclaredFunctionParameters(
-        domain._resolver,
-        declaredFunctionsOfLibrary,
-        gettersOfLibrary,
-      ).toList();
+    domain._resolver,
+    declaredFunctionsOfLibrary,
+    gettersOfLibrary,
+  ).toList();
   return _LibraryDomain(
     library,
     declaredVariablesOfLibrary,
@@ -6081,38 +6036,34 @@ _ClassDomain _createClassDomain(
   _ReflectorDomain domain,
 ) {
   if (type is MixinApplication) {
-    Iterable<FieldElement2> declaredFieldsOfClass =
-        _extractDeclaredFields(
-          domain._resolver,
-          type.mixin,
-          domain._capabilities,
-        ).where((FieldElement2 e) => !e.isStatic).toList();
-    Iterable<MethodElement2> declaredMethodsOfClass =
-        _extractDeclaredMethods(
-          domain._resolver,
-          type.mixin,
-          domain._capabilities,
-        ).where((MethodElement2 e) => !e.isStatic).toList();
-    Iterable<GetterElement> declaredAndImplicitGettersOfClass =
-        _extractGetters(
-          domain._resolver,
-          type.mixin,
-          domain._capabilities,
-        ).toList();
-    Iterable<SetterElement> declaredAndImplicitSettersOfClass =
-        _extractSetters(
-          domain._resolver,
-          type.mixin,
-          domain._capabilities,
-        ).toList();
+    Iterable<FieldElement2> declaredFieldsOfClass = _extractDeclaredFields(
+      domain._resolver,
+      type.mixin,
+      domain._capabilities,
+    ).where((FieldElement2 e) => !e.isStatic).toList();
+    Iterable<MethodElement2> declaredMethodsOfClass = _extractDeclaredMethods(
+      domain._resolver,
+      type.mixin,
+      domain._capabilities,
+    ).where((MethodElement2 e) => !e.isStatic).toList();
+    Iterable<GetterElement> declaredAndImplicitGettersOfClass = _extractGetters(
+      domain._resolver,
+      type.mixin,
+      domain._capabilities,
+    ).toList();
+    Iterable<SetterElement> declaredAndImplicitSettersOfClass = _extractSetters(
+      domain._resolver,
+      type.mixin,
+      domain._capabilities,
+    ).toList();
     Iterable<ConstructorElement2> declaredConstructorsOfClass =
         <ConstructorElement2>[];
     Iterable<FormalParameterElement> declaredParametersOfClass =
         _extractDeclaredParameters(
-          declaredMethodsOfClass,
-          declaredConstructorsOfClass,
-          declaredAndImplicitSettersOfClass,
-        );
+      declaredMethodsOfClass,
+      declaredConstructorsOfClass,
+      declaredAndImplicitSettersOfClass,
+    );
 
     return _ClassDomain(
       type,
@@ -6126,35 +6077,33 @@ _ClassDomain _createClassDomain(
     );
   }
 
-  List<FieldElement2> declaredFieldsOfClass =
-      _extractDeclaredFields(
-        domain._resolver,
-        type,
-        domain._capabilities,
-      ).toList();
-  List<MethodElement2> declaredMethodsOfClass =
-      _extractDeclaredMethods(
-        domain._resolver,
-        type,
-        domain._capabilities,
-      ).toList();
+  List<FieldElement2> declaredFieldsOfClass = _extractDeclaredFields(
+    domain._resolver,
+    type,
+    domain._capabilities,
+  ).toList();
+  List<MethodElement2> declaredMethodsOfClass = _extractDeclaredMethods(
+    domain._resolver,
+    type,
+    domain._capabilities,
+  ).toList();
   List<GetterElement> declaredAndImplicitGettersOfClass =
       _extractGetters(domain._resolver, type, domain._capabilities).toList();
   List<SetterElement> declaredAndImplicitSettersOfClass =
       _extractSetters(domain._resolver, type, domain._capabilities).toList();
   List<ConstructorElement2> declaredConstructorsOfClass =
       _extractDeclaredConstructors(
-        domain._resolver,
-        type.library2,
-        type,
-        domain._capabilities,
-      ).toList();
+    domain._resolver,
+    type.library2,
+    type,
+    domain._capabilities,
+  ).toList();
   List<FormalParameterElement> declaredParametersOfClass =
       _extractDeclaredParameters(
-        declaredMethodsOfClass,
-        declaredConstructorsOfClass,
-        declaredAndImplicitSettersOfClass,
-      );
+    declaredMethodsOfClass,
+    declaredConstructorsOfClass,
+    declaredAndImplicitSettersOfClass,
+  );
   return _ClassDomain(
     type,
     declaredFieldsOfClass,
@@ -6315,11 +6264,12 @@ class MixinApplication implements ClassElementImpl2 {
   InterfaceType instantiate({
     required List<DartType> typeArguments,
     required NullabilitySuffix nullabilitySuffix,
-  }) => InterfaceTypeImpl(
-    element: this,
-    typeArguments: typeArguments,
-    nullabilitySuffix: nullabilitySuffix,
-  );
+  }) =>
+      InterfaceTypeImpl(
+        element: this,
+        typeArguments: typeArguments,
+        nullabilitySuffix: nullabilitySuffix,
+      );
 
   @override
   InterfaceType? get supertype {
@@ -6575,8 +6525,8 @@ Future<String> _formatDiagnosticMessage(
       resolver,
     );
     if (resolvedLibrary != null) {
-      final ElementDeclarationResult? targetDeclaration = resolvedLibrary
-          .getElementDeclaration(target!);
+      final ElementDeclarationResult? targetDeclaration =
+          resolvedLibrary.getElementDeclaration(target!);
       final CompilationUnit? unit = targetDeclaration?.resolvedUnit?.unit;
       final CharacterLocation? location = unit?.lineInfo.getLocation(
         nameOffset,
@@ -6598,10 +6548,9 @@ Future<void> _emitMessage(
   Element2? target,
   Resolver? resolver,
 ]) async {
-  String formattedMessage =
-      (target != null && resolver != null)
-          ? await _formatDiagnosticMessage(message, target, resolver)
-          : message;
+  String formattedMessage = (target != null && resolver != null)
+      ? await _formatDiagnosticMessage(message, target, resolver)
+      : message;
   log.warning(formattedMessage);
 }
 
@@ -6622,8 +6571,8 @@ Future<ResolvedLibraryResult?> _getResolvedLibrary(
     await resolver.assetIdForElement(library),
   );
   final AnalysisSession freshSession = freshLibrary.session;
-  final SomeResolvedLibraryResult someResult = await freshSession
-      .getResolvedLibraryByElement(freshLibrary);
+  final SomeResolvedLibraryResult someResult =
+      await freshSession.getResolvedLibraryByElement(freshLibrary);
   if (someResult is ResolvedLibraryResult) {
     return someResult;
   } else {

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -3234,21 +3234,11 @@ class _ClassDomain {
         if (member.isPrivate) return;
         // If [member] is a synthetic accessor created from a field, search for
         // the metadata on the original field.
-        List<ElementAnnotation> metadata;
-        if (member is GetterElement) {
-          metadata =
-              member.isSynthetic
-                  ? (member.variable3?.metadata2.annotations ??
-                      const <ElementAnnotation>[])
-                  : member.metadata2.annotations;
-        } else if (member is SetterElement) {
-          metadata =
-              member.isSynthetic
-                  ? (member.variable3?.metadata2.annotations ??
-                      const <ElementAnnotation>[])
-                  : member.metadata2.annotations;
-        }
-
+        List<ElementAnnotation> metadata =
+            (member is PropertyAccessorElement2 && member.isSynthetic)
+                ? member.variable3?.metadata2.annotations ??
+                    const <ElementAnnotation>[]
+                : member.metadata2.annotations;
         List<ElementAnnotation>? getterMetadata;
         if (_reflectorDomain._capabilities._impliesCorrespondingSetters &&
             member is SetterElement &&

--- a/reflectable/lib/src/element_capability.dart
+++ b/reflectable/lib/src/element_capability.dart
@@ -197,8 +197,10 @@ const subtypeQuantifyCapability = _SubtypeQuantifyCapability();
 class SuperclassQuantifyCapability implements ReflecteeQuantifyCapability {
   final Element? upperBound;
   final bool excludeUpperBound;
-  const SuperclassQuantifyCapability(this.upperBound,
-      {this.excludeUpperBound = false});
+  const SuperclassQuantifyCapability(
+    this.upperBound, {
+    this.excludeUpperBound = false,
+  });
 }
 
 // Note that `null` represents the [ClassElement] for `Object`.
@@ -211,8 +213,9 @@ class TypeAnnotationQuantifyCapability implements ReflecteeQuantifyCapability {
 
 const typeAnnotationQuantifyCapability = TypeAnnotationQuantifyCapability();
 
-const typeAnnotationDeepQuantifyCapability =
-    TypeAnnotationQuantifyCapability(transitive: true);
+const typeAnnotationDeepQuantifyCapability = TypeAnnotationQuantifyCapability(
+  transitive: true,
+);
 
 const correspondingSetterQuantifyCapability =
     _CorrespondingSetterQuantifyCapability();
@@ -227,13 +230,13 @@ class ImportAttachedCapability {
 class GlobalQuantifyCapability extends ImportAttachedCapability {
   final String classNamePattern;
   const GlobalQuantifyCapability(this.classNamePattern, Element reflector)
-      : super(reflector);
+    : super(reflector);
 }
 
 class GlobalQuantifyMetaCapability extends ImportAttachedCapability {
   final Element metadataType;
   const GlobalQuantifyMetaCapability(this.metadataType, Element reflector)
-      : super(reflector);
+    : super(reflector);
 }
 
 class _ReflectedTypeCapability implements DeclarationsCapability {

--- a/reflectable/lib/src/element_capability.dart
+++ b/reflectable/lib/src/element_capability.dart
@@ -19,7 +19,7 @@ library reflectable.src.element_capability;
 // NB! It is crucial that all changes in '../capabilities.dart' are
 // performed in the corresponding manner here, and vice versa.
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 
 abstract class ReflectCapability {
   const ReflectCapability();
@@ -35,7 +35,7 @@ abstract class NamePatternCapability implements ApiReflectCapability {
 }
 
 abstract class MetadataQuantifiedCapability implements ApiReflectCapability {
-  final InterfaceElement metadataType;
+  final InterfaceElement2 metadataType;
   const MetadataQuantifiedCapability(this.metadataType);
 }
 
@@ -195,7 +195,7 @@ abstract class ReflecteeQuantifyCapability implements ReflectCapability {
 const subtypeQuantifyCapability = _SubtypeQuantifyCapability();
 
 class SuperclassQuantifyCapability implements ReflecteeQuantifyCapability {
-  final Element? upperBound;
+  final Element2? upperBound;
   final bool excludeUpperBound;
   const SuperclassQuantifyCapability(
     this.upperBound, {
@@ -223,19 +223,19 @@ const correspondingSetterQuantifyCapability =
 const admitSubtypeCapability = _AdmitSubtypeCapability();
 
 class ImportAttachedCapability {
-  final Element reflector;
+  final Element2 reflector;
   const ImportAttachedCapability(this.reflector);
 }
 
 class GlobalQuantifyCapability extends ImportAttachedCapability {
   final String classNamePattern;
-  const GlobalQuantifyCapability(this.classNamePattern, Element reflector)
+  const GlobalQuantifyCapability(this.classNamePattern, Element2 reflector)
     : super(reflector);
 }
 
 class GlobalQuantifyMetaCapability extends ImportAttachedCapability {
-  final Element metadataType;
-  const GlobalQuantifyMetaCapability(this.metadataType, Element reflector)
+  final Element2 metadataType;
+  const GlobalQuantifyMetaCapability(this.metadataType, Element2 reflector)
     : super(reflector);
 }
 

--- a/reflectable/lib/src/incompleteness.dart
+++ b/reflectable/lib/src/incompleteness.dart
@@ -36,7 +36,8 @@ Never unreachableError(String message) {
 /// avoid warnings about a missing return problem, and the code may be more
 /// readable.
 Never unimplementedError(String message) {
-  var extendedMessage = '*** Unfortunately, this feature has not yet been '
+  var extendedMessage =
+      '*** Unfortunately, this feature has not yet been '
       'implemented: $message.\n'
       'If you wish to ensure that it is prioritized, please report it '
       'on github.com/dart-lang/reflectable.';

--- a/reflectable/lib/src/reflectable_base.dart
+++ b/reflectable/lib/src/reflectable_base.dart
@@ -54,30 +54,30 @@ class ReflectableBase {
 
   /// Const constructor, to enable usage as metadata, allowing for varargs
   /// style invocation with up to ten arguments.
-  const ReflectableBase(
-      [this._cap0,
-      this._cap1,
-      this._cap2,
-      this._cap3,
-      this._cap4,
-      this._cap5,
-      this._cap6,
-      this._cap7,
-      this._cap8,
-      this._cap9])
-      : _capabilitiesGivenAsList = false,
-        _capabilities = null;
+  const ReflectableBase([
+    this._cap0,
+    this._cap1,
+    this._cap2,
+    this._cap3,
+    this._cap4,
+    this._cap5,
+    this._cap6,
+    this._cap7,
+    this._cap8,
+    this._cap9,
+  ]) : _capabilitiesGivenAsList = false,
+       _capabilities = null;
 
   const ReflectableBase.fromList(this._capabilities)
-      : _capabilitiesGivenAsList = true,
-        _cap0 = null,
-        _cap1 = null,
-        _cap2 = null,
-        _cap3 = null,
-        _cap4 = null,
-        _cap5 = null,
-        _cap6 = null,
-        _cap7 = null,
-        _cap8 = null,
-        _cap9 = null;
+    : _capabilitiesGivenAsList = true,
+      _cap0 = null,
+      _cap1 = null,
+      _cap2 = null,
+      _cap3 = null,
+      _cap4 = null,
+      _cap5 = null,
+      _cap6 = null,
+      _cap7 = null,
+      _cap8 = null,
+      _cap9 = null;
 }

--- a/reflectable/lib/src/reflectable_builder_based.dart
+++ b/reflectable/lib/src/reflectable_builder_based.dart
@@ -110,15 +110,16 @@ class ReflectorData {
   Map<Type, TypeMirror>? _typeToTypeMirrorCache;
 
   ReflectorData(
-      this.typeMirrors,
-      this.memberMirrors,
-      this.parameterMirrors,
-      this.types,
-      this.supportedClassCount,
-      this.getters,
-      this.setters,
-      this.libraryMirrors,
-      this.parameterListShapes);
+    this.typeMirrors,
+    this.memberMirrors,
+    this.parameterMirrors,
+    this.types,
+    this.supportedClassCount,
+    this.getters,
+    this.setters,
+    this.libraryMirrors,
+    this.parameterListShapes,
+  );
 
   /// Returns a type mirror for the given [type].
   ///
@@ -135,9 +136,11 @@ class ReflectorData {
         // Note that [types] corresponds to the prefix of [typeMirrors] which
         // are class mirrors; [typeMirrors] continues with type variable
         // mirrors, and they are irrelevant here.
-        _typeToTypeMirrorCache = typeToTypeMirrorCache = <Type, TypeMirror>{
-          for (var i = 0; i < supportedClassCount; ++i) types[i]: typeMirrors[i]
-        };
+        _typeToTypeMirrorCache =
+            typeToTypeMirrorCache = <Type, TypeMirror>{
+              for (var i = 0; i < supportedClassCount; ++i)
+                types[i]: typeMirrors[i],
+            };
       }
       typeToTypeMirrorCache[_typeOf<void>()] = VoidMirrorImpl();
       typeToTypeMirrorCache[dynamic] = DynamicMirrorImpl();
@@ -154,7 +157,10 @@ class ReflectorData {
       if (typeMirror is GenericClassMirrorImpl) {
         if (typeMirror._isGenericRuntimeTypeOf(instance)) {
           return _createInstantiatedGenericClass(
-              typeMirror, instance.runtimeType, null);
+            typeMirror,
+            instance.runtimeType,
+            null,
+          );
         }
       }
     }
@@ -163,7 +169,8 @@ class ReflectorData {
   }
 }
 
-const String pleaseInitializeMessage = 'Reflectable has not been initialized.\n'
+const String pleaseInitializeMessage =
+    'Reflectable has not been initialized.\n'
     'Please make sure that the first action taken by your program\n'
     'in `main` is to call `initializeReflectable()`.';
 
@@ -216,7 +223,8 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
       // type of the reflectee is known.
       if (!_data.types.contains(reflectee.runtimeType)) {
         throw NoSuchCapabilityError(
-            'Reflecting on un-marked type "${reflectee.runtimeType}"');
+          'Reflecting on un-marked type "${reflectee.runtimeType}"',
+        );
       }
     }
   }
@@ -229,21 +237,29 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
   ClassMirror get type {
     if (!_supportsType) {
       throw NoSuchCapabilityError(
-          'Attempt to get `type` without `TypeCapability`.');
+        'Attempt to get `type` without `TypeCapability`.',
+      );
     }
     return _type!;
   }
 
   @override
-  Object? invoke(String methodName, List<Object?> positionalArguments,
-      [Map<Symbol, Object?>? namedArguments]) {
+  Object? invoke(
+    String methodName,
+    List<Object?> positionalArguments, [
+    Map<Symbol, Object?>? namedArguments,
+  ]) {
     Never fail() {
       // It could be a method that exists but the given capabilities rejected
       // it, it could be a method that does not exist at all, or it could be
       // a non-conforming argument list shape. In all cases we consider the
       // invocation to be a capability violation.
       throw reflectableNoSuchMethodError(
-          reflectee, methodName, positionalArguments, namedArguments);
+        reflectee,
+        methodName,
+        positionalArguments,
+        namedArguments,
+      );
     }
 
     // Obtain the tear-off closure for the method that we will invoke.
@@ -260,11 +276,17 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
       throw unreachableError('Attempt to `invoke` without class mirrors');
     }
     if (!_type!._checkInstanceParameterListShape(
-        methodName, positionalArguments.length, namedArguments?.keys)) {
+      methodName,
+      positionalArguments.length,
+      namedArguments?.keys,
+    )) {
       fail();
     }
     return Function.apply(
-        methodTearer(reflectee), positionalArguments, namedArguments);
+      methodTearer(reflectee),
+      positionalArguments,
+      namedArguments,
+    );
   }
 
   @override
@@ -283,26 +305,29 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
   @override
   dynamic delegate(Invocation invocation) {
     Never fail() {
-      StringInvocationKind kind = invocation.isGetter
-          ? StringInvocationKind.getter
-          : (invocation.isSetter
-              ? StringInvocationKind.setter
-              : StringInvocationKind.method);
+      StringInvocationKind kind =
+          invocation.isGetter
+              ? StringInvocationKind.getter
+              : (invocation.isSetter
+                  ? StringInvocationKind.setter
+                  : StringInvocationKind.method);
       // TODO(eernst) implement: Pass the de-minified `memberName` string, if
       // get support for translating arbitrary symbols to strings (the caller
       // could use `new Symbol(..)` so we cannot assume that this symbol is
       // known).
       throw reflectableNoSuchInvokableError(
-          reflectee,
-          '${invocation.memberName}',
-          invocation.positionalArguments,
-          invocation.namedArguments,
-          kind);
+        reflectee,
+        '${invocation.memberName}',
+        invocation.positionalArguments,
+        invocation.namedArguments,
+        kind,
+      );
     }
 
     if (memberSymbolMap == null) {
       throw NoSuchCapabilityError(
-          'Attempt to `delegate` without `delegateCapability`');
+        'Attempt to `delegate` without `delegateCapability`',
+      );
     }
     String? memberName = memberSymbolMap![invocation.memberName];
     if (memberName == null) {
@@ -325,8 +350,11 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
       }
       return invokeSetter(memberName, invocation.positionalArguments[0]);
     } else {
-      return invoke(memberName, invocation.positionalArguments,
-          invocation.namedArguments);
+      return invoke(
+        memberName,
+        invocation.positionalArguments,
+        invocation.namedArguments,
+      );
     }
   }
 
@@ -392,8 +420,9 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     if (_superinterfaceIndices.length == 1 &&
         _superinterfaceIndices[0] == noCapabilityIndex) {
       throw NoSuchCapabilityError(
-          'Requesting `superinterfaces` of `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Requesting `superinterfaces` of `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return _superinterfaceIndices.map<ClassMirror>((int i) {
       if (i == noCapabilityIndex) {
@@ -402,8 +431,9 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
         // we do have the `typeRelationsCapability`, but we may still
         // encounter a single unsupported superinterface.
         throw NoSuchCapabilityError(
-            'Requesting a superinterface of `$qualifiedName` '
-            'without capability');
+          'Requesting a superinterface of `$qualifiedName` '
+          'without capability',
+        );
       }
       return _data.typeMirrors[i] as ClassMirror;
     }).toList();
@@ -450,23 +480,24 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   final Map<String, int>? _parameterListShapes;
 
   ClassMirrorBase(
-      this.simpleName,
-      this.qualifiedName,
-      this._descriptor,
-      this._classIndex,
-      this._reflector,
-      this._declarationIndices,
-      this._instanceMemberIndices,
-      this._staticMemberIndices,
-      this._superclassIndex,
-      this._getters,
-      this._setters,
-      this._constructors,
-      this._ownerIndex,
-      this._mixinIndex,
-      this._superinterfaceIndices,
-      this._metadata,
-      this._parameterListShapes);
+    this.simpleName,
+    this.qualifiedName,
+    this._descriptor,
+    this._classIndex,
+    this._reflector,
+    this._declarationIndices,
+    this._instanceMemberIndices,
+    this._staticMemberIndices,
+    this._superclassIndex,
+    this._getters,
+    this._setters,
+    this._constructors,
+    this._ownerIndex,
+    this._mixinIndex,
+    this._superinterfaceIndices,
+    this._metadata,
+    this._parameterListShapes,
+  );
 
   @override
   bool get isAbstract => (_descriptor & constants.abstractAttribute != 0);
@@ -487,7 +518,8 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
         // that.
         if (declarationIndex == noCapabilityIndex) {
           throw NoSuchCapabilityError(
-              'Requesting declarations of "$qualifiedName" without capability');
+            'Requesting declarations of "$qualifiedName" without capability',
+          );
         }
         DeclarationMirror declarationMirror =
             _data.memberMirrors![declarationIndex];
@@ -508,7 +540,8 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       List<int>? instanceMemberIndices = _instanceMemberIndices;
       if (instanceMemberIndices == null) {
         throw NoSuchCapabilityError(
-            'Requesting instanceMembers without `declarationsCapability`.');
+          'Requesting instanceMembers without `declarationsCapability`.',
+        );
       }
       var result = <String, MethodMirror>{};
       for (int instanceMemberIndex in instanceMemberIndices) {
@@ -532,7 +565,8 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       List<int>? staticMemberIndices = _staticMemberIndices;
       if (staticMemberIndices == null) {
         throw NoSuchCapabilityError(
-            'Requesting instanceMembers without `declarationsCapability`.');
+          'Requesting instanceMembers without `declarationsCapability`.',
+        );
       }
       var result = <String, MethodMirror>{};
       for (int staticMemberIndex in staticMemberIndices) {
@@ -553,22 +587,28 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     if (_mixinIndex == noCapabilityIndex) {
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to get `mixin` for `$qualifiedName` '
-            'without `typeRelationsCapability`');
+          'Attempt to get `mixin` for `$qualifiedName` '
+          'without `typeRelationsCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Attempt to get mixin from "$simpleName" without capability');
+        'Attempt to get mixin from "$simpleName" without capability',
+      );
     }
     return _data.typeMirrors[_mixinIndex] as ClassMirror;
   }
 
   bool _checkParameterListShape(
-      String methodName,
+    String methodName,
+    int numberOfPositionalArguments,
+    Iterable<Symbol>? namedArgumentNames,
+    MethodMirrorProvider methodMirrorProvider,
+  ) {
+    bool checkUsingShape(
+      List parameterListShape,
       int numberOfPositionalArguments,
       Iterable<Symbol>? namedArgumentNames,
-      MethodMirrorProvider methodMirrorProvider) {
-    bool checkUsingShape(List parameterListShape,
-        int numberOfPositionalArguments, Iterable<Symbol>? namedArgumentNames) {
+    ) {
       assert(parameterListShape.length == 3);
       int numberOfPositionalParameters = parameterListShape[0];
       int numberOfOptionalPositionalParameters = parameterListShape[1];
@@ -586,8 +626,9 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // We do have named arguments; check that they are all known.
       return namesOfNamedParameters == null
           ? false
-          : namedArgumentNames
-              .every((Symbol name) => namesOfNamedParameters.contains(name));
+          : namedArgumentNames.every(
+            (Symbol name) => namesOfNamedParameters.contains(name),
+          );
     }
 
     Map<String, int>? parameterListShapes = _parameterListShapes;
@@ -605,8 +646,11 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // invocation received an argument list that it supports. It is a bug if
       // `shapeIndex` is out of range for `parameterListShapes`, but if that
       // happens the built-in range check will catch it.
-      return checkUsingShape(_data.parameterListShapes![shapeIndex],
-          numberOfPositionalArguments, namedArgumentNames);
+      return checkUsingShape(
+        _data.parameterListShapes![shapeIndex],
+        numberOfPositionalArguments,
+        namedArgumentNames,
+      );
     } else {
       // Without ready-to-use parameter list shape information we must compute
       // the shape from declaration mirrors.
@@ -627,29 +671,52 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       var methodMirrorImpl = methodMirror as MethodMirrorImpl;
       // Let the [methodMirrorImpl] check it based on declaration mirrors.
       return methodMirrorImpl._isArgumentListShapeAppropriate(
-          numberOfPositionalArguments, namedArgumentNames);
+        numberOfPositionalArguments,
+        namedArgumentNames,
+      );
     }
   }
 
-  bool _checkInstanceParameterListShape(String methodName,
-      int numberOfPositionalArguments, Iterable<Symbol>? namedArgumentNames) {
-    return _checkParameterListShape(methodName, numberOfPositionalArguments,
-        namedArgumentNames, (String name) => instanceMembers[name]);
+  bool _checkInstanceParameterListShape(
+    String methodName,
+    int numberOfPositionalArguments,
+    Iterable<Symbol>? namedArgumentNames,
+  ) {
+    return _checkParameterListShape(
+      methodName,
+      numberOfPositionalArguments,
+      namedArgumentNames,
+      (String name) => instanceMembers[name],
+    );
   }
 
-  bool _checkStaticParameterListShape(String methodName,
-      int numberOfPositionalArguments, Iterable<Symbol>? namedArgumentNames) {
-    return _checkParameterListShape(methodName, numberOfPositionalArguments,
-        namedArgumentNames, (String name) => staticMembers[name]);
+  bool _checkStaticParameterListShape(
+    String methodName,
+    int numberOfPositionalArguments,
+    Iterable<Symbol>? namedArgumentNames,
+  ) {
+    return _checkParameterListShape(
+      methodName,
+      numberOfPositionalArguments,
+      namedArgumentNames,
+      (String name) => staticMembers[name],
+    );
   }
 
   @override
-  Object newInstance(String constructorName, List positionalArguments,
-      [Map<Symbol, dynamic>? namedArguments]) {
+  Object newInstance(
+    String constructorName,
+    List positionalArguments, [
+    Map<Symbol, dynamic>? namedArguments,
+  ]) {
     Never fail() {
       Type? type = hasReflectedType ? reflectedType : null;
       throw reflectableNoSuchConstructorError(
-          type, constructorName, positionalArguments, namedArguments);
+        type,
+        constructorName,
+        positionalArguments,
+        namedArguments,
+      );
     }
 
     Function? constructor = _constructors[constructorName];
@@ -660,28 +727,41 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       fail();
     }
     return Function.apply(
-        constructor(true), positionalArguments, namedArguments);
+      constructor(true),
+      positionalArguments,
+      namedArguments,
+    );
   }
 
   @override
-  Object? invoke(String memberName, List positionalArguments,
-      [Map<Symbol, dynamic>? namedArguments]) {
+  Object? invoke(
+    String memberName,
+    List positionalArguments, [
+    Map<Symbol, dynamic>? namedArguments,
+  ]) {
     Never fail() {
       throw reflectableNoSuchMethodError(
-          hasReflectedType ? reflectedType : null,
-          memberName,
-          positionalArguments,
-          namedArguments);
+        hasReflectedType ? reflectedType : null,
+        memberName,
+        positionalArguments,
+        namedArguments,
+      );
     }
 
     StaticGetter? getter = _getters[memberName];
     if (getter == null) fail();
     if (!_checkStaticParameterListShape(
-        memberName, positionalArguments.length, namedArguments?.keys)) {
+      memberName,
+      positionalArguments.length,
+      namedArguments?.keys,
+    )) {
       fail();
     }
     return Function.apply(
-        getter() as Function, positionalArguments, namedArguments);
+      getter() as Function,
+      positionalArguments,
+      namedArguments,
+    );
   }
 
   @override
@@ -699,8 +779,9 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
         _isSetterName(name) ? name : _getterNameToSetterName(name);
     StaticSetter? setter = _setters[setterName];
     if (setter == null) {
-      throw reflectableNoSuchSetterError(
-          reflectedType, setterName, [value], {});
+      throw reflectableNoSuchSetterError(reflectedType, setterName, [
+        value,
+      ], {});
     }
     return setter(value);
   }
@@ -736,7 +817,8 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       String description =
           hasReflectedType ? reflectedType.toString() : qualifiedName;
       throw NoSuchCapabilityError(
-          'Requesting metadata of "$description" without capability');
+        'Requesting metadata of "$description" without capability',
+      );
     }
     return _metadata;
   }
@@ -762,12 +844,14 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // for access to superinterfaces here.
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to evaluate `isAssignableTo` for `$qualifiedName` '
-            'without `typeRelationsCapability`');
+          'Attempt to evaluate `isAssignableTo` for `$qualifiedName` '
+          'without `typeRelationsCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Attempt to evaluate `isAssignableTo` for `$qualifiedName` '
-          'without capability.');
+        'Attempt to evaluate `isAssignableTo` for `$qualifiedName` '
+        'without capability.',
+      );
     }
     return _isSubtypeOf(other) ||
         (other is ClassMirrorBase && other._isSubtypeOf(this));
@@ -785,12 +869,14 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // for access to superinterfaces here.
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to evaluate `isSubtypeOf` for `$qualifiedName` '
-            'without `typeRelationsCapability`');
+          'Attempt to evaluate `isSubtypeOf` for `$qualifiedName` '
+          'without `typeRelationsCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Attempt to evaluate `isSubtypeOf` for `$qualifiedName` '
-          'without capability.');
+        'Attempt to evaluate `isSubtypeOf` for `$qualifiedName` '
+        'without capability.',
+      );
     }
     return _isSubtypeOf(other);
   }
@@ -808,8 +894,10 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     // Recursively test hierarchy over `superclass`.
     if (superclass!._isSubtypeOf(other)) return true;
     // Recursively test hierarchy over remaining direct supertypes.
-    return superinterfaces.any((ClassMirror classMirror) =>
-        classMirror is ClassMirrorBase && classMirror._isSubtypeOf(other));
+    return superinterfaces.any(
+      (ClassMirror classMirror) =>
+          classMirror is ClassMirrorBase && classMirror._isSubtypeOf(other),
+    );
   }
 
   @override
@@ -824,12 +912,14 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // for access to superinterfaces here.
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to evaluate `isSubclassOf` for `$qualifiedName` '
-            'without `typeRelationsCapability`');
+          'Attempt to evaluate `isSubclassOf` for `$qualifiedName` '
+          'without `typeRelationsCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Attempt to evaluate `isSubclassOf` for $qualifiedName '
-          'without capability.');
+        'Attempt to evaluate `isSubclassOf` for $qualifiedName '
+        'without capability.',
+      );
     }
     return _isSubclassOf(other);
   }
@@ -852,12 +942,14 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     if (_ownerIndex == noCapabilityIndex) {
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to get `owner` of `$qualifiedName` '
-            'without `typeRelationsCapability`');
+          'Attempt to get `owner` of `$qualifiedName` '
+          'without `typeRelationsCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Trying to get owner of class `$qualifiedName` '
-          'without `libraryCapability`');
+        'Trying to get owner of class `$qualifiedName` '
+        'without `libraryCapability`',
+      );
     }
     return _data.libraryMirrors![_ownerIndex];
   }
@@ -867,11 +959,14 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     if (_superclassIndex == noCapabilityIndex) {
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to get `superclass` of `$qualifiedName` '
-            'without `typeRelationsCapability`');
+          'Attempt to get `superclass` of `$qualifiedName` '
+          'without `typeRelationsCapability`',
+        );
       }
-      throw NoSuchCapabilityError('Requesting mirror on un-marked class, '
-          '`superclass` of `$qualifiedName`');
+      throw NoSuchCapabilityError(
+        'Requesting mirror on un-marked class, '
+        '`superclass` of `$qualifiedName`',
+      );
     }
     if (_superclassIndex == null) return null; // Superclass of [Object].
     return _data.typeMirrors[_superclassIndex] as ClassMirrorBase?;
@@ -880,30 +975,32 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
 
 class NonGenericClassMirrorImpl extends ClassMirrorBase {
   NonGenericClassMirrorImpl(
-      super.simpleName,
-      super.qualifiedName,
-      super.descriptor,
-      super.classIndex,
-      super.reflector,
-      super.declarationIndices,
-      super.instanceMemberIndices,
-      super.staticMemberIndices,
-      super.superclassIndex,
-      super.getters,
-      super.setters,
-      super.constructors,
-      super.ownerIndex,
-      super.mixinIndex,
-      super.superinterfaceIndices,
-      super.metadata,
-      super.parameterListShapes);
+    super.simpleName,
+    super.qualifiedName,
+    super.descriptor,
+    super.classIndex,
+    super.reflector,
+    super.declarationIndices,
+    super.instanceMemberIndices,
+    super.staticMemberIndices,
+    super.superclassIndex,
+    super.getters,
+    super.setters,
+    super.constructors,
+    super.ownerIndex,
+    super.mixinIndex,
+    super.superinterfaceIndices,
+    super.metadata,
+    super.parameterListShapes,
+  );
 
   @override
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `typeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `typeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return const <TypeMirror>[];
   }
@@ -913,8 +1010,9 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `typeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability` or `reflectedTypeCapability`');
+        'Attempt to get `typeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability` or `reflectedTypeCapability`',
+      );
     }
     return const <Type>[];
   }
@@ -923,8 +1021,9 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
   List<TypeVariableMirror> get typeVariables {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to evaluate `typeVariables` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to evaluate `typeVariables` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return const <TypeVariableMirror>[];
   }
@@ -936,8 +1035,9 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `originalDeclaration` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `originalDeclaration` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return this;
   }
@@ -982,33 +1082,35 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   final int _dynamicReflectedTypeIndex;
 
   GenericClassMirrorImpl(
-      super.simpleName,
-      super.qualifiedName,
-      super.descriptor,
-      super.classIndex,
-      super.reflector,
-      super.declarationIndices,
-      super.instanceMemberIndices,
-      super.staticMemberIndices,
-      int super.superclassIndex,
-      super.getters,
-      super.setters,
-      super.constructors,
-      super.ownerIndex,
-      super.mixinIndex,
-      super.superinterfaceIndices,
-      super.metadata,
-      super.parameterListShapes,
-      this._isGenericRuntimeTypeOf,
-      this._typeVariableIndices,
-      this._dynamicReflectedTypeIndex);
+    super.simpleName,
+    super.qualifiedName,
+    super.descriptor,
+    super.classIndex,
+    super.reflector,
+    super.declarationIndices,
+    super.instanceMemberIndices,
+    super.staticMemberIndices,
+    int super.superclassIndex,
+    super.getters,
+    super.setters,
+    super.constructors,
+    super.ownerIndex,
+    super.mixinIndex,
+    super.superinterfaceIndices,
+    super.metadata,
+    super.parameterListShapes,
+    this._isGenericRuntimeTypeOf,
+    this._typeVariableIndices,
+    this._dynamicReflectedTypeIndex,
+  );
 
   @override
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `typeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `typeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     // This mirror represents the original declaration, so no actual type
     // arguments have been passed. By convention we represent this situation
@@ -1021,8 +1123,9 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability` or `reflectedTypeCapability`');
+        'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability` or `reflectedTypeCapability`',
+      );
     }
     // This mirror represents the original declaration, so no actual type
     // arguments have been passed. By convention we represent this situation
@@ -1040,11 +1143,13 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
     if (typeVariableIndices == null) {
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to evaluate `typeVariables` for `$qualifiedName` '
-            'without `typeRelationsCapability`');
+          'Attempt to evaluate `typeVariables` for `$qualifiedName` '
+          'without `typeRelationsCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Requesting type variables of `$qualifiedName` without capability');
+        'Requesting type variables of `$qualifiedName` without capability',
+      );
     }
     var result = <TypeVariableMirror>[];
     for (int typeVariableIndex in typeVariableIndices) {
@@ -1062,8 +1167,9 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `originalDeclaration` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `originalDeclaration` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return this;
   }
@@ -1073,8 +1179,10 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
 
   @override
   Type get reflectedType {
-    throw UnsupportedError('Attempt to obtain `reflectedType` '
-        'from generic class `$qualifiedName`.');
+    throw UnsupportedError(
+      'Attempt to obtain `reflectedType` '
+      'from generic class `$qualifiedName`.',
+    );
   }
 
   @override
@@ -1085,12 +1193,14 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
     if (_dynamicReflectedTypeIndex == noCapabilityIndex) {
       if (!_supportsReflectedType(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to evaluate `dynamicReflectedType` for `$qualifiedName` '
-            'without `reflectedTypeCapability`');
+          'Attempt to evaluate `dynamicReflectedType` for `$qualifiedName` '
+          'without `reflectedTypeCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Attempt to get `dynamicReflectedType` for `$qualifiedName` '
-          'without capability');
+        'Attempt to get `dynamicReflectedType` for `$qualifiedName` '
+        'without capability',
+      );
     }
     return _data.types[_dynamicReflectedTypeIndex];
   }
@@ -1112,33 +1222,35 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
   final List<int>? _reflectedTypeArgumentIndices;
 
   InstantiatedGenericClassMirrorImpl(
-      super.simpleName,
-      super.qualifiedName,
-      super.descriptor,
-      super.classIndex,
-      super.reflector,
-      super.declarationIndices,
-      super.instanceMemberIndices,
-      super.staticMemberIndices,
-      super.superclassIndex,
-      super.getters,
-      super.setters,
-      super.constructors,
-      super.ownerIndex,
-      super.mixinIndex,
-      super.superinterfaceIndices,
-      super.metadata,
-      super.parameterListShapes,
-      this._originalDeclaration,
-      this._reflectedType,
-      this._reflectedTypeArgumentIndices);
+    super.simpleName,
+    super.qualifiedName,
+    super.descriptor,
+    super.classIndex,
+    super.reflector,
+    super.declarationIndices,
+    super.instanceMemberIndices,
+    super.staticMemberIndices,
+    super.superclassIndex,
+    super.getters,
+    super.setters,
+    super.constructors,
+    super.ownerIndex,
+    super.mixinIndex,
+    super.superinterfaceIndices,
+    super.metadata,
+    super.parameterListShapes,
+    this._originalDeclaration,
+    this._reflectedType,
+    this._reflectedTypeArgumentIndices,
+  );
 
   @override
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `typeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `typeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return reflectedTypeArguments
         .map((Type type) => _reflector.reflectType(type))
@@ -1150,8 +1262,9 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability` or `reflectedTypeCapability`');
+        'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability` or `reflectedTypeCapability`',
+      );
     }
     List<int>? reflectedTypeArgumentIndices = _reflectedTypeArgumentIndices;
     if (reflectedTypeArgumentIndices == null) {
@@ -1173,8 +1286,9 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `originalDeclaration` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `originalDeclaration` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return _originalDeclaration;
   }
@@ -1188,8 +1302,10 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
     if (reflectedType != null) {
       return reflectedType;
     }
-    throw UnsupportedError('Cannot provide `reflectedType` of '
-        'instance of generic type `$simpleName`.');
+    throw UnsupportedError(
+      'Cannot provide `reflectedType` of '
+      'instance of generic type `$simpleName`.',
+    );
   }
 
   @override
@@ -1246,34 +1362,36 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
 }
 
 InstantiatedGenericClassMirrorImpl _createInstantiatedGenericClass(
-    GenericClassMirrorImpl genericClassMirror,
-    Type? reflectedType,
-    List<int>? reflectedTypeArguments,
-    [int? descriptor]) {
+  GenericClassMirrorImpl genericClassMirror,
+  Type? reflectedType,
+  List<int>? reflectedTypeArguments, [
+  int? descriptor,
+]) {
   // TODO(eernst) implement: Pass a representation of type arguments to this
   // method, and create an instantiated generic class which includes that
   // information.
   return InstantiatedGenericClassMirrorImpl(
-      genericClassMirror.simpleName,
-      genericClassMirror.qualifiedName,
-      descriptor ?? genericClassMirror._descriptor,
-      genericClassMirror._classIndex,
-      genericClassMirror._reflector,
-      genericClassMirror._declarationIndices,
-      genericClassMirror._instanceMemberIndices,
-      genericClassMirror._staticMemberIndices,
-      genericClassMirror._superclassIndex,
-      genericClassMirror._getters,
-      genericClassMirror._setters,
-      genericClassMirror._constructors,
-      genericClassMirror._ownerIndex,
-      genericClassMirror._mixinIndex,
-      genericClassMirror._superinterfaceIndices,
-      genericClassMirror._metadata,
-      genericClassMirror._parameterListShapes,
-      genericClassMirror,
-      reflectedType,
-      reflectedTypeArguments);
+    genericClassMirror.simpleName,
+    genericClassMirror.qualifiedName,
+    descriptor ?? genericClassMirror._descriptor,
+    genericClassMirror._classIndex,
+    genericClassMirror._reflector,
+    genericClassMirror._declarationIndices,
+    genericClassMirror._instanceMemberIndices,
+    genericClassMirror._staticMemberIndices,
+    genericClassMirror._superclassIndex,
+    genericClassMirror._getters,
+    genericClassMirror._setters,
+    genericClassMirror._constructors,
+    genericClassMirror._ownerIndex,
+    genericClassMirror._mixinIndex,
+    genericClassMirror._superinterfaceIndices,
+    genericClassMirror._metadata,
+    genericClassMirror._parameterListShapes,
+    genericClassMirror,
+    reflectedType,
+    reflectedTypeArguments,
+  );
 }
 
 class TypeVariableMirrorImpl extends _DataCaching
@@ -1304,8 +1422,14 @@ class TypeVariableMirrorImpl extends _DataCaching
   /// means no metadata, null means no capability.
   final List<Object>? _metadata;
 
-  TypeVariableMirrorImpl(this.simpleName, this.qualifiedName, this._reflector,
-      this._upperBoundIndex, this._ownerIndex, this._metadata);
+  TypeVariableMirrorImpl(
+    this.simpleName,
+    this.qualifiedName,
+    this._reflector,
+    this._upperBoundIndex,
+    this._ownerIndex,
+    this._metadata,
+  );
 
   @override
   bool get isStatic => false;
@@ -1315,8 +1439,10 @@ class TypeVariableMirrorImpl extends _DataCaching
     int? upperBoundIndex = _upperBoundIndex;
     if (upperBoundIndex == null) return DynamicMirrorImpl();
     if (upperBoundIndex == noCapabilityIndex) {
-      throw NoSuchCapabilityError('Attempt to get `upperBound` from type '
-          'variable mirror without capability.');
+      throw NoSuchCapabilityError(
+        'Attempt to get `upperBound` from type '
+        'variable mirror without capability.',
+      );
     }
     return _data.typeMirrors[upperBoundIndex];
   }
@@ -1325,8 +1451,9 @@ class TypeVariableMirrorImpl extends _DataCaching
   bool isAssignableTo(TypeMirror other) {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `isAssignableTo` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `isAssignableTo` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return upperBound.isSubtypeOf(other) || other.isSubtypeOf(this);
   }
@@ -1335,8 +1462,9 @@ class TypeVariableMirrorImpl extends _DataCaching
   bool isSubtypeOf(TypeMirror other) {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `isSubtypeOf` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `isSubtypeOf` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return upperBound.isSubtypeOf(other);
   }
@@ -1345,8 +1473,9 @@ class TypeVariableMirrorImpl extends _DataCaching
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `originalDeclaration` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `originalDeclaration` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return this;
   }
@@ -1358,8 +1487,9 @@ class TypeVariableMirrorImpl extends _DataCaching
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `typeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `typeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return const <TypeMirror>[];
   }
@@ -1369,8 +1499,9 @@ class TypeVariableMirrorImpl extends _DataCaching
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability` or `reflectedTypeCapability`');
+        'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability` or `reflectedTypeCapability`',
+      );
     }
     return const <Type>[];
   }
@@ -1379,16 +1510,19 @@ class TypeVariableMirrorImpl extends _DataCaching
   List<TypeVariableMirror> get typeVariables {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to evaluate `typeVariables` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to evaluate `typeVariables` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return <TypeVariableMirror>[];
   }
 
   @override
   Type get reflectedType {
-    throw UnsupportedError('Attempt to get `reflectedType` from type '
-        'variable $simpleName');
+    throw UnsupportedError(
+      'Attempt to get `reflectedType` from type '
+      'variable $simpleName',
+    );
   }
 
   @override
@@ -1397,8 +1531,10 @@ class TypeVariableMirrorImpl extends _DataCaching
   @override
   List<Object> get metadata {
     if (_metadata == null) {
-      throw NoSuchCapabilityError('Attempt to get `metadata` from type '
-          'variable $simpleName without capability');
+      throw NoSuchCapabilityError(
+        'Attempt to get `metadata` from type '
+        'variable $simpleName without capability',
+      );
     }
     return <Object>[];
   }
@@ -1428,8 +1564,9 @@ class TypeVariableMirrorImpl extends _DataCaching
   DeclarationMirror get owner {
     if (_ownerIndex == noCapabilityIndex) {
       throw NoSuchCapabilityError(
-          'Trying to get owner of type parameter `$qualifiedName` '
-          'without capability');
+        'Trying to get owner of type parameter `$qualifiedName` '
+        'without capability',
+      );
     }
     return _data.typeMirrors[_ownerIndex];
   }
@@ -1461,14 +1598,15 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
   final Map<String, int>? _parameterListShapes;
 
   LibraryMirrorImpl(
-      this.simpleName,
-      this.uri,
-      this._reflector,
-      this._declarationIndices,
-      this.getters,
-      this.setters,
-      this._metadata,
-      this._parameterListShapes);
+    this.simpleName,
+    this.uri,
+    this._reflector,
+    this._declarationIndices,
+    this.getters,
+    this.setters,
+    this._metadata,
+    this._parameterListShapes,
+  );
 
   Map<String, DeclarationMirror>? _declarations;
 
@@ -1486,7 +1624,8 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
         // that.
         if (declarationIndex == noCapabilityIndex) {
           throw NoSuchCapabilityError(
-              'Requesting declarations of `$qualifiedName` without capability');
+            'Requesting declarations of `$qualifiedName` without capability',
+          );
         }
         DeclarationMirror declarationMirror =
             _data.memberMirrors![declarationIndex];
@@ -1503,10 +1642,16 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
     return declarations;
   }
 
-  bool _checkParameterListShape(String memberName,
-      int numberOfPositionalArguments, Iterable<Symbol>? namedArgumentNames) {
-    bool checkUsingShape(List parameterListShape,
-        int numberOfPositionalArguments, Iterable<Symbol>? namedArgumentNames) {
+  bool _checkParameterListShape(
+    String memberName,
+    int numberOfPositionalArguments,
+    Iterable<Symbol>? namedArgumentNames,
+  ) {
+    bool checkUsingShape(
+      List parameterListShape,
+      int numberOfPositionalArguments,
+      Iterable<Symbol>? namedArgumentNames,
+    ) {
       assert(parameterListShape.length == 3);
       int numberOfPositionalParameters = parameterListShape[0];
       int numberOfOptionalPositionalParameters = parameterListShape[1];
@@ -1518,8 +1663,9 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
         return false;
       }
       if (namedArgumentNames == null) return true;
-      return namedArgumentNames
-          .every((Symbol name) => namesOfNamedParameters.contains(name));
+      return namedArgumentNames.every(
+        (Symbol name) => namesOfNamedParameters.contains(name),
+      );
     }
 
     Map<String, int>? parameterListShapes = _parameterListShapes;
@@ -1537,8 +1683,11 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
       // invocation received an argument list that it supports. It is a bug if
       // `shapeIndex` is out of range for `parameterListShapes`, but if that
       // happens the built-in range check will catch it.
-      return checkUsingShape(_data.parameterListShapes![shapeIndex],
-          numberOfPositionalArguments, namedArgumentNames);
+      return checkUsingShape(
+        _data.parameterListShapes![shapeIndex],
+        numberOfPositionalArguments,
+        namedArgumentNames,
+      );
     } else {
       // Without ready-to-use parameter list shape information we must compute
       // the shape from declaration mirrors.
@@ -1562,26 +1711,41 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
       var methodMirrorImpl = methodMirror as MethodMirrorImpl;
       // Let the [methodMirrorImpl] check it based on declaration mirrors.
       return methodMirrorImpl._isArgumentListShapeAppropriate(
-          numberOfPositionalArguments, namedArgumentNames);
+        numberOfPositionalArguments,
+        namedArgumentNames,
+      );
     }
   }
 
   @override
-  Object? invoke(String memberName, List positionalArguments,
-      [Map<Symbol, dynamic>? namedArguments]) {
+  Object? invoke(
+    String memberName,
+    List positionalArguments, [
+    Map<Symbol, dynamic>? namedArguments,
+  ]) {
     Never fail() {
       throw reflectableNoSuchMethodError(
-          null, memberName, positionalArguments, namedArguments);
+        null,
+        memberName,
+        positionalArguments,
+        namedArguments,
+      );
     }
 
     StaticGetter? getter = getters[memberName];
     if (getter == null) fail();
     if (!_checkParameterListShape(
-        memberName, positionalArguments.length, namedArguments?.keys)) {
+      memberName,
+      positionalArguments.length,
+      namedArguments?.keys,
+    )) {
       fail();
     }
     return Function.apply(
-        getter() as Function, positionalArguments, namedArguments);
+      getter() as Function,
+      positionalArguments,
+      namedArguments,
+    );
   }
 
   @override
@@ -1621,7 +1785,8 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
     List<Object>? metadata = _metadata;
     if (metadata == null) {
       throw NoSuchCapabilityError(
-          'Requesting metadata of library `$simpleName` without capability');
+        'Requesting metadata of library `$simpleName` without capability',
+      );
     }
     return metadata;
   }
@@ -1696,16 +1861,17 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   final List<Object>? _metadata;
 
   MethodMirrorImpl(
-      this._name,
-      this._descriptor,
-      this._ownerIndex,
-      this._returnTypeIndex,
-      this._reflectedReturnTypeIndex,
-      this._dynamicReflectedReturnTypeIndex,
-      this._reflectedTypeArgumentsOfReturnType,
-      this._parameterIndices,
-      this._reflector,
-      this._metadata);
+    this._name,
+    this._descriptor,
+    this._ownerIndex,
+    this._returnTypeIndex,
+    this._reflectedReturnTypeIndex,
+    this._dynamicReflectedReturnTypeIndex,
+    this._reflectedTypeArgumentsOfReturnType,
+    this._parameterIndices,
+    this._reflector,
+    this._metadata,
+  );
 
   int get kind => constants.kindFromEncoding(_descriptor);
 
@@ -1713,8 +1879,9 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   DeclarationMirror get owner {
     if (_ownerIndex == noCapabilityIndex) {
       throw NoSuchCapabilityError(
-          'Trying to get owner of method `$qualifiedName` '
-          'without `LibraryCapability`');
+        'Trying to get owner of method `$qualifiedName` '
+        'without `LibraryCapability`',
+      );
     }
     return isTopLevel
         ? _data.libraryMirrors![_ownerIndex]
@@ -1792,7 +1959,8 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
     List<Object>? metadata = _metadata;
     if (metadata == null) {
       throw NoSuchCapabilityError(
-          'Requesting metadata of method `$simpleName` without capability');
+        'Requesting metadata of method `$simpleName` without capability',
+      );
     }
     return metadata;
   }
@@ -1801,7 +1969,8 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   List<ParameterMirror> get parameters {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `parameters` without `DeclarationsCapability`');
+        'Attempt to get `parameters` without `DeclarationsCapability`',
+      );
     }
     return _parameterIndices
         .map((int parameterIndex) => _data.parameterMirrors![parameterIndex])
@@ -1818,15 +1987,17 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
     if (_hasNeverReturnType) return VoidMirrorImpl();
     if (_returnTypeIndex == noCapabilityIndex) {
       throw NoSuchCapabilityError(
-          'Requesting returnType of method `$simpleName` without capability');
+        'Requesting returnType of method `$simpleName` without capability',
+      );
     }
     if (_hasClassReturnType) {
       TypeMirror typeMirror = _data.typeMirrors[_returnTypeIndex];
       return _hasGenericReturnType
           ? _createInstantiatedGenericClass(
-              typeMirror as GenericClassMirrorImpl,
-              null,
-              _reflectedTypeArgumentsOfReturnType)
+            typeMirror as GenericClassMirrorImpl,
+            null,
+            _reflectedTypeArgumentsOfReturnType,
+          )
           : typeMirror;
     }
     throw unreachableError('Unexpected kind of returnType');
@@ -1845,8 +2016,10 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
     if (_hasDynamicReturnType) return dynamic;
     if (_hasNeverReturnType) return Never;
     if (_reflectedReturnTypeIndex == noCapabilityIndex) {
-      throw NoSuchCapabilityError('Requesting reflectedReturnType of method '
-          '`$simpleName` without capability');
+      throw NoSuchCapabilityError(
+        'Requesting reflectedReturnType of method '
+        '`$simpleName` without capability',
+      );
     }
     return _data.types[_reflectedReturnTypeIndex];
   }
@@ -1864,9 +2037,10 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   }
 
   @override
-  String get simpleName => isConstructor
-      ? (_name == '' ? owner.simpleName : '${owner.simpleName}.$_name')
-      : _name;
+  String get simpleName =>
+      isConstructor
+          ? (_name == '' ? owner.simpleName : '${owner.simpleName}.$_name')
+          : _name;
 
   @override
   String? get source => null;
@@ -1928,7 +2102,9 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   Set<Symbol>? _namesOfNamedParameters;
 
   bool _isArgumentListShapeAppropriate(
-      int numberOfPositionalArguments, Iterable<Symbol>? namedArgumentNames) {
+    int numberOfPositionalArguments,
+    Iterable<Symbol>? namedArgumentNames,
+  ) {
     if (numberOfPositionalArguments <
             numberOfPositionalParameters -
                 numberOfOptionalPositionalParameters ||
@@ -1936,8 +2112,9 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
       return false;
     }
     if (namedArgumentNames == null) return true;
-    return namedArgumentNames
-        .every((Symbol name) => namesOfNamedParameters.contains(name));
+    return namedArgumentNames.every(
+      (Symbol name) => namesOfNamedParameters.contains(name),
+    );
   }
 
   @override
@@ -1958,7 +2135,10 @@ abstract class ImplicitAccessorMirrorImpl extends _DataCaching
       _data.memberMirrors![_variableMirrorIndex] as VariableMirrorImpl;
 
   ImplicitAccessorMirrorImpl(
-      this._reflector, this._variableMirrorIndex, this._selfIndex);
+    this._reflector,
+    this._variableMirrorIndex,
+    this._selfIndex,
+  );
 
   int get kind => constants.kindFromEncoding(_variableMirror._descriptor);
 
@@ -2032,7 +2212,10 @@ abstract class ImplicitAccessorMirrorImpl extends _DataCaching
 
 class ImplicitGetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   ImplicitGetterMirrorImpl(
-      super.reflector, super.variableMirrorIndex, super.selfIndex);
+    super.reflector,
+    super.variableMirrorIndex,
+    super.selfIndex,
+  );
 
   @override
   bool get isGetter => true;
@@ -2044,7 +2227,8 @@ class ImplicitGetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   List<ParameterMirror> get parameters {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `parameters` without `DeclarationsCapability`');
+        'Attempt to get `parameters` without `DeclarationsCapability`',
+      );
     }
     return <ParameterMirror>[];
   }
@@ -2061,7 +2245,10 @@ class ImplicitGetterMirrorImpl extends ImplicitAccessorMirrorImpl {
 
 class ImplicitSetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   ImplicitSetterMirrorImpl(
-      super.reflector, super.variableMirrorIndex, super.selfIndex);
+    super.reflector,
+    super.variableMirrorIndex,
+    super.selfIndex,
+  );
 
   @override
   bool get isGetter => false;
@@ -2087,21 +2274,23 @@ class ImplicitSetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   List<ParameterMirror> get parameters {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `parameters` without `DeclarationsCapability`');
+        'Attempt to get `parameters` without `DeclarationsCapability`',
+      );
     }
     return <ParameterMirror>[
       ParameterMirrorImpl(
-          _variableMirror.simpleName,
-          _parameterDescriptor,
-          _selfIndex,
-          _variableMirror._reflector,
-          _variableMirror._classMirrorIndex,
-          _variableMirror._reflectedTypeIndex,
-          _variableMirror._dynamicReflectedTypeIndex,
-          _variableMirror._reflectedTypeArguments,
-          const <Object>[],
-          null,
-          null)
+        _variableMirror.simpleName,
+        _parameterDescriptor,
+        _selfIndex,
+        _variableMirror._reflector,
+        _variableMirror._classMirrorIndex,
+        _variableMirror._reflectedTypeIndex,
+        _variableMirror._dynamicReflectedTypeIndex,
+        _variableMirror._reflectedTypeArguments,
+        const <Object>[],
+        null,
+        null,
+      ),
     ];
   }
 
@@ -2131,15 +2320,16 @@ abstract class VariableMirrorBase extends _DataCaching
   final List<Object>? _metadata;
 
   VariableMirrorBase(
-      this._name,
-      this._descriptor,
-      this._ownerIndex,
-      this._reflector,
-      this._classMirrorIndex,
-      this._reflectedTypeIndex,
-      this._dynamicReflectedTypeIndex,
-      this._reflectedTypeArguments,
-      this._metadata);
+    this._name,
+    this._descriptor,
+    this._ownerIndex,
+    this._reflector,
+    this._classMirrorIndex,
+    this._reflectedTypeIndex,
+    this._dynamicReflectedTypeIndex,
+    this._reflectedTypeArguments,
+    this._metadata,
+  );
 
   int get kind => constants.kindFromEncoding(_descriptor);
 
@@ -2176,7 +2366,8 @@ abstract class VariableMirrorBase extends _DataCaching
     List<Object>? metadata = _metadata;
     if (metadata == null) {
       throw NoSuchCapabilityError(
-          'Requesting metadata of field `$simpleName` without capability');
+        'Requesting metadata of field `$simpleName` without capability',
+      );
     }
     return metadata;
   }
@@ -2195,10 +2386,12 @@ abstract class VariableMirrorBase extends _DataCaching
     if (_classMirrorIndex == noCapabilityIndex) {
       if (!_supportsType(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to get `type` without `TypeCapability`');
+          'Attempt to get `type` without `TypeCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Attempt to get class mirror for un-marked class (type of `$_name`)');
+        'Attempt to get class mirror for un-marked class (type of `$_name`)',
+      );
     }
     if (_isClassType) {
       TypeMirror typeMirror = _data.typeMirrors[_classMirrorIndex];
@@ -2206,10 +2399,11 @@ abstract class VariableMirrorBase extends _DataCaching
           typeMirror.isNonNullable != _isNonNullable) {
         if (_isGenericType) {
           return _createInstantiatedGenericClass(
-              typeMirror as GenericClassMirrorImpl,
-              hasReflectedType ? reflectedType : null,
-              _reflectedTypeArguments,
-              _descriptor);
+            typeMirror as GenericClassMirrorImpl,
+            hasReflectedType ? reflectedType : null,
+            _reflectedTypeArguments,
+            _descriptor,
+          );
         } else {
           var classMirror = typeMirror as NonGenericClassMirrorImpl;
           return NonGenericClassMirrorImpl(
@@ -2235,9 +2429,10 @@ abstract class VariableMirrorBase extends _DataCaching
       } else {
         return _isGenericType
             ? _createInstantiatedGenericClass(
-                typeMirror as GenericClassMirrorImpl,
-                hasReflectedType ? reflectedType : null,
-                _reflectedTypeArguments)
+              typeMirror as GenericClassMirrorImpl,
+              hasReflectedType ? reflectedType : null,
+              _reflectedTypeArguments,
+            )
             : typeMirror;
       }
     }
@@ -2259,10 +2454,12 @@ abstract class VariableMirrorBase extends _DataCaching
     if (_reflectedTypeIndex == noCapabilityIndex) {
       if (!_supportsReflectedType(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to get `reflectedType` without `reflectedTypeCapability`');
+          'Attempt to get `reflectedType` without `reflectedTypeCapability`',
+        );
       }
       throw UnsupportedError(
-          'Attempt to get reflectedType without capability (of `$_name`)');
+        'Attempt to get reflectedType without capability (of `$_name`)',
+      );
     }
     return _data.types[_reflectedTypeIndex];
   }
@@ -2292,8 +2489,9 @@ class VariableMirrorImpl extends VariableMirrorBase {
   DeclarationMirror get owner {
     if (_ownerIndex == noCapabilityIndex) {
       throw NoSuchCapabilityError(
-          'Trying to get owner of variable `$qualifiedName` '
-          'without capability');
+        'Trying to get owner of variable `$qualifiedName` '
+        'without capability',
+      );
     }
     return isTopLevel
         ? _data.libraryMirrors![_ownerIndex]
@@ -2307,15 +2505,16 @@ class VariableMirrorImpl extends VariableMirrorBase {
   bool get isConst => (_descriptor & constants.constAttribute != 0);
 
   VariableMirrorImpl(
-      super.name,
-      super.descriptor,
-      super.ownerIndex,
-      super.reflectable,
-      super.classMirrorIndex,
-      super.reflectedTypeIndex,
-      super.dynamicReflectedTypeIndex,
-      super.reflectedTypeArguments,
-      super.metadata);
+    super.name,
+    super.descriptor,
+    super.ownerIndex,
+    super.reflectable,
+    super.classMirrorIndex,
+    super.reflectedTypeIndex,
+    super.dynamicReflectedTypeIndex,
+    super.reflectedTypeArguments,
+    super.metadata,
+  );
 
   // Note that the corresponding implementation of [hashCode] is inherited from
   // [VariableMirrorBase].
@@ -2347,7 +2546,8 @@ class ParameterMirrorImpl extends VariableMirrorBase
   bool get hasDefaultValue {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `hasDefaultValue` without `DeclarationsCapability`');
+        'Attempt to get `hasDefaultValue` without `DeclarationsCapability`',
+      );
     }
     return (_descriptor & constants.hasDefaultValueAttribute != 0);
   }
@@ -2356,7 +2556,8 @@ class ParameterMirrorImpl extends VariableMirrorBase
   Object? get defaultValue {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `defaultValue` without `DeclarationsCapability`');
+        'Attempt to get `defaultValue` without `DeclarationsCapability`',
+      );
     }
     return _defaultValue;
   }
@@ -2371,17 +2572,18 @@ class ParameterMirrorImpl extends VariableMirrorBase
   MethodMirror get owner => _data.memberMirrors![_ownerIndex] as MethodMirror;
 
   ParameterMirrorImpl(
-      super.name,
-      super.descriptor,
-      super.ownerIndex,
-      super.reflectable,
-      super.classMirrorIndex,
-      super.reflectedTypeIndex,
-      super.dynamicReflectedTypeIndex,
-      super.reflectedTypeArguments,
-      super.metadata,
-      this._defaultValue,
-      this._nameSymbol);
+    super.name,
+    super.descriptor,
+    super.ownerIndex,
+    super.reflectable,
+    super.classMirrorIndex,
+    super.reflectedTypeIndex,
+    super.dynamicReflectedTypeIndex,
+    super.reflectedTypeArguments,
+    super.metadata,
+    this._defaultValue,
+    this._nameSymbol,
+  );
 
   // Note that the corresponding implementation of [hashCode] is inherited from
   // [VariableMirrorBase].
@@ -2534,20 +2736,21 @@ abstract class ReflectableImpl extends ReflectableBase
     implements ReflectableInterface {
   /// Const constructor, to enable usage as metadata, allowing for varargs
   /// style invocation with up to ten arguments.
-  const ReflectableImpl(
-      [super.cap0,
-      super.cap1,
-      super.cap2,
-      super.cap3,
-      super.cap4,
-      super.cap5,
-      super.cap6,
-      super.cap7,
-      super.cap8,
-      super.cap9]);
+  const ReflectableImpl([
+    super.cap0,
+    super.cap1,
+    super.cap2,
+    super.cap3,
+    super.cap4,
+    super.cap5,
+    super.cap6,
+    super.cap7,
+    super.cap8,
+    super.cap9,
+  ]);
 
   const ReflectableImpl.fromList(List<ReflectCapability> super.capabilities)
-      : super.fromList();
+    : super.fromList();
 
   @override
   bool canReflect(Object reflectee) {
@@ -2560,8 +2763,9 @@ abstract class ReflectableImpl extends ReflectableBase
   }
 
   bool get _hasTypeCapability {
-    return capabilities
-        .any((ReflectCapability capability) => capability is TypeCapability);
+    return capabilities.any(
+      (ReflectCapability capability) => capability is TypeCapability,
+    );
   }
 
   @override
@@ -2574,7 +2778,8 @@ abstract class ReflectableImpl extends ReflectableBase
     TypeMirror? result = data[this]!.typeMirrorForType(type);
     if (result == null || !_hasTypeCapability) {
       throw NoSuchCapabilityError(
-          'Reflecting on type `$type` without capability');
+        'Reflecting on type `$type` without capability',
+      );
     }
     return result;
   }
@@ -2583,8 +2788,10 @@ abstract class ReflectableImpl extends ReflectableBase
   LibraryMirror findLibrary(String libraryName) {
     ReflectorData reflectorData = data[this]!;
     if (reflectorData.libraryMirrors == null) {
-      throw NoSuchCapabilityError('Using `findLibrary` without capability. '
-          'Try adding `libraryCapability`.');
+      throw NoSuchCapabilityError(
+        'Using `findLibrary` without capability. '
+        'Try adding `libraryCapability`.',
+      );
     }
     // The specification says that an exception shall be thrown if there
     // is anything other than one library with a matching name.
@@ -2610,8 +2817,10 @@ abstract class ReflectableImpl extends ReflectableBase
   Map<Uri, LibraryMirror> get libraries {
     ReflectorData reflectorData = data[this]!;
     if (reflectorData.libraryMirrors == null) {
-      throw NoSuchCapabilityError('Using `libraries` without capability. '
-          'Try adding `libraryCapability`.');
+      throw NoSuchCapabilityError(
+        'Using `libraries` without capability. '
+        'Try adding `libraryCapability`.',
+      );
     }
     var result = <Uri, LibraryMirror>{};
     for (LibraryMirror library in reflectorData.libraryMirrors!) {
@@ -2623,7 +2832,8 @@ abstract class ReflectableImpl extends ReflectableBase
   @override
   Iterable<ClassMirror> get annotatedClasses {
     return List<ClassMirror>.unmodifiable(
-        data[this]!.typeMirrors.whereType<ClassMirror>());
+      data[this]!.typeMirrors.whereType<ClassMirror>(),
+    );
   }
 }
 
@@ -2643,21 +2853,25 @@ bool _isSetterName(String name) => name.endsWith('=');
 String _getterNameToSetterName(String name) => '$name=';
 
 bool _supportsType(ReflectableImpl reflector) {
-  return reflector.capabilities
-      .any((ReflectCapability capability) => capability is TypeCapability);
+  return reflector.capabilities.any(
+    (ReflectCapability capability) => capability is TypeCapability,
+  );
 }
 
 bool _supportsTypeRelations(ReflectableImpl reflector) {
   return reflector.capabilities.any(
-      (ReflectCapability capability) => capability is TypeRelationsCapability);
+    (ReflectCapability capability) => capability is TypeRelationsCapability,
+  );
 }
 
 bool _supportsReflectedType(ReflectableImpl reflector) {
   return reflector.capabilities.any(
-      (ReflectCapability capability) => capability == reflectedTypeCapability);
+    (ReflectCapability capability) => capability == reflectedTypeCapability,
+  );
 }
 
 bool _supportsDeclarations(ReflectableImpl reflector) {
   return reflector.capabilities.any(
-      (ReflectCapability capability) => capability is DeclarationsCapability);
+    (ReflectCapability capability) => capability is DeclarationsCapability,
+  );
 }

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=3.7.0 <4.0.0'
 dependencies:
-  analyzer: ">=6.11.0 <7.0.0"
+  analyzer: ">=7.0.0 <7.1.0"
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.1.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 dependencies:
   analyzer: ">=7.3.0 <7.4.0"
   build: ^2.4.0
-  build_resolvers: ^2.4.0
   build_config: ^1.1.0
   build_runner: ^2.4.15
   build_runner_core: ^8.0.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=3.7.0 <4.0.0'
 dependencies:
-  analyzer: ">=7.0.0 <7.1.0"
+  analyzer: ">=7.1.0 <7.2.0"
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.1.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -21,5 +21,5 @@ dependencies:
   source_span: ^1.10.0
 dev_dependencies:
   build_test: ^2.2.0
-  lints: ^6.0.0
+  lints: ^5.0.0
   test: ^1.25.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=3.7.0 <4.0.0'
 dependencies:
-  analyzer: ">=6.10.0 <6.11.0"
+  analyzer: ">=6.11.0 <7.0.0"
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.1.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=3.7.0 <4.0.0'
 dependencies:
-  analyzer: ^7.4.0
+  analyzer: ^7.0.0
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.1.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,19 +1,19 @@
 name: reflectable
-version: 4.0.12
+version: 4.0.13
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
 homepage: https://github.com/google/reflectable.dart
 environment:
-  sdk: '>=3.5.0 <4.0.0'
+  sdk: '>=3.7.0 <4.0.0'
 dependencies:
-  analyzer: ^6.8.0
+  analyzer: ^7.4.0
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.1.0
-  build_runner: ^2.4.0
-  build_runner_core: ^7.2.0
-  dart_style: ^2.3.0
+  build_runner: ^2.4.15
+  build_runner_core: ^8.0.0
+  dart_style: ^3.0.0
   glob: ^2.1.0
   logging: ^1.2.0
   package_config: ^2.1.0
@@ -21,5 +21,5 @@ dependencies:
   source_span: ^1.10.0
 dev_dependencies:
   build_test: ^2.2.0
-  lints: ^5.0.0
+  lints: ^6.0.0
   test: ^1.25.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=3.7.0 <4.0.0'
 dependencies:
-  analyzer: ">=7.1.0 <7.2.0"
+  analyzer: ">=7.2.0 <7.3.0"
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.1.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   logging: ^1.2.0
   package_config: ^2.1.0
   path: ^1.9.0
+  pub_semver: ^2.2.0 
   source_span: ^1.10.0
 dev_dependencies:
   build_test: ^2.2.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=3.7.0 <4.0.0'
 dependencies:
-  analyzer: ">=6.9.0 <6.10.0"
+  analyzer: ">=6.10.0 <6.11.0"
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.1.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=3.7.0 <4.0.0'
 dependencies:
-  analyzer: ">=7.2.0 <7.3.0"
+  analyzer: ">=7.3.0 <7.4.0"
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.1.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=3.7.0 <4.0.0'
 dependencies:
-  analyzer: ^7.0.0
+  analyzer: ">=6.9.0 <6.10.0"
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.1.0

--- a/test_reflectable/analysis_options.yaml
+++ b/test_reflectable/analysis_options.yaml
@@ -1,4 +1,5 @@
 include: package:lints/recommended.yaml
 linter:
   rules:
-    - await_only_futures
+    await_only_futures: true
+    unnecessary_library_name: false

--- a/test_reflectable/pubspec.yaml
+++ b/test_reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ description: >
   package. It is not intended to be useful for other purposes than
   testing package reflectable.
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: '>=3.7.0 <4.0.0'
 dependencies:
   build_runner: any
   glob: any


### PR DESCRIPTION
This PR updates reflectable to use the new element model of the analyzer (the one that uses class names like `ClassElement2`).

It is blocked by the fact that the package [build](https://pub.dev/packages/build), currently in version 2.4.2, does not support the new element model.