### PR TITLE
Update reflectable to work with Flutter 3.35

### DIFF
--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## 4.0.14
 
 - Use language version 3.7.
-
-
+- Migrate reflectable to use analyzer version ^7.0.0 (which removes
+  the dependency on `_macros`, which doesn't exist any more).
+- This includes a small part of the migration work needed in order
+  to use the new element model in the analyzer (`Element2`, for now).
+- Lots of reformatting (creates a big diff).
 
 ## 4.0.13
 

--- a/reflectable/CHANGELOG.md
+++ b/reflectable/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.14
+
+- Use language version 3.7.
+
+
+
 ## 4.0.13
 
 - Use language version 3.6.

--- a/reflectable/lib/capability.dart
+++ b/reflectable/lib/capability.dart
@@ -337,8 +337,10 @@ const subtypeQuantifyCapability = _SubtypeQuantifyCapability();
 class SuperclassQuantifyCapability implements ReflecteeQuantifyCapability {
   final Type upperBound;
   final bool excludeUpperBound;
-  const SuperclassQuantifyCapability(this.upperBound,
-      {this.excludeUpperBound = false});
+  const SuperclassQuantifyCapability(
+    this.upperBound, {
+    this.excludeUpperBound = false,
+  });
 }
 
 /// Gives support for reflection on all superclasses of covered classes.
@@ -371,8 +373,9 @@ const typeAnnotationQuantifyCapability = TypeAnnotationQuantifyCapability();
 /// the vocered classes, as well as the transitive closure thereof (that is,
 /// including classes used as type annotations in classes used as type
 /// annotations, etc.).
-const typeAnnotationDeepQuantifyCapability =
-    TypeAnnotationQuantifyCapability(transitive: true);
+const typeAnnotationDeepQuantifyCapability = TypeAnnotationQuantifyCapability(
+  transitive: true,
+);
 
 /// Quantifying capability instance specifying that the reflection support
 /// for any given explicitly declared getter must also be given to its
@@ -427,7 +430,7 @@ class ImportAttachedCapability {
 class GlobalQuantifyCapability extends ImportAttachedCapability {
   final String classNamePattern;
   const GlobalQuantifyCapability(this.classNamePattern, Reflectable reflector)
-      : super(reflector);
+    : super(reflector);
 }
 
 /// Gives reflection support in [reflector] for every class
@@ -443,7 +446,7 @@ class GlobalQuantifyCapability extends ImportAttachedCapability {
 class GlobalQuantifyMetaCapability extends ImportAttachedCapability {
   final Type metadataType;
   const GlobalQuantifyMetaCapability(this.metadataType, Reflectable reflector)
-      : super(reflector);
+    : super(reflector);
 }
 
 // ---------- Private classes used to enable capability instances above.
@@ -509,8 +512,12 @@ class _StringInvocation extends StringInvocation {
   @override
   bool get isSetter => kind == StringInvocationKind.setter;
 
-  _StringInvocation(this.memberName, this.positionalArguments,
-      this.namedArguments, this.kind);
+  _StringInvocation(
+    this.memberName,
+    this.positionalArguments,
+    this.namedArguments,
+    this.kind,
+  );
 }
 
 /// Thrown when a method is invoked via a reflectable, but the reflectable
@@ -533,11 +540,20 @@ class ReflectableNoSuchMethodError extends Error
 
   final StringInvocationKind kind;
 
-  ReflectableNoSuchMethodError(this.receiver, this.memberName,
-      this.positionalArguments, this.namedArguments, this.kind);
+  ReflectableNoSuchMethodError(
+    this.receiver,
+    this.memberName,
+    this.positionalArguments,
+    this.namedArguments,
+    this.kind,
+  );
 
   StringInvocation get invocation => _StringInvocation(
-      memberName, positionalArguments, namedArguments ?? const {}, kind);
+    memberName,
+    positionalArguments,
+    namedArguments ?? const {},
+    kind,
+  );
 
   @override
   String toString() {
@@ -555,7 +571,8 @@ class ReflectableNoSuchMethodError extends Error
       case StringInvocationKind.constructor:
         kindName = 'constructor';
     }
-    var description = 'NoSuchCapabilityError: no capability to invoke the '
+    var description =
+        'NoSuchCapabilityError: no capability to invoke the '
         '$kindName "$memberName"\n'
         'Receiver: $receiver\n'
         'Arguments: $positionalArguments\n';
@@ -567,38 +584,77 @@ class ReflectableNoSuchMethodError extends Error
 }
 
 dynamic reflectableNoSuchInvokableError(
-    Object? receiver,
-    String memberName,
-    List positionalArguments,
-    Map<Symbol, dynamic>? namedArguments,
-    StringInvocationKind kind) {
+  Object? receiver,
+  String memberName,
+  List positionalArguments,
+  Map<Symbol, dynamic>? namedArguments,
+  StringInvocationKind kind,
+) {
   throw ReflectableNoSuchMethodError(
-      receiver, memberName, positionalArguments, namedArguments, kind);
+    receiver,
+    memberName,
+    positionalArguments,
+    namedArguments,
+    kind,
+  );
 }
 
-dynamic reflectableNoSuchMethodError(Object? receiver, String memberName,
-    List positionalArguments, Map<Symbol, dynamic>? namedArguments) {
-  throw ReflectableNoSuchMethodError(receiver, memberName, positionalArguments,
-      namedArguments, StringInvocationKind.method);
+dynamic reflectableNoSuchMethodError(
+  Object? receiver,
+  String memberName,
+  List positionalArguments,
+  Map<Symbol, dynamic>? namedArguments,
+) {
+  throw ReflectableNoSuchMethodError(
+    receiver,
+    memberName,
+    positionalArguments,
+    namedArguments,
+    StringInvocationKind.method,
+  );
 }
 
-dynamic reflectableNoSuchGetterError(Object? receiver, String memberName,
-    List positionalArguments, Map<Symbol, dynamic>? namedArguments) {
-  throw ReflectableNoSuchMethodError(receiver, memberName, positionalArguments,
-      namedArguments, StringInvocationKind.getter);
+dynamic reflectableNoSuchGetterError(
+  Object? receiver,
+  String memberName,
+  List positionalArguments,
+  Map<Symbol, dynamic>? namedArguments,
+) {
+  throw ReflectableNoSuchMethodError(
+    receiver,
+    memberName,
+    positionalArguments,
+    namedArguments,
+    StringInvocationKind.getter,
+  );
 }
 
-dynamic reflectableNoSuchSetterError(Object? receiver, String memberName,
-    List positionalArguments, Map<Symbol, dynamic>? namedArguments) {
-  throw ReflectableNoSuchMethodError(receiver, memberName, positionalArguments,
-      namedArguments, StringInvocationKind.setter);
+dynamic reflectableNoSuchSetterError(
+  Object? receiver,
+  String memberName,
+  List positionalArguments,
+  Map<Symbol, dynamic>? namedArguments,
+) {
+  throw ReflectableNoSuchMethodError(
+    receiver,
+    memberName,
+    positionalArguments,
+    namedArguments,
+    StringInvocationKind.setter,
+  );
 }
 
 dynamic reflectableNoSuchConstructorError(
-    Object? receiver,
-    String constructorName,
-    List positionalArguments,
-    Map<Symbol, dynamic>? namedArguments) {
-  throw ReflectableNoSuchMethodError(receiver, constructorName,
-      positionalArguments, namedArguments, StringInvocationKind.constructor);
+  Object? receiver,
+  String constructorName,
+  List positionalArguments,
+  Map<Symbol, dynamic>? namedArguments,
+) {
+  throw ReflectableNoSuchMethodError(
+    receiver,
+    constructorName,
+    positionalArguments,
+    namedArguments,
+    StringInvocationKind.constructor,
+  );
 }

--- a/reflectable/lib/mirrors.dart
+++ b/reflectable/lib/mirrors.dart
@@ -337,8 +337,11 @@ abstract class ObjectMirror implements Mirror {
   /// [StaticInvokeMetaCapability]; and [invoke] on a top-level function
   /// requires a matching [TopLevelInvokeCapability] or
   /// [TopLevelInvokeMetaCapability].
-  Object? invoke(String memberName, List positionalArguments,
-      [Map<Symbol, dynamic>? namedArguments]); // RET: InstanceMirror
+  Object? invoke(
+    String memberName,
+    List positionalArguments, [
+    Map<Symbol, dynamic>? namedArguments,
+  ]); // RET: InstanceMirror
 
   /// Invokes a getter and returns the result. The getter can be the
   /// implicit getter for a field, or a user-defined getter method.
@@ -540,8 +543,10 @@ abstract class ClosureMirror implements InstanceMirror {
   /// Required capabilities: [apply] requires a matching
   /// [InstanceInvokeCapability] or [InstanceInvokeMetaCapability], targeting
   /// the relevant `call` method.
-  Object? apply(List positionalArguments,
-      [Map<Symbol, dynamic>? namedArguments]); // RET: InstanceMirror
+  Object? apply(
+    List positionalArguments, [
+    Map<Symbol, dynamic>? namedArguments,
+  ]); // RET: InstanceMirror
 }
 
 /// A [LibraryMirror] reflects a Dart language library, providing
@@ -965,8 +970,11 @@ abstract class ClassMirror implements TypeMirror, ObjectMirror {
   ///
   /// Required capabilities: [newInstance] requires a matching
   /// [NewInstanceCapability] or [NewInstanceMetaCapability].
-  Object newInstance(String constructorName, List positionalArguments,
-      [Map<Symbol, dynamic> namedArguments]); // RET: InstanceMirror
+  Object newInstance(
+    String constructorName,
+    List positionalArguments, [
+    Map<Symbol, dynamic> namedArguments,
+  ]); // RET: InstanceMirror
 
   /// Whether this mirror is equal to [other].
   ///

--- a/reflectable/lib/reflectable.dart
+++ b/reflectable/lib/reflectable.dart
@@ -114,17 +114,18 @@ abstract class Reflectable extends implementation.ReflectableImpl
 
   /// Const constructor, to enable usage as metadata, allowing for varargs
   /// style invocation with up to ten arguments.
-  const Reflectable(
-      [super.cap0,
-      super.cap1,
-      super.cap2,
-      super.cap3,
-      super.cap4,
-      super.cap5,
-      super.cap6,
-      super.cap7,
-      super.cap8,
-      super.cap9]);
+  const Reflectable([
+    super.cap0,
+    super.cap1,
+    super.cap2,
+    super.cap3,
+    super.cap4,
+    super.cap5,
+    super.cap6,
+    super.cap7,
+    super.cap8,
+    super.cap9,
+  ]);
 
   const Reflectable.fromList(super.capabilities) : super.fromList();
 

--- a/reflectable/lib/reflectable_builder.dart
+++ b/reflectable/lib/reflectable_builder.dart
@@ -51,20 +51,21 @@ class ReflectableBuilder implements Builder {
     List<LibraryElement> visibleLibraries = await resolver.libraries.toList();
     List<WarningKind> suppressedWarnings = _computeSuppressedWarnings();
     String generatedSource = await BuilderImplementation().buildMirrorLibrary(
-        resolver,
-        inputId,
-        outputId,
-        inputLibrary,
-        visibleLibraries.cast(),
-        true,
-        suppressedWarnings);
+      resolver,
+      inputId,
+      outputId,
+      inputLibrary,
+      visibleLibraries.cast(),
+      true,
+      suppressedWarnings,
+    );
     await buildStep.writeAsString(outputId, generatedSource);
   }
 
   @override
   Map<String, List<String>> get buildExtensions => const {
-        '.dart': ['.reflectable.dart']
-      };
+    '.dart': ['.reflectable.dart'],
+  };
 }
 
 ReflectableBuilder reflectableBuilder(BuilderOptions options) {

--- a/reflectable/lib/reflectable_builder.dart
+++ b/reflectable/lib/reflectable_builder.dart
@@ -55,7 +55,7 @@ class ReflectableBuilder implements Builder {
         inputId,
         outputId,
         inputLibrary,
-        visibleLibraries,
+        visibleLibraries.cast(),
         true,
         suppressedWarnings);
     await buildStep.writeAsString(outputId, generatedSource);

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -3978,6 +3978,7 @@ class BuilderImplementation {
         capabilityLibrary
             .getClass('GlobalQuantifyMetaCapability')!
             .getNamedConstructor('')!;
+    print('>>> $globalQuantifyCapabilityConstructor'); // DEBUG
 
     for (LibraryElement library in _libraries) {
       List<LibraryElement> imports = library.importedLibraries;
@@ -4014,6 +4015,8 @@ class BuilderImplementation {
                   continue;
                 }
               }
+              print('>>> $reflector'); // DEBUG
+              if (pattern == null
               globalPatterns
                   .putIfAbsent(
                     RegExp(pattern ?? ''),

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -3978,7 +3978,7 @@ class BuilderImplementation {
         capabilityLibrary
             .getClass('GlobalQuantifyMetaCapability')!
             .getNamedConstructor('')!;
-    print('>>> $globalQuantifyCapabilityConstructor'); // DEBUG
+    print('>>> constructor: $globalQuantifyCapabilityConstructor'); // DEBUG
 
     for (LibraryElement library in _libraries) {
       List<LibraryElement> imports = library.importedLibraries;
@@ -4015,7 +4015,7 @@ class BuilderImplementation {
                   continue;
                 }
               }
-              print('>>> $reflector'); // DEBUG
+              print('>>> reflector: $reflector'); // DEBUG
               globalPatterns
                   .putIfAbsent(
                     RegExp(pattern ?? ''),

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -14,6 +14,7 @@ import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/dart/element/type_system.dart';
@@ -26,9 +27,12 @@ import 'package:analyzer/src/dart/constant/compute.dart';
 import 'package:analyzer/src/dart/constant/evaluation.dart';
 import 'package:analyzer/src/dart/constant/utilities.dart';
 import 'package:analyzer/src/dart/constant/value.dart';
+import 'package:analyzer/src/dart/element/display_string_builder.dart';
 import 'package:analyzer/src/dart/element/element.dart';
+import 'package:analyzer/src/dart/element/inheritance_manager3.dart';
 import 'package:analyzer/src/dart/element/type.dart';
 import 'package:analyzer/src/summary/package_bundle_reader.dart';
+import 'package:analyzer/src/summary2/reference.dart';
 import 'package:build/build.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:pub_semver/pub_semver.dart' as semver;
@@ -6181,6 +6185,8 @@ class MixinApplication implements ClassElement {
   @override
   String get displayName => name;
 
+  InterfaceElementImpl2 get element3 => MixinApplication2(this);
+
   @override
   List<InterfaceType> get interfaces => const <InterfaceType>[];
 
@@ -6195,15 +6201,11 @@ class MixinApplication implements ClassElement {
     required List<DartType> typeArguments,
     required NullabilitySuffix nullabilitySuffix,
   }) =>
-      /* DEBUG
       InterfaceTypeImpl(
         element: this.element3,
         typeArguments: typeArguments.cast(),
         nullabilitySuffix: nullabilitySuffix,
       );
-      */
-      throw UnimplementedError(
-          "Attempt to instantiate the MixinApplication $this");
 
   @override
   InterfaceType? get supertype {
@@ -6287,6 +6289,378 @@ class MixinApplication implements ClassElement {
   @override
   dynamic noSuchMethod(Invocation invocation) {
     log.severe('Missing MixinApplication member: ${invocation.memberName}');
+  }
+}
+
+/// Partially migrating [MixinApplication] to the [Element2] model.
+class MixinApplication2 implements InterfaceElementImpl2 {
+  final MixinApplication delegatee;
+
+  MixinApplication2(this.delegatee);
+
+  @override
+  bool get isSimplyBounded => true;
+
+  @override
+  T? accept2<T>(ElementVisitor2<T> visitor) {
+    // TODO: implement accept2
+    throw UnimplementedError();
+  }
+
+  @override
+  List<InterfaceType> get allSupertypes => delegatee.interfaces;
+
+  @override
+  void appendTo(ElementDisplayStringBuilder builder) {
+    // TODO: implement appendTo
+  }
+
+  @override
+  InstanceElement2 get baseElement => this;
+
+  @override
+  // TODO: implement children2
+  List<Element2> get children2 => throw UnimplementedError();
+
+  @override
+  // TODO: implement constructors2
+  List<ConstructorElementImpl2> get constructors2 => throw UnimplementedError();
+
+  @override
+  String get displayName => delegatee.displayName;
+
+  @override
+  String displayString2(
+          {bool multiline = false, bool preferTypeAlias = false}) =>
+      delegatee.getDisplayString(multiline: multiline);
+
+  @override
+  String? get documentationComment => delegatee.documentationComment;
+
+  @override
+  // TODO: implement enclosingElement2
+  LibraryElement2 get enclosingElement2 => throw UnimplementedError();
+
+  @override
+  // TODO: implement fields2
+  List<FieldElementImpl2> get fields2 => throw UnimplementedError();
+
+  @override
+  // TODO: implement firstFragment
+  InterfaceElementImpl get firstFragment => throw UnimplementedError();
+
+  @override
+  // TODO: implement fragments
+  List<InterfaceElementImpl> get fragments => throw UnimplementedError();
+
+  @override
+  String getExtendedDisplayName2({String? shortName}) =>
+      delegatee.getExtendedDisplayName(shortName);
+
+  @override
+  FieldElementImpl2? getField2(String name) {
+    // TODO: implement getField2
+    throw UnimplementedError();
+  }
+
+  @override
+  GetterElementImpl? getGetter2(String name) {
+    // TODO: implement getGetter2
+    throw UnimplementedError();
+  }
+
+  @override
+  ExecutableElement2? getInheritedConcreteMember(Name name) {
+    // TODO: implement getInheritedConcreteMember
+    throw UnimplementedError();
+  }
+
+  @override
+  ExecutableElement2? getInheritedMember(Name name) {
+    // TODO: implement getInheritedMember
+    throw UnimplementedError();
+  }
+
+  @override
+  ExecutableElement2? getInterfaceMember(Name name) {
+    // TODO: implement getInterfaceMember
+    throw UnimplementedError();
+  }
+
+  @override
+  MethodElementImpl2? getMethod2(String name) {
+    // TODO: implement getMethod2
+    throw UnimplementedError();
+  }
+
+  @override
+  ConstructorElementImpl2? getNamedConstructor2(String name) {
+    // TODO: implement getNamedConstructor2
+    throw UnimplementedError();
+  }
+
+  @override
+  List<ExecutableElement2>? getOverridden(Name name) {
+    // TODO: implement getOverridden
+    throw UnimplementedError();
+  }
+
+  @override
+  SetterElementImpl? getSetter2(String name) {
+    // TODO: implement getSetter2
+    throw UnimplementedError();
+  }
+
+  @override
+  // TODO: implement getters2
+  List<GetterElementImpl> get getters2 => throw UnimplementedError();
+
+  @override
+  bool hasModifier(Modifier modifier) {
+    // TODO: implement hasModifier
+    throw UnimplementedError();
+  }
+
+  @override
+  // TODO: implement id
+  int get id => throw UnimplementedError();
+
+  @override
+  // TODO: implement identifier
+  String get identifier => throw UnimplementedError();
+
+  @override
+  // TODO: implement inheritanceManager
+  InheritanceManager3 get inheritanceManager => throw UnimplementedError();
+
+  @override
+  // TODO: implement inheritedConcreteMembers
+  Map<Name, ExecutableElement2> get inheritedConcreteMembers =>
+      throw UnimplementedError();
+
+  @override
+  // TODO: implement inheritedMembers
+  Map<Name, ExecutableElement2> get inheritedMembers =>
+      throw UnimplementedError();
+
+  @override
+  InterfaceTypeImpl instantiate(
+      {required List<DartType> typeArguments,
+      required NullabilitySuffix nullabilitySuffix}) {
+    // TODO: implement instantiate
+    throw UnimplementedError();
+  }
+
+  @override
+  InterfaceTypeImpl instantiateImpl(
+      {required List<TypeImpl> typeArguments,
+      required NullabilitySuffix nullabilitySuffix}) {
+    // TODO: implement instantiateImpl
+    throw UnimplementedError();
+  }
+
+  @override
+  // TODO: implement interfaceMembers
+  Map<Name, ExecutableElement2> get interfaceMembers =>
+      throw UnimplementedError();
+
+  @override
+  // TODO: implement interfaces
+  List<InterfaceTypeImpl> get interfaces => throw UnimplementedError();
+
+  @override
+  bool isAccessibleIn2(LibraryElement2 library) {
+    // TODO: implement isAccessibleIn2
+    throw UnimplementedError();
+  }
+
+  @override
+  // TODO: implement isPrivate
+  bool get isPrivate => throw UnimplementedError();
+
+  @override
+  // TODO: implement isPublic
+  bool get isPublic => throw UnimplementedError();
+
+  @override
+  // TODO: implement isSynthetic
+  bool get isSynthetic => throw UnimplementedError();
+
+  @override
+  // TODO: implement kind
+  ElementKind get kind => throw UnimplementedError();
+
+  @override
+  // TODO: implement library2
+  LibraryElementImpl get library2 => throw UnimplementedError();
+
+  @override
+  MethodElement2? lookUpConcreteMethod(
+      String methodName, LibraryElement2 library) {
+    // TODO: implement lookUpConcreteMethod
+    throw UnimplementedError();
+  }
+
+  @override
+  GetterElement? lookUpGetter2(
+      {required String name, required LibraryElement2 library}) {
+    // TODO: implement lookUpGetter2
+    throw UnimplementedError();
+  }
+
+  @override
+  PropertyAccessorElement2? lookUpInheritedConcreteGetter(
+      String getterName, LibraryElement2 library) {
+    // TODO: implement lookUpInheritedConcreteGetter
+    throw UnimplementedError();
+  }
+
+  @override
+  MethodElement2? lookUpInheritedConcreteMethod(
+      String methodName, LibraryElement2 library) {
+    // TODO: implement lookUpInheritedConcreteMethod
+    throw UnimplementedError();
+  }
+
+  @override
+  PropertyAccessorElement2? lookUpInheritedConcreteSetter(
+      String setterName, LibraryElement2 library) {
+    // TODO: implement lookUpInheritedConcreteSetter
+    throw UnimplementedError();
+  }
+
+  @override
+  MethodElement2? lookUpInheritedMethod(
+      String methodName, LibraryElement2 library) {
+    // TODO: implement lookUpInheritedMethod
+    throw UnimplementedError();
+  }
+
+  @override
+  MethodElement2? lookUpInheritedMethod2(
+      {required String methodName, required LibraryElement2 library}) {
+    // TODO: implement lookUpInheritedMethod2
+    throw UnimplementedError();
+  }
+
+  @override
+  MethodElement2? lookUpMethod2(
+      {required String name, required LibraryElement2 library}) {
+    // TODO: implement lookUpMethod2
+    throw UnimplementedError();
+  }
+
+  @override
+  SetterElement? lookUpSetter2(
+      {required String name, required LibraryElement2 library}) {
+    // TODO: implement lookUpSetter2
+    throw UnimplementedError();
+  }
+
+  @override
+  // TODO: implement lookupName
+  String? get lookupName => throw UnimplementedError();
+
+  @override
+  GetterElement2OrMember? lookupStaticGetter(
+      String name, LibraryElement2 library) {
+    // TODO: implement lookupStaticGetter
+    throw UnimplementedError();
+  }
+
+  @override
+  MethodElement2OrMember? lookupStaticMethod(
+      String name, LibraryElement2 library) {
+    // TODO: implement lookupStaticMethod
+    throw UnimplementedError();
+  }
+
+  @override
+  SetterElement2OrMember? lookupStaticSetter(
+      String name, LibraryElement2 library) {
+    // TODO: implement lookupStaticSetter
+    throw UnimplementedError();
+  }
+
+  @override
+  // TODO: implement metadata2
+  MetadataImpl get metadata2 => throw UnimplementedError();
+
+  @override
+  // TODO: implement methods2
+  List<MethodElementImpl2> get methods2 => throw UnimplementedError();
+
+  @override
+  // TODO: implement mixins
+  List<InterfaceTypeImpl> get mixins => throw UnimplementedError();
+
+  @override
+  // TODO: implement name3
+  String? get name3 => throw UnimplementedError();
+
+  @override
+  // TODO: implement nonSynthetic2
+  Element2 get nonSynthetic2 => throw UnimplementedError();
+
+  @override
+  // TODO: implement reference
+  Reference? get reference => throw UnimplementedError();
+
+  @override
+  void resetCachedAllSupertypes() {
+    // TODO: implement resetCachedAllSupertypes
+  }
+
+  @override
+  // TODO: implement session
+  AnalysisSession? get session => throw UnimplementedError();
+
+  @override
+  void setModifier(Modifier modifier, bool value) {
+    // TODO: implement setModifier
+  }
+
+  @override
+  // TODO: implement setters2
+  List<SetterElementImpl> get setters2 => throw UnimplementedError();
+
+  @override
+  // TODO: implement sinceSdkVersion
+  semver.Version? get sinceSdkVersion => throw UnimplementedError();
+
+  @override
+  // TODO: implement supertype
+  InterfaceTypeImpl? get supertype => throw UnimplementedError();
+
+  @override
+  Element2? thisOrAncestorMatching2(bool Function(Element2 p1) predicate) {
+    // TODO: implement thisOrAncestorMatching2
+    throw UnimplementedError();
+  }
+
+  @override
+  E? thisOrAncestorOfType2<E extends Element2>() {
+    // TODO: implement thisOrAncestorOfType2
+    throw UnimplementedError();
+  }
+
+  @override
+  // TODO: implement thisType
+  InterfaceTypeImpl get thisType => throw UnimplementedError();
+
+  @override
+  // TODO: implement typeParameters2
+  List<TypeParameterElementImpl2> get typeParameters2 =>
+      throw UnimplementedError();
+
+  @override
+  // TODO: implement unnamedConstructor2
+  ConstructorElementImpl2? get unnamedConstructor2 =>
+      throw UnimplementedError();
+
+  @override
+  void visitChildren2<T>(ElementVisitor2<T> visitor) {
+    // TODO: implement visitChildren2
   }
 }
 

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -61,7 +61,7 @@ enum WarningKind {
 
 class _ReflectionWorld {
   final Resolver resolver;
-  final List<LibraryElement> libraries;
+  final List<LibraryElementImpl> libraries;
   final AssetId generatedLibraryId;
   final List<_ReflectorDomain> reflectors;
   final LibraryElement reflectableLibrary;
@@ -103,7 +103,7 @@ class _ReflectionWorld {
     }
 
     // Fill in [_subtypesCache].
-    for (LibraryElement library in libraries) {
+    for (LibraryElementImpl library in libraries) {
       void addInterfaceElement(InterfaceElement interfaceElement) {
         InterfaceType? supertype = interfaceElement.supertype;
         if (interfaceElement.mixins.isEmpty) {
@@ -2795,7 +2795,7 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement> {
         name,
         superclass,
         mixinClass,
-        element.library,
+        element.library as LibraryElementImpl,
         subClass,
       );
       // We have already ensured that `workingSuperclass` is a
@@ -2864,7 +2864,7 @@ Set<InterfaceElement> _mixinApplicationsOfClasses(
         name,
         superclass,
         mixinClass,
-        interfaceElement.library,
+        interfaceElement.library as LibraryElementImpl,
         subClass,
       );
       mixinApplications.add(mixinApplication);
@@ -3766,7 +3766,7 @@ int _processedEntryPointCount = 0;
 
 class BuilderImplementation {
   late final Resolver _resolver;
-  var _libraries = <LibraryElement>[];
+  var _libraries = <LibraryElementImpl>[];
   final _librariesByName = <String, LibraryElement>{};
   late final bool _formatted;
   late final List<WarningKind> _suppressedWarnings;
@@ -4827,6 +4827,7 @@ ${imports.join('\n')}
 // ignore_for_file: prefer_collection_literals
 // ignore_for_file: unnecessary_const
 // ignore_for_file: unused_import
+// ignore_for_file: sdk_version_since
 
 import 'package:reflectable/mirrors.dart' as m;
 import 'package:reflectable/src/reflectable_builder_based.dart' as r;
@@ -4857,7 +4858,7 @@ void initializeReflectable() {
     AssetId inputId,
     AssetId generatedLibraryId,
     LibraryElement inputLibrary,
-    List<LibraryElement> visibleLibraries,
+    List<LibraryElementImpl> visibleLibraries,
     bool formatted,
     List<WarningKind> suppressedWarnings,
   ) async {
@@ -6152,14 +6153,14 @@ Future<Uri> _getImportUri(
 ///
 /// This class is only used to mark the synthetic mixin application classes,
 /// so most of the class is left unimplemented.
-class MixinApplication implements ClassElement {
+class MixinApplication implements ClassElementImpl {
   final String? declaredName;
   final InterfaceElement superclass;
   final InterfaceElement mixin;
   final InterfaceElement? subclass;
 
   @override
-  final LibraryElement library;
+  final LibraryElementImpl library;
 
   MixinApplication(
     this.declaredName,
@@ -6188,38 +6189,40 @@ class MixinApplication implements ClassElement {
   InterfaceElementImpl2 get element3 => MixinApplication2(this);
 
   @override
-  List<InterfaceType> get interfaces => const <InterfaceType>[];
+  List<InterfaceTypeImpl> get interfaces => const <InterfaceTypeImpl>[];
 
   @override
-  List<ElementAnnotation> get metadata => const <ElementAnnotation>[];
+  List<ElementAnnotationImpl> get metadata => const <ElementAnnotationImpl>[];
 
   @override
   bool get isSynthetic => declaredName == null;
 
   @override
-  InterfaceType instantiate({
+  InterfaceTypeImpl instantiate({
     required List<DartType> typeArguments,
     required NullabilitySuffix nullabilitySuffix,
   }) =>
       InterfaceTypeImpl(
-        element: this.element3,
+        element: element3,
         typeArguments: typeArguments.cast(),
         nullabilitySuffix: nullabilitySuffix,
       );
 
   @override
-  InterfaceType? get supertype {
-    if (superclass is MixinApplication) return superclass.supertype;
-    return _typeForReflectable(superclass) as InterfaceType;
+  InterfaceTypeImpl? get supertype {
+    if (superclass is MixinApplication) {
+      return superclass.supertype as InterfaceTypeImpl;
+    }
+    return _typeForReflectable(superclass) as InterfaceTypeImpl;
   }
 
   @override
-  List<InterfaceType> get mixins {
-    var result = <InterfaceType>[];
+  List<InterfaceTypeImpl> get mixins {
+    var result = <InterfaceTypeImpl>[];
     if (superclass is MixinApplication) {
-      result.addAll(superclass.mixins);
+      result.addAll(superclass.mixins.cast());
     }
-    result.add(_typeForReflectable(mixin) as InterfaceType);
+    result.add(_typeForReflectable(mixin) as InterfaceTypeImpl);
     return result;
   }
 
@@ -6254,7 +6257,8 @@ class MixinApplication implements ClassElement {
   bool get isPrivate => false;
 
   @override
-  List<TypeParameterElement> get typeParameters => <TypeParameterElement>[];
+  List<TypeParameterElementImpl> get typeParameters =>
+      <TypeParameterElementImpl>[];
 
   @override
   ElementKind get kind => ElementKind.CLASS;
@@ -6263,7 +6267,7 @@ class MixinApplication implements ClassElement {
   bool get isAugmentation => false;
 
   @override
-  ElementLocation? get location => null;
+  ElementLocation get location => throw UnimplementedError();
 
   @override
   bool operator ==(Object other) {
@@ -6340,6 +6344,8 @@ class MixinApplication2 implements InterfaceElementImpl2 {
   @override
   String? get documentationComment => delegatee.documentationComment;
 
+  MixinApplication get element => delegatee;
+
   @override
   // TODO: implement enclosingElement2
   LibraryElement2 get enclosingElement2 => throw UnimplementedError();
@@ -6350,11 +6356,10 @@ class MixinApplication2 implements InterfaceElementImpl2 {
 
   @override
   // TODO: implement firstFragment
-  InterfaceElementImpl get firstFragment => throw UnimplementedError();
+  InterfaceElementImpl get firstFragment => delegatee;
 
   @override
-  // TODO: implement fragments
-  List<InterfaceElementImpl> get fragments => throw UnimplementedError();
+  List<InterfaceElementImpl> get fragments => [];
 
   @override
   String getExtendedDisplayName2({String? shortName}) =>
@@ -6599,7 +6604,7 @@ class MixinApplication2 implements InterfaceElementImpl2 {
 
   @override
   // TODO: implement name3
-  String? get name3 => throw UnimplementedError();
+  String? get name3 => delegatee.name;
 
   @override
   // TODO: implement nonSynthetic2

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -120,12 +120,13 @@ class _ReflectionWorld {
             InterfaceElement mixinElement = mixin.element;
             InterfaceElement? subClass =
                 mixin == interfaceElement.mixins.last ? interfaceElement : null;
-            String? name = subClass == null
-                ? null
-                : (interfaceElement is MixinApplication &&
-                        interfaceElement.isMixinApplication
-                    ? interfaceElement.name
-                    : null);
+            String? name =
+                subClass == null
+                    ? null
+                    : (interfaceElement is MixinApplication &&
+                            interfaceElement.isMixinApplication
+                        ? interfaceElement.name
+                        : null);
             var mixinApplication = MixinApplication(
               name,
               superclass,
@@ -621,14 +622,16 @@ class ParameterListShape {
   );
 
   @override
-  bool operator ==(other) => other is ParameterListShape
-      ? numberOfPositionalParameters == other.numberOfPositionalParameters &&
-          numberOfOptionalPositionalParameters ==
-              other.numberOfOptionalPositionalParameters &&
-          namesOfNamedParameters
-              .difference(other.namesOfNamedParameters)
-              .isEmpty
-      : false;
+  bool operator ==(other) =>
+      other is ParameterListShape
+          ? numberOfPositionalParameters ==
+                  other.numberOfPositionalParameters &&
+              numberOfOptionalPositionalParameters ==
+                  other.numberOfOptionalPositionalParameters &&
+              namesOfNamedParameters
+                  .difference(other.namesOfNamedParameters)
+                  .isEmpty
+          : false;
 
   @override
   int get hashCode =>
@@ -744,9 +747,10 @@ class _ReflectorDomain {
     int requiredPositionalCount = type.normalParameterTypes.length;
     int optionalPositionalCount = type.optionalParameterTypes.length;
 
-    List<String> parameterNames = type.parameters
-        .map((ParameterElement parameter) => parameter.name)
-        .toList();
+    List<String> parameterNames =
+        type.parameters
+            .map((ParameterElement parameter) => parameter.name)
+            .toList();
 
     List<String> namedParameterNames = type.namedParameterTypes.keys.toList();
 
@@ -813,8 +817,9 @@ class _ReflectorDomain {
       optionalPositionalCount,
       (int i) => parameterNames[i + requiredPositionalCount],
     ).join(', ');
-    String namedArguments =
-        namedParameterNames.map((String name) => '$name: $name').join(', ');
+    String namedArguments = namedParameterNames
+        .map((String name) => '$name: $name')
+        .join(', ');
 
     var parameterParts = <String>[];
     var argumentParts = <String>[];
@@ -1502,22 +1507,23 @@ class _ReflectorDomain {
     Iterable<int> methodsIndices = classDomain._declarations
         .where(_executableIsntImplicitGetterOrSetter)
         .map((ExecutableElement element) {
-      // TODO(eernst) implement: The "magic" default constructor in `Object`
-      // (the one that ultimately allocates the memory for _every_ new
-      // object) has no index, which creates the need to catch a `null`
-      // here. Search for "magic" to find other occurrences of the same
-      // issue. For now, we use the index [constants.noCapabilityIndex]
-      // for this declaration, because it is not yet supported.
-      // Need to find the correct solution, though!
-      int? index = members.indexOf(element);
-      return index == null
-          ? constants.noCapabilityIndex
-          : index + methodsOffset;
-    });
+          // TODO(eernst) implement: The "magic" default constructor in `Object`
+          // (the one that ultimately allocates the memory for _every_ new
+          // object) has no index, which creates the need to catch a `null`
+          // here. Search for "magic" to find other occurrences of the same
+          // issue. For now, we use the index [constants.noCapabilityIndex]
+          // for this declaration, because it is not yet supported.
+          // Need to find the correct solution, though!
+          int? index = members.indexOf(element);
+          return index == null
+              ? constants.noCapabilityIndex
+              : index + methodsOffset;
+        });
 
-    String declarationsCode = _capabilities._impliesDeclarations
-        ? _formatAsConstList('int', [...fieldsIndices, ...methodsIndices])
-        : 'const <int>[${constants.noCapabilityIndex}]';
+    String declarationsCode =
+        _capabilities._impliesDeclarations
+            ? _formatAsConstList('int', [...fieldsIndices, ...methodsIndices])
+            : 'const <int>[${constants.noCapabilityIndex}]';
 
     // All instance members belong to the behavioral interface, so they
     // also get an offset of `fields.length`.
@@ -1564,10 +1570,11 @@ class _ReflectorDomain {
       // convention we make it supported and report it in the same way as
       // 'dart:mirrors'. Other superclasses use `noCapabilityIndex` to
       // indicate missing support.
-      superclassIndex = (interfaceElement is! MixinApplication &&
-              _typeForReflectable(interfaceElement).isDartCoreObject)
-          ? 'null'
-          : ((await classes).contains(superclass))
+      superclassIndex =
+          (interfaceElement is! MixinApplication &&
+                  _typeForReflectable(interfaceElement).isDartCoreObject)
+              ? 'null'
+              : ((await classes).contains(superclass))
               ? '${(await classes).indexOf(superclass!)}'
               : '${constants.noCapabilityIndex}';
     }
@@ -1655,9 +1662,10 @@ class _ReflectorDomain {
       mixinIndex ??= constants.noCapabilityIndex;
     }
 
-    int ownerIndex = _capabilities._supportsLibraries
-        ? libraries.indexOf(libraryMap[interfaceElement.library]!)!
-        : constants.noCapabilityIndex;
+    int ownerIndex =
+        _capabilities._supportsLibraries
+            ? libraries.indexOf(libraryMap[interfaceElement.library]!)!
+            : constants.noCapabilityIndex;
 
     var superinterfaceIndices = 'const <int>[${constants.noCapabilityIndex}]';
     if (_capabilities._impliesTypeRelations) {
@@ -1816,9 +1824,10 @@ class _ReflectorDomain {
       // There is no type propagation, so we declare an `accessorElement`.
       PropertyAccessorElement accessorElement = element;
       PropertyInducingElement? variable = accessorElement.variable2;
-      int variableMirrorIndex = variable is TopLevelVariableElement
-          ? topLevelVariables.indexOf(variable)!
-          : variable is FieldElement
+      int variableMirrorIndex =
+          variable is TopLevelVariableElement
+              ? topLevelVariables.indexOf(variable)!
+              : variable is FieldElement
               ? fields.indexOf(variable)!
               : constants.noCapabilityIndex;
       int selfIndex = members.indexOf(accessorElement)! + fields.length;
@@ -1837,18 +1846,19 @@ class _ReflectorDomain {
       // getter or setter.
       int descriptor = _declarationDescriptor(element);
       int returnTypeIndex = await _computeReturnTypeIndex(element, descriptor);
-      int ownerIndex = (await _computeOwnerIndex(element, descriptor)) ??
+      int ownerIndex =
+          (await _computeOwnerIndex(element, descriptor)) ??
           constants.noCapabilityIndex;
       var reflectedTypeArgumentsOfReturnType = 'null';
       if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
         reflectedTypeArgumentsOfReturnType =
             await _computeReflectedTypeArguments(
-          element.returnType,
-          reflectedTypes,
-          reflectedTypesOffset,
-          importCollector,
-          typedefs,
-        );
+              element.returnType,
+              reflectedTypes,
+              reflectedTypesOffset,
+              importCollector,
+              typedefs,
+            );
       }
       String parameterIndicesCode = _formatAsConstList(
         'int',
@@ -1876,14 +1886,15 @@ class _ReflectorDomain {
           typedefs,
         );
       }
-      String? metadataCode = _capabilities._supportsMetadata
-          ? await _extractMetadataCode(
-              element,
-              _resolver,
-              importCollector,
-              _generatedLibraryId,
-            )
-          : null;
+      String? metadataCode =
+          _capabilities._supportsMetadata
+              ? await _extractMetadataCode(
+                element,
+                _resolver,
+                importCollector,
+                _generatedLibraryId,
+              )
+              : null;
       return "r.MethodMirrorImpl(r'${element.name}', $descriptor, "
           '$ownerIndex, $returnTypeIndex, $reflectedReturnTypeIndex, '
           '$dynamicReflectedReturnTypeIndex, '
@@ -1904,24 +1915,26 @@ class _ReflectorDomain {
     LibraryElement owner = element.library;
     int ownerIndex = _libraries.indexOf(owner) ?? constants.noCapabilityIndex;
     int classMirrorIndex = await _computeVariableTypeIndex(element, descriptor);
-    int? reflectedTypeIndex = reflectedTypeRequested
-        ? _typeCodeIndex(
-            element.type,
-            await classes,
-            reflectedTypes,
-            reflectedTypesOffset,
-            typedefs,
-          )
-        : constants.noCapabilityIndex;
-    int? dynamicReflectedTypeIndex = reflectedTypeRequested
-        ? _dynamicTypeCodeIndex(
-            element.type,
-            await classes,
-            reflectedTypes,
-            reflectedTypesOffset,
-            typedefs,
-          )
-        : constants.noCapabilityIndex;
+    int? reflectedTypeIndex =
+        reflectedTypeRequested
+            ? _typeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
+    int? dynamicReflectedTypeIndex =
+        reflectedTypeRequested
+            ? _dynamicTypeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
     var reflectedTypeArguments = 'null';
     if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
       reflectedTypeArguments = await _computeReflectedTypeArguments(
@@ -1961,27 +1974,30 @@ class _ReflectorDomain {
     bool reflectedTypeRequested,
   ) async {
     int descriptor = _fieldDescriptor(element);
-    int ownerIndex = (await classes).indexOf(element.enclosingElement3) ??
+    int ownerIndex =
+        (await classes).indexOf(element.enclosingElement3) ??
         constants.noCapabilityIndex;
     int classMirrorIndex = await _computeVariableTypeIndex(element, descriptor);
-    int reflectedTypeIndex = reflectedTypeRequested
-        ? _typeCodeIndex(
-            element.type,
-            await classes,
-            reflectedTypes,
-            reflectedTypesOffset,
-            typedefs,
-          )
-        : constants.noCapabilityIndex;
-    int dynamicReflectedTypeIndex = reflectedTypeRequested
-        ? _dynamicTypeCodeIndex(
-            element.type,
-            await classes,
-            reflectedTypes,
-            reflectedTypesOffset,
-            typedefs,
-          )
-        : constants.noCapabilityIndex;
+    int reflectedTypeIndex =
+        reflectedTypeRequested
+            ? _typeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
+    int dynamicReflectedTypeIndex =
+        reflectedTypeRequested
+            ? _dynamicTypeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
     var reflectedTypeArguments = 'null';
     if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
       reflectedTypeArguments = await _computeReflectedTypeArguments(
@@ -2228,9 +2244,10 @@ class _ReflectorDomain {
         if (dartType.typeFormals.isNotEmpty) {
           if (useNameOfGenericFunctionType) {
             // Requested: just the name of the typedef; get it and return.
-            int dartTypeNumber = typedefs.containsKey(dartType)
-                ? typedefs[dartType]!
-                : typedefNumber++;
+            int dartTypeNumber =
+                typedefs.containsKey(dartType)
+                    ? typedefs[dartType]!
+                    : typedefNumber++;
             return _typedefName(dartTypeNumber);
           } else {
             // Requested: the spelled-out generic function type; continue.
@@ -2286,7 +2303,8 @@ class _ReflectorDomain {
             );
           }
           var connector = argumentTypes.isEmpty ? '' : ', ';
-          argumentTypes = '$argumentTypes$connector'
+          argumentTypes =
+              '$argumentTypes$connector'
               '[${optionalParameterTypeList.join(', ')}]';
         }
         if (dartType.namedParameterTypes.isNotEmpty) {
@@ -2305,7 +2323,8 @@ class _ReflectorDomain {
             namedParameterTypeList.add('$typeCode $name');
           }
           var connector = argumentTypes.isEmpty ? '' : ', ';
-          argumentTypes = '$argumentTypes$connector'
+          argumentTypes =
+              '$argumentTypes$connector'
               '{${namedParameterTypeList.join(', ')}}';
         }
         return '$returnType Function$typeArguments($argumentTypes)';
@@ -2432,9 +2451,10 @@ class _ReflectorDomain {
     TypeDefiningElement typeDefiningElement,
     _ImportCollector importCollector,
   ) {
-    DartType? type = typeDefiningElement is InterfaceElement
-        ? _typeForReflectable(typeDefiningElement)
-        : null;
+    DartType? type =
+        typeDefiningElement is InterfaceElement
+            ? _typeForReflectable(typeDefiningElement)
+            : null;
     if (type is DynamicType) return 'dynamic';
     if (type is InterfaceType) {
       InterfaceElement interfaceElement = type.element;
@@ -2499,9 +2519,9 @@ class _ReflectorDomain {
     Iterable<int> methodIndices = libraryDomain._declarations
         .where(_executableIsntImplicitGetterOrSetter)
         .map((ExecutableElement element) {
-      int index = members.indexOf(element)!;
-      return index + methodsOffset;
-    });
+          int index = members.indexOf(element)!;
+          return index + methodsOffset;
+        });
 
     var declarationsCode = 'const <int>[${constants.noCapabilityIndex}]';
     if (_capabilities._impliesDeclarations) {
@@ -2589,32 +2609,35 @@ class _ReflectorDomain {
         DartType elementType = element.type;
         if (elementType is InterfaceType) {
           InterfaceElement elementTypeElement = elementType.element;
-          classMirrorIndex = (await classes).contains(elementTypeElement)
-              ? (await classes).indexOf(elementTypeElement)!
-              : constants.noCapabilityIndex;
+          classMirrorIndex =
+              (await classes).contains(elementTypeElement)
+                  ? (await classes).indexOf(elementTypeElement)!
+                  : constants.noCapabilityIndex;
         } else {
           classMirrorIndex = constants.noCapabilityIndex;
         }
       }
     }
-    int reflectedTypeIndex = reflectedTypeRequested
-        ? _typeCodeIndex(
-            element.type,
-            await classes,
-            reflectedTypes,
-            reflectedTypesOffset,
-            typedefs,
-          )
-        : constants.noCapabilityIndex;
-    int dynamicReflectedTypeIndex = reflectedTypeRequested
-        ? _dynamicTypeCodeIndex(
-            element.type,
-            await classes,
-            reflectedTypes,
-            reflectedTypesOffset,
-            typedefs,
-          )
-        : constants.noCapabilityIndex;
+    int reflectedTypeIndex =
+        reflectedTypeRequested
+            ? _typeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
+    int dynamicReflectedTypeIndex =
+        reflectedTypeRequested
+            ? _dynamicTypeCodeIndex(
+              element.type,
+              await classes,
+              reflectedTypes,
+              reflectedTypesOffset,
+              typedefs,
+            )
+            : constants.noCapabilityIndex;
     var reflectedTypeArguments = 'null';
     if (reflectedTypeRequested && _capabilities._impliesTypeRelations) {
       reflectedTypeArguments = await _computeReflectedTypeArguments(
@@ -2650,9 +2673,10 @@ class _ReflectorDomain {
     }
     String code = await _extractDefaultValueCode(importCollector, element);
     var defaultValueCode = code.isEmpty ? 'null' : code;
-    var parameterSymbolCode = descriptor & constants.namedAttribute != 0
-        ? '#${element.name}'
-        : 'null';
+    var parameterSymbolCode =
+        descriptor & constants.namedAttribute != 0
+            ? '#${element.name}'
+            : 'null';
 
     return "r.ParameterMirrorImpl(r'${element.name}', $descriptor, "
         '$ownerIndex, ${await _constConstructionCode(importCollector)}, '
@@ -2671,8 +2695,9 @@ class _ReflectorDomain {
     // TODO(eernst): 'dart:*' is not considered valid. To survive, we return
     // '' for all declarations from there. Issue 173.
     if (_isPlatformLibrary(parameterElement.library!)) return '';
-    var parameterNode = await _getDeclarationAst(parameterElement, _resolver)
-        as FormalParameter?;
+    var parameterNode =
+        await _getDeclarationAst(parameterElement, _resolver)
+            as FormalParameter?;
     // The node can be null because the declaration is synthetic, e.g.,
     // the parameter of an induced setter; they have no default value.
     if (parameterNode is DefaultFormalParameter &&
@@ -2785,11 +2810,12 @@ class _SuperclassFixedPoint extends FixedPoint<InterfaceElement> {
       if (mixinsRequested) result.add(mixinClass);
       InterfaceElement? subClass =
           mixin == element.mixins.last ? element : null;
-      String? name = subClass == null
-          ? null
-          : (element is MixinApplication && element.isMixinApplication
-              ? element.name
-              : null);
+      String? name =
+          subClass == null
+              ? null
+              : (element is MixinApplication && element.isMixinApplication
+                  ? element.name
+                  : null);
       InterfaceElement mixinApplication = MixinApplication(
         name,
         superclass,
@@ -2853,12 +2879,13 @@ Set<InterfaceElement> _mixinApplicationsOfClasses(
       InterfaceElement mixinClass = mixin.element;
       InterfaceElement? subClass =
           mixin == interfaceElement.mixins.last ? interfaceElement : null;
-      String? name = subClass == null
-          ? null
-          : (interfaceElement is MixinApplication &&
-                  interfaceElement.isMixinApplication
-              ? interfaceElement.name
-              : null);
+      String? name =
+          subClass == null
+              ? null
+              : (interfaceElement is MixinApplication &&
+                      interfaceElement.isMixinApplication
+                  ? interfaceElement.name
+                  : null);
       InterfaceElement mixinApplication = MixinApplication(
         name,
         superclass,
@@ -3090,9 +3117,9 @@ class _LibraryDomain {
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
   Iterable<ExecutableElement> get _declarations => [
-        ..._declaredFunctions,
-        ..._accessors,
-      ];
+    ..._declaredFunctions,
+    ..._accessors,
+  ];
 
   @override
   String toString() {
@@ -3194,11 +3221,11 @@ class _ClassDomain {
   /// behavioral point of view on the class. Also note that this is not
   /// the same semantics as that of `declarations` in [ClassMirror].
   Iterable<ExecutableElement> get _declarations => [
-        // TODO(sigurdm) feature: Include type variables (if we keep them).
-        ..._declaredMethods,
-        ..._accessors,
-        ..._constructors,
-      ];
+    // TODO(sigurdm) feature: Include type variables (if we keep them).
+    ..._declaredMethods,
+    ..._accessors,
+    ..._constructors,
+  ];
 
   /// Finds all instance members by going through the class hierarchy.
   Iterable<ExecutableElement> get _instanceMembers {
@@ -3306,9 +3333,10 @@ class _ClassDomain {
       if (!accessor.isStatic || accessor.isPrivate) return;
       // If [member] is a synthetic accessor created from a field, search for
       // the metadata on the original field.
-      List<ElementAnnotation> metadata = accessor.isSynthetic
-          ? (accessor.variable2?.metadata ?? const <ElementAnnotation>[])
-          : accessor.metadata;
+      List<ElementAnnotation> metadata =
+          accessor.isSynthetic
+              ? (accessor.variable2?.metadata ?? const <ElementAnnotation>[])
+              : accessor.metadata;
       List<ElementAnnotation>? getterMetadata;
       if (_reflectorDomain._capabilities._impliesCorrespondingSetters &&
           accessor.isSetter &&
@@ -3891,7 +3919,8 @@ class BuilderImplementation {
     if (element is ConstructorElement) {
       DartType enclosingType = _typeForReflectable(element.enclosingElement3);
       DartType focusClassType = _typeForReflectable(focusClass);
-      bool isOk = enclosingType is ParameterizedType &&
+      bool isOk =
+          enclosingType is ParameterizedType &&
           focusClassType is InterfaceType &&
           await checkInheritance(enclosingType, focusClassType);
       if (isOk) {
@@ -3916,7 +3945,8 @@ class BuilderImplementation {
       if (constantValue == null) return null;
       DartType? constantValueType = constantValue.type;
       DartType focusClassType = _typeForReflectable(focusClass);
-      bool isOk = constantValueType is ParameterizedType &&
+      bool isOk =
+          constantValueType is ParameterizedType &&
           focusClassType is InterfaceType &&
           await checkInheritance(constantValueType, focusClassType);
       // When `isOK` is true, result.value.type.element is a InterfaceElement.
@@ -3970,9 +4000,10 @@ class BuilderImplementation {
     InterfaceType typeType = reflectableLibrary.typeProvider.typeType;
     InterfaceElement typeTypeClass = typeType.element;
 
-    ConstructorElement globalQuantifyCapabilityConstructor = capabilityLibrary
-        .getClass('GlobalQuantifyCapability')!
-        .getNamedConstructor('')!;
+    ConstructorElement globalQuantifyCapabilityConstructor =
+        capabilityLibrary
+            .getClass('GlobalQuantifyCapability')!
+            .getNamedConstructor('')!;
     ConstructorElement globalQuantifyMetaCapabilityConstructor =
         capabilityLibrary
             .getClass('GlobalQuantifyMetaCapability')!
@@ -3982,8 +4013,9 @@ class BuilderImplementation {
       List<LibraryImportElement> imports =
           library.definingCompilationUnit.libraryImports;
       for (var importElement in imports) {
-        if (importElement.importedLibrary?.id != reflectableLibrary.id)
+        if (importElement.importedLibrary?.id != reflectableLibrary.id) {
           continue;
+        }
         for (ElementAnnotation metadatum in importElement.metadata) {
           Element? metadatumElement = metadatum.element?.declaration;
           if (metadatumElement == globalQuantifyCapabilityConstructor) {
@@ -4044,10 +4076,11 @@ class BuilderImplementation {
                 await _warn(WarningKind.badMetadata, message, metadatumElement);
                 continue;
               }
-              DartType? reflectorType = constantValue
-                  .getField('(super)')
-                  ?.getField('reflector')
-                  ?.type;
+              DartType? reflectorType =
+                  constantValue
+                      .getField('(super)')
+                      ?.getField('reflector')
+                      ?.type;
               InterfaceElement? reflector =
                   reflectorType is InterfaceType ? reflectorType.element : null;
               if (reflector == null) {
@@ -4783,8 +4816,9 @@ class BuilderImplementation {
     }
     final periodIndex = version.indexOf('.');
     final majorVersion = int.parse(version.substring(0, periodIndex));
-    final minorVersion =
-        int.parse(version.substring(periodIndex + 1, version.length));
+    final minorVersion = int.parse(
+      version.substring(periodIndex + 1, version.length),
+    );
     return semver.Version(majorVersion, minorVersion, 0);
   }
 
@@ -4804,9 +4838,10 @@ class BuilderImplementation {
 
     var imports = <String>[];
     for (LibraryElement library in world.importCollector._libraries) {
-      Uri uri = library == world.entryPointLibrary
-          ? Uri.parse(originalEntryPointFilename)
-          : await _getImportUri(library, _resolver, generatedLibraryId);
+      Uri uri =
+          library == world.entryPointLibrary
+              ? Uri.parse(originalEntryPointFilename)
+              : await _getImportUri(library, _resolver, generatedLibraryId);
       String prefix = world.importCollector._getPrefix(library);
       if (prefix.isNotEmpty) {
         imports.add(
@@ -5165,9 +5200,10 @@ int _declarationDescriptor(ExecutableElement element) {
 }
 
 Future<String> _nameOfConstructor(ConstructorElement element) async {
-  String name = element.name == ''
-      ? element.enclosingElement3.name
-      : '${element.enclosingElement3.name}.${element.name}';
+  String name =
+      element.name == ''
+          ? element.enclosingElement3.name
+          : '${element.enclosingElement3.name}.${element.name}';
   if (_isPrivateName(name)) {
     await _severe('Cannot access private name $name', element);
   }
@@ -5346,9 +5382,10 @@ Future<String> _extractConstantCode(
         Element? staticElement = expression.staticElement;
         if (staticElement is PropertyAccessorElement) {
           VariableElement? variable = staticElement.variable2;
-          AstNode? variableDeclaration = variable != null
-              ? await _getDeclarationAst(variable, resolver)
-              : null;
+          AstNode? variableDeclaration =
+              variable != null
+                  ? await _getDeclarationAst(variable, resolver)
+                  : null;
           if (variableDeclaration == null ||
               variableDeclaration is! VariableDeclaration) {
             await _severe('Cannot handle private identifier $expression');
@@ -5766,12 +5803,13 @@ Iterable<ParameterElement> _extractDeclaredFunctionParameters(
   return result;
 }
 
-typedef CapabilityChecker = bool Function(
-  TypeSystem,
-  String methodName,
-  Iterable<ElementAnnotation> metadata,
-  Iterable<ElementAnnotation>? getterMetadata,
-);
+typedef CapabilityChecker =
+    bool Function(
+      TypeSystem,
+      String methodName,
+      Iterable<ElementAnnotation> metadata,
+      Iterable<ElementAnnotation>? getterMetadata,
+    );
 
 /// Returns the declared fields in the given [interfaceElement], filtered such
 /// that the returned ones are the ones that are supported by [capabilities].
@@ -5782,9 +5820,10 @@ Iterable<FieldElement> _extractDeclaredFields(
 ) {
   return interfaceElement.fields.where((FieldElement field) {
     if (field.isPrivate) return false;
-    CapabilityChecker capabilityChecker = field.isStatic
-        ? capabilities.supportsStaticInvoke
-        : capabilities.supportsInstanceInvoke;
+    CapabilityChecker capabilityChecker =
+        field.isStatic
+            ? capabilities.supportsStaticInvoke
+            : capabilities.supportsInstanceInvoke;
     return !field.isSynthetic &&
         capabilityChecker(
           interfaceElement.library.typeSystem,
@@ -5804,9 +5843,10 @@ Iterable<MethodElement> _extractDeclaredMethods(
 ) {
   return interfaceElement.methods.where((MethodElement method) {
     if (method.isPrivate) return false;
-    CapabilityChecker capabilityChecker = method.isStatic
-        ? capabilities.supportsStaticInvoke
-        : capabilities.supportsInstanceInvoke;
+    CapabilityChecker capabilityChecker =
+        method.isStatic
+            ? capabilities.supportsStaticInvoke
+            : capabilities.supportsInstanceInvoke;
     return capabilityChecker(
       method.library.typeSystem,
       method.name,
@@ -5895,12 +5935,14 @@ Iterable<PropertyAccessorElement> _extractAccessors(
     // such that we avoid passing in `null` at all call sites except one,
     // when we might as well move the processing to that single call site (such
     // as here, but also in `_extractLibraryAccessors()`, etc).
-    CapabilityChecker capabilityChecker = accessor.isStatic
-        ? capabilities.supportsStaticInvoke
-        : capabilities.supportsInstanceInvoke;
-    List<ElementAnnotation> metadata = accessor.isSynthetic
-        ? (accessor.variable2?.metadata ?? const <ElementAnnotation>[])
-        : accessor.metadata;
+    CapabilityChecker capabilityChecker =
+        accessor.isStatic
+            ? capabilities.supportsStaticInvoke
+            : capabilities.supportsInstanceInvoke;
+    List<ElementAnnotation> metadata =
+        accessor.isSynthetic
+            ? (accessor.variable2?.metadata ?? const <ElementAnnotation>[])
+            : accessor.metadata;
     List<ElementAnnotation>? getterMetadata;
     if (capabilities._impliesCorrespondingSetters &&
         accessor.isSetter &&
@@ -5944,28 +5986,28 @@ _LibraryDomain _createLibraryDomain(
 ) {
   Iterable<TopLevelVariableElement> declaredVariablesOfLibrary =
       _extractDeclaredVariables(
-    domain._resolver,
-    library,
-    domain._capabilities,
-  ).toList();
+        domain._resolver,
+        library,
+        domain._capabilities,
+      ).toList();
   Iterable<FunctionElement> declaredFunctionsOfLibrary =
       _extractDeclaredFunctions(
-    domain._resolver,
-    library,
-    domain._capabilities,
-  ).toList();
+        domain._resolver,
+        library,
+        domain._capabilities,
+      ).toList();
   Iterable<PropertyAccessorElement> accessorsOfLibrary =
       _extractLibraryAccessors(
-    domain._resolver,
-    library,
-    domain._capabilities,
-  ).toList();
+        domain._resolver,
+        library,
+        domain._capabilities,
+      ).toList();
   Iterable<ParameterElement> declaredParametersOfLibrary =
       _extractDeclaredFunctionParameters(
-    domain._resolver,
-    declaredFunctionsOfLibrary,
-    accessorsOfLibrary,
-  ).toList();
+        domain._resolver,
+        declaredFunctionsOfLibrary,
+        accessorsOfLibrary,
+      ).toList();
   return _LibraryDomain(
     library,
     declaredVariablesOfLibrary,
@@ -5981,30 +6023,32 @@ _ClassDomain _createClassDomain(
   _ReflectorDomain domain,
 ) {
   if (type is MixinApplication) {
-    Iterable<FieldElement> declaredFieldsOfClass = _extractDeclaredFields(
-      domain._resolver,
-      type.mixin,
-      domain._capabilities,
-    ).where((FieldElement e) => !e.isStatic).toList();
-    Iterable<MethodElement> declaredMethodsOfClass = _extractDeclaredMethods(
-      domain._resolver,
-      type.mixin,
-      domain._capabilities,
-    ).where((MethodElement e) => !e.isStatic).toList();
+    Iterable<FieldElement> declaredFieldsOfClass =
+        _extractDeclaredFields(
+          domain._resolver,
+          type.mixin,
+          domain._capabilities,
+        ).where((FieldElement e) => !e.isStatic).toList();
+    Iterable<MethodElement> declaredMethodsOfClass =
+        _extractDeclaredMethods(
+          domain._resolver,
+          type.mixin,
+          domain._capabilities,
+        ).where((MethodElement e) => !e.isStatic).toList();
     Iterable<PropertyAccessorElement> declaredAndImplicitAccessorsOfClass =
         _extractAccessors(
-      domain._resolver,
-      type.mixin,
-      domain._capabilities,
-    ).toList();
+          domain._resolver,
+          type.mixin,
+          domain._capabilities,
+        ).toList();
     Iterable<ConstructorElement> declaredConstructorsOfClass =
         <ConstructorElement>[];
     Iterable<ParameterElement> declaredParametersOfClass =
         _extractDeclaredParameters(
-      declaredMethodsOfClass,
-      declaredConstructorsOfClass,
-      declaredAndImplicitAccessorsOfClass,
-    );
+          declaredMethodsOfClass,
+          declaredConstructorsOfClass,
+          declaredAndImplicitAccessorsOfClass,
+        );
 
     return _ClassDomain(
       type,
@@ -6017,25 +6061,27 @@ _ClassDomain _createClassDomain(
     );
   }
 
-  List<FieldElement> declaredFieldsOfClass = _extractDeclaredFields(
-    domain._resolver,
-    type,
-    domain._capabilities,
-  ).toList();
-  List<MethodElement> declaredMethodsOfClass = _extractDeclaredMethods(
-    domain._resolver,
-    type,
-    domain._capabilities,
-  ).toList();
+  List<FieldElement> declaredFieldsOfClass =
+      _extractDeclaredFields(
+        domain._resolver,
+        type,
+        domain._capabilities,
+      ).toList();
+  List<MethodElement> declaredMethodsOfClass =
+      _extractDeclaredMethods(
+        domain._resolver,
+        type,
+        domain._capabilities,
+      ).toList();
   List<PropertyAccessorElement> declaredAndImplicitAccessorsOfClass =
       _extractAccessors(domain._resolver, type, domain._capabilities).toList();
   List<ConstructorElement> declaredConstructorsOfClass =
       _extractDeclaredConstructors(
-    domain._resolver,
-    type.library,
-    type,
-    domain._capabilities,
-  ).toList();
+        domain._resolver,
+        type.library,
+        type,
+        domain._capabilities,
+      ).toList();
   List<ParameterElement> declaredParametersOfClass = _extractDeclaredParameters(
     declaredMethodsOfClass,
     declaredConstructorsOfClass,
@@ -6202,12 +6248,11 @@ class MixinApplication implements ClassElementImpl {
   InterfaceTypeImpl instantiate({
     required List<DartType> typeArguments,
     required NullabilitySuffix nullabilitySuffix,
-  }) =>
-      InterfaceTypeImpl(
-        element: element3,
-        typeArguments: typeArguments.cast(),
-        nullabilitySuffix: nullabilitySuffix,
-      );
+  }) => InterfaceTypeImpl(
+    element: element3,
+    typeArguments: typeArguments.cast(),
+    nullabilitySuffix: nullabilitySuffix,
+  );
 
   @override
   InterfaceTypeImpl? get supertype {
@@ -6335,9 +6380,10 @@ class MixinApplication2 implements InterfaceElementImpl2 {
   String get displayName => delegatee.displayName;
 
   @override
-  String displayString2(
-          {bool multiline = false, bool preferTypeAlias = false}) =>
-      delegatee.getDisplayString(multiline: multiline);
+  String displayString2({
+    bool multiline = false,
+    bool preferTypeAlias = false,
+  }) => delegatee.getDisplayString(multiline: multiline);
 
   @override
   String? get documentationComment => delegatee.documentationComment;
@@ -6450,17 +6496,19 @@ class MixinApplication2 implements InterfaceElementImpl2 {
       throw UnimplementedError();
 
   @override
-  InterfaceTypeImpl instantiate(
-      {required List<DartType> typeArguments,
-      required NullabilitySuffix nullabilitySuffix}) {
+  InterfaceTypeImpl instantiate({
+    required List<DartType> typeArguments,
+    required NullabilitySuffix nullabilitySuffix,
+  }) {
     // TODO: implement instantiate
     throw UnimplementedError();
   }
 
   @override
-  InterfaceTypeImpl instantiateImpl(
-      {required List<TypeImpl> typeArguments,
-      required NullabilitySuffix nullabilitySuffix}) {
+  InterfaceTypeImpl instantiateImpl({
+    required List<TypeImpl> typeArguments,
+    required NullabilitySuffix nullabilitySuffix,
+  }) {
     // TODO: implement instantiateImpl
     throw UnimplementedError();
   }
@@ -6502,63 +6550,81 @@ class MixinApplication2 implements InterfaceElementImpl2 {
 
   @override
   MethodElement2? lookUpConcreteMethod(
-      String methodName, LibraryElement2 library) {
+    String methodName,
+    LibraryElement2 library,
+  ) {
     // TODO: implement lookUpConcreteMethod
     throw UnimplementedError();
   }
 
   @override
-  GetterElement? lookUpGetter2(
-      {required String name, required LibraryElement2 library}) {
+  GetterElement? lookUpGetter2({
+    required String name,
+    required LibraryElement2 library,
+  }) {
     // TODO: implement lookUpGetter2
     throw UnimplementedError();
   }
 
   @override
   PropertyAccessorElement2? lookUpInheritedConcreteGetter(
-      String getterName, LibraryElement2 library) {
+    String getterName,
+    LibraryElement2 library,
+  ) {
     // TODO: implement lookUpInheritedConcreteGetter
     throw UnimplementedError();
   }
 
   @override
   MethodElement2? lookUpInheritedConcreteMethod(
-      String methodName, LibraryElement2 library) {
+    String methodName,
+    LibraryElement2 library,
+  ) {
     // TODO: implement lookUpInheritedConcreteMethod
     throw UnimplementedError();
   }
 
   @override
   PropertyAccessorElement2? lookUpInheritedConcreteSetter(
-      String setterName, LibraryElement2 library) {
+    String setterName,
+    LibraryElement2 library,
+  ) {
     // TODO: implement lookUpInheritedConcreteSetter
     throw UnimplementedError();
   }
 
   @override
   MethodElement2? lookUpInheritedMethod(
-      String methodName, LibraryElement2 library) {
+    String methodName,
+    LibraryElement2 library,
+  ) {
     // TODO: implement lookUpInheritedMethod
     throw UnimplementedError();
   }
 
   @override
-  MethodElement2? lookUpInheritedMethod2(
-      {required String methodName, required LibraryElement2 library}) {
+  MethodElement2? lookUpInheritedMethod2({
+    required String methodName,
+    required LibraryElement2 library,
+  }) {
     // TODO: implement lookUpInheritedMethod2
     throw UnimplementedError();
   }
 
   @override
-  MethodElement2? lookUpMethod2(
-      {required String name, required LibraryElement2 library}) {
+  MethodElement2? lookUpMethod2({
+    required String name,
+    required LibraryElement2 library,
+  }) {
     // TODO: implement lookUpMethod2
     throw UnimplementedError();
   }
 
   @override
-  SetterElement? lookUpSetter2(
-      {required String name, required LibraryElement2 library}) {
+  SetterElement? lookUpSetter2({
+    required String name,
+    required LibraryElement2 library,
+  }) {
     // TODO: implement lookUpSetter2
     throw UnimplementedError();
   }
@@ -6569,21 +6635,27 @@ class MixinApplication2 implements InterfaceElementImpl2 {
 
   @override
   GetterElement2OrMember? lookupStaticGetter(
-      String name, LibraryElement2 library) {
+    String name,
+    LibraryElement2 library,
+  ) {
     // TODO: implement lookupStaticGetter
     throw UnimplementedError();
   }
 
   @override
   MethodElement2OrMember? lookupStaticMethod(
-      String name, LibraryElement2 library) {
+    String name,
+    LibraryElement2 library,
+  ) {
     // TODO: implement lookupStaticMethod
     throw UnimplementedError();
   }
 
   @override
   SetterElement2OrMember? lookupStaticSetter(
-      String name, LibraryElement2 library) {
+    String name,
+    LibraryElement2 library,
+  ) {
     // TODO: implement lookupStaticSetter
     throw UnimplementedError();
   }
@@ -6837,8 +6909,8 @@ Future<String> _formatDiagnosticMessage(
       resolver,
     );
     if (resolvedLibrary != null) {
-      final ElementDeclarationResult? targetDeclaration =
-          resolvedLibrary.getElementDeclaration(target!);
+      final ElementDeclarationResult? targetDeclaration = resolvedLibrary
+          .getElementDeclaration(target!);
       final CompilationUnit? unit = targetDeclaration?.resolvedUnit?.unit;
       final CharacterLocation? location = unit?.lineInfo.getLocation(
         nameOffset,
@@ -6868,8 +6940,8 @@ Future<ResolvedLibraryResult?> _getResolvedLibrary(
     await resolver.assetIdForElement(library),
   );
   final AnalysisSession freshSession = freshLibrary.session;
-  final SomeResolvedLibraryResult someResult =
-      await freshSession.getResolvedLibraryByElement(freshLibrary);
+  final SomeResolvedLibraryResult someResult = await freshSession
+      .getResolvedLibraryByElement(freshLibrary);
   if (someResult is ResolvedLibraryResult) {
     return someResult;
   } else {

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -3981,11 +3981,13 @@ class BuilderImplementation {
     print('>>> constructor: $globalQuantifyCapabilityConstructor'); // DEBUG
 
     for (LibraryElement library in _libraries) {
-      List<LibraryElement> imports = library.importedLibraries;
+      List<LibraryImportElement> imports =
+          library.definingCompilationUnit.libraryImports;
       print('>>> imports: $imports'); // DEBUG
-      for (var import in imports) {
-        if (import.id != reflectableLibrary.id) continue;
-        for (ElementAnnotation metadatum in import.metadata) {
+      for (var importElement in imports) {
+        if (importElement.importedLibrary?.id != reflectableLibrary.id)
+          continue;
+        for (ElementAnnotation metadatum in importElement.metadata) {
           Element? metadatumElement = metadatum.element?.declaration;
           if (metadatumElement == globalQuantifyCapabilityConstructor) {
             DartObject? value = _getEvaluatedMetadatum(metadatum);

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -763,8 +763,9 @@ class _ReflectorDomain {
     // argument (say, "Hello, world!") and then test for that value, but that
     // would suppress an error in a very-hard-to-explain case, so that's safer
     // in a sense, but too weird.
+    ConstructorElement? _; // DEBUG
     if (constructor.library.isDartCore &&
-        constructor.enclosingElement.name == 'List' &&
+        constructor.enclosingElement3.name == 'List' &&
         constructor.name == '') {
       return '(bool b) => ([length]) => '
           'b ? (length == null ? [] : List.filled(length, null)) : null';
@@ -1406,9 +1407,9 @@ class _ReflectorDomain {
     ExecutableElement element,
     int descriptor,
   ) async {
-    if (element.enclosingElement is InterfaceElement) {
-      return (await classes).indexOf(element.enclosingElement);
-    } else if (element.enclosingElement is CompilationUnitElement) {
+    if (element.enclosingElement3 is InterfaceElement) {
+      return (await classes).indexOf(element.enclosingElement3);
+    } else if (element.enclosingElement3 is CompilationUnitElement) {
       return _libraries.indexOf(element.library);
     }
     await _severe('Unexpected kind of request for owner');
@@ -1455,7 +1456,7 @@ class _ReflectorDomain {
       }
     }
     int? ownerIndex = (await classes).indexOf(
-      typeParameterElement.enclosingElement!,
+      typeParameterElement.enclosingElement3!,
     );
     // TODO(eernst) implement: Update when type variables support metadata.
     var metadataCode = _capabilities._supportsMetadata ? '<Object>[]' : 'null';
@@ -1578,7 +1579,7 @@ class _ReflectorDomain {
     } else {
       var mapEntries = <String>[];
       for (ConstructorElement constructor in classDomain._constructors) {
-        InterfaceElement enclosingElement = constructor.enclosingElement;
+        InterfaceElement enclosingElement = constructor.enclosingElement3;
         if (constructor.isFactory ||
             ((enclosingElement is ClassElement &&
                     !enclosingElement.isAbstract) &&
@@ -1957,7 +1958,7 @@ class _ReflectorDomain {
     bool reflectedTypeRequested,
   ) async {
     int descriptor = _fieldDescriptor(element);
-    int ownerIndex = (await classes).indexOf(element.enclosingElement) ??
+    int ownerIndex = (await classes).indexOf(element.enclosingElement3) ??
         constants.noCapabilityIndex;
     int classMirrorIndex = await _computeVariableTypeIndex(element, descriptor);
     int reflectedTypeIndex = reflectedTypeRequested
@@ -2570,7 +2571,7 @@ class _ReflectorDomain {
   ) async {
     int descriptor = _parameterDescriptor(element);
     int ownerIndex =
-        members.indexOf(element.enclosingElement!)! + fields.length;
+        members.indexOf(element.enclosingElement3!)! + fields.length;
     int classMirrorIndex = constants.noCapabilityIndex;
     if (_capabilities._impliesTypes) {
       if (descriptor & constants.dynamicAttribute != 0 ||
@@ -3885,7 +3886,7 @@ class BuilderImplementation {
 
     Element? element = elementAnnotation.element;
     if (element is ConstructorElement) {
-      DartType enclosingType = _typeForReflectable(element.enclosingElement);
+      DartType enclosingType = _typeForReflectable(element.enclosingElement3);
       DartType focusClassType = _typeForReflectable(focusClass);
       bool isOk = enclosingType is ParameterizedType &&
           focusClassType is InterfaceType &&
@@ -3975,9 +3976,9 @@ class BuilderImplementation {
             .getNamedConstructor('')!;
 
     for (LibraryElement library in _libraries) {
-      List<LibraryImportElement> imports = library.libraryImports;
+      List<LibraryElement> imports = library.importedLibraries;
       for (var import in imports) {
-        if (import.importedLibrary?.id != reflectableLibrary.id) continue;
+        if (import.id != reflectableLibrary.id) continue;
         for (ElementAnnotation metadatum in import.metadata) {
           Element? metadatumElement = metadatum.element?.declaration;
           if (metadatumElement == globalQuantifyCapabilityConstructor) {
@@ -5151,7 +5152,7 @@ int _declarationDescriptor(ExecutableElement element) {
   if (element is! ConstructorElement) {
     if (element.isAbstract) result |= constants.abstractAttribute;
   }
-  if (element.enclosingElement is! InterfaceElement) {
+  if (element.enclosingElement3 is! InterfaceElement) {
     result |= constants.topLevelAttribute;
   }
   return result;
@@ -5159,8 +5160,8 @@ int _declarationDescriptor(ExecutableElement element) {
 
 Future<String> _nameOfConstructor(ConstructorElement element) async {
   String name = element.name == ''
-      ? element.enclosingElement.name
-      : '${element.enclosingElement.name}.${element.name}';
+      ? element.enclosingElement3.name
+      : '${element.enclosingElement3.name}.${element.name}';
   if (_isPrivateName(name)) {
     await _severe('Cannot access private name $name', element);
   }
@@ -5375,7 +5376,7 @@ Future<String> _extractConstantCode(
               )) {
             importCollector._addLibrary(elementLibrary);
             String prefix = importCollector._getPrefix(elementLibrary);
-            Element? enclosingElement = element.enclosingElement;
+            Element? enclosingElement = element.enclosingElement3;
             if (enclosingElement is InterfaceElement) {
               prefix += '${enclosingElement.name}.';
             }
@@ -6194,11 +6195,15 @@ class MixinApplication implements ClassElement {
     required List<DartType> typeArguments,
     required NullabilitySuffix nullabilitySuffix,
   }) =>
+      /* DEBUG
       InterfaceTypeImpl(
-        element: this,
-        typeArguments: typeArguments,
+        element: this.element3,
+        typeArguments: typeArguments.cast(),
         nullabilitySuffix: nullabilitySuffix,
       );
+      */
+      throw UnimplementedError(
+          "Attempt to instantiate the MixinApplication $this");
 
   @override
   InterfaceType? get supertype {
@@ -6303,7 +6308,7 @@ String _qualifiedFunctionName(FunctionElement functionElement) {
 
 String _qualifiedTypeParameterName(TypeParameterElement? typeParameterElement) {
   if (typeParameterElement == null) return 'null';
-  return '${_qualifiedName(typeParameterElement.enclosingElement!)}.'
+  return '${_qualifiedName(typeParameterElement.enclosingElement3!)}.'
       '${typeParameterElement.name}';
 }
 

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -5188,11 +5188,7 @@ int _declarationDescriptor(ExecutableElement element) {
   if (element.isPrivate) result |= constants.privateAttribute;
   if (element.isStatic) result |= constants.staticAttribute;
   if (element.isSynthetic) result |= constants.syntheticAttribute;
-  // TODO(eernst): Work around issue in analyzer, cf. #39051.
-  // When resolved, only the inner `if` is needed.
-  if (element is! ConstructorElement) {
-    if (element.isAbstract) result |= constants.abstractAttribute;
-  }
+  if (element.isAbstract) result |= constants.abstractAttribute;
   if (element.enclosingElement3 is! InterfaceElement) {
     result |= constants.topLevelAttribute;
   }

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -6302,6 +6302,9 @@ class MixinApplication2 implements InterfaceElementImpl2 {
   bool get isSimplyBounded => true;
 
   @override
+  set isSimplyBounded(bool value) => throw UnimplementedError();
+
+  @override
   T? accept2<T>(ElementVisitor2<T> visitor) {
     // TODO: implement accept2
     throw UnimplementedError();

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -4016,7 +4016,6 @@ class BuilderImplementation {
                 }
               }
               print('>>> $reflector'); // DEBUG
-              if (pattern == null
               globalPatterns
                   .putIfAbsent(
                     RegExp(pattern ?? ''),

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -3982,6 +3982,7 @@ class BuilderImplementation {
 
     for (LibraryElement library in _libraries) {
       List<LibraryElement> imports = library.importedLibraries;
+      print('>>> imports: $imports'); // DEBUG
       for (var import in imports) {
         if (import.id != reflectableLibrary.id) continue;
         for (ElementAnnotation metadatum in import.metadata) {

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -767,7 +767,6 @@ class _ReflectorDomain {
     // argument (say, "Hello, world!") and then test for that value, but that
     // would suppress an error in a very-hard-to-explain case, so that's safer
     // in a sense, but too weird.
-    ConstructorElement? _; // DEBUG
     if (constructor.library.isDartCore &&
         constructor.enclosingElement3.name == 'List' &&
         constructor.name == '') {
@@ -3978,12 +3977,10 @@ class BuilderImplementation {
         capabilityLibrary
             .getClass('GlobalQuantifyMetaCapability')!
             .getNamedConstructor('')!;
-    print('>>> constructor: $globalQuantifyCapabilityConstructor'); // DEBUG
 
     for (LibraryElement library in _libraries) {
       List<LibraryImportElement> imports =
           library.definingCompilationUnit.libraryImports;
-      print('>>> imports: $imports'); // DEBUG
       for (var importElement in imports) {
         if (importElement.importedLibrary?.id != reflectableLibrary.id)
           continue;
@@ -4018,7 +4015,6 @@ class BuilderImplementation {
                   continue;
                 }
               }
-              print('>>> reflector: $reflector'); // DEBUG
               globalPatterns
                   .putIfAbsent(
                     RegExp(pattern ?? ''),
@@ -4083,8 +4079,6 @@ class BuilderImplementation {
         }
       }
     }
-    print(
-        '>>> globalMetadata: $globalMetadata, globalPatterns: $globalPatterns'); // DEBUG
   }
 
   /// Returns true iff [potentialReflectorClass] is a proper reflector class,

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -6282,9 +6282,6 @@ class MixinApplication implements ClassElementImpl {
   int get hashCode => superclass.hashCode ^ mixin.hashCode ^ library.hashCode;
 
   @override
-  Null get augmentationTarget => null;
-
-  @override
   String toString() => 'MixinApplication($superclass, $mixin)';
 
   // Let the compiler generate forwarders for all remaining methods: Instances

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -4078,6 +4078,7 @@ class BuilderImplementation {
         }
       }
     }
+    print('>>> $globalMetadata'); // DEBUG
   }
 
   /// Returns true iff [potentialReflectorClass] is a proper reflector class,

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -4080,7 +4080,7 @@ class BuilderImplementation {
         }
       }
     }
-    print('>>> $globalMetadata'); // DEBUG
+    print('>>> globalMetadata: $globalMetadata'); // DEBUG
   }
 
   /// Returns true iff [potentialReflectorClass] is a proper reflector class,

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -4080,7 +4080,8 @@ class BuilderImplementation {
         }
       }
     }
-    print('>>> globalMetadata: $globalMetadata'); // DEBUG
+    print(
+        '>>> globalMetadata: $globalMetadata, globalPatterns: $globalPatterns'); // DEBUG
   }
 
   /// Returns true iff [potentialReflectorClass] is a proper reflector class,

--- a/reflectable/lib/src/builder_implementation.dart
+++ b/reflectable/lib/src/builder_implementation.dart
@@ -6340,6 +6340,12 @@ class MixinApplication implements ClassElementImpl {
 }
 
 /// Partially migrating [MixinApplication] to the [Element2] model.
+///
+/// This class is only needed because one location in `MixinApplication`
+/// needs to return an `Element2`, so we create an instance of this class
+/// and use that to wrap the `MixinApplication`. Members have been implemented
+/// based on what is needed. This class will probably go away when the
+/// package is migrated to use the new element model consistently.
 class MixinApplication2 implements InterfaceElementImpl2 {
   final MixinApplication delegatee;
 
@@ -6353,7 +6359,6 @@ class MixinApplication2 implements InterfaceElementImpl2 {
 
   @override
   T? accept2<T>(ElementVisitor2<T> visitor) {
-    // TODO: implement accept2
     throw UnimplementedError();
   }
 
@@ -6361,19 +6366,15 @@ class MixinApplication2 implements InterfaceElementImpl2 {
   List<InterfaceType> get allSupertypes => delegatee.interfaces;
 
   @override
-  void appendTo(ElementDisplayStringBuilder builder) {
-    // TODO: implement appendTo
-  }
+  void appendTo(ElementDisplayStringBuilder builder) {}
 
   @override
   InstanceElement2 get baseElement => this;
 
   @override
-  // TODO: implement children2
   List<Element2> get children2 => throw UnimplementedError();
 
   @override
-  // TODO: implement constructors2
   List<ConstructorElementImpl2> get constructors2 => throw UnimplementedError();
 
   @override
@@ -6391,15 +6392,12 @@ class MixinApplication2 implements InterfaceElementImpl2 {
   MixinApplication get element => delegatee;
 
   @override
-  // TODO: implement enclosingElement2
   LibraryElement2 get enclosingElement2 => throw UnimplementedError();
 
   @override
-  // TODO: implement fields2
   List<FieldElementImpl2> get fields2 => throw UnimplementedError();
 
   @override
-  // TODO: implement firstFragment
   InterfaceElementImpl get firstFragment => delegatee;
 
   @override
@@ -6411,87 +6409,71 @@ class MixinApplication2 implements InterfaceElementImpl2 {
 
   @override
   FieldElementImpl2? getField2(String name) {
-    // TODO: implement getField2
     throw UnimplementedError();
   }
 
   @override
   GetterElementImpl? getGetter2(String name) {
-    // TODO: implement getGetter2
     throw UnimplementedError();
   }
 
   @override
   ExecutableElement2? getInheritedConcreteMember(Name name) {
-    // TODO: implement getInheritedConcreteMember
     throw UnimplementedError();
   }
 
   @override
   ExecutableElement2? getInheritedMember(Name name) {
-    // TODO: implement getInheritedMember
     throw UnimplementedError();
   }
 
   @override
   ExecutableElement2? getInterfaceMember(Name name) {
-    // TODO: implement getInterfaceMember
     throw UnimplementedError();
   }
 
   @override
   MethodElementImpl2? getMethod2(String name) {
-    // TODO: implement getMethod2
     throw UnimplementedError();
   }
 
   @override
   ConstructorElementImpl2? getNamedConstructor2(String name) {
-    // TODO: implement getNamedConstructor2
     throw UnimplementedError();
   }
 
   @override
   List<ExecutableElement2>? getOverridden(Name name) {
-    // TODO: implement getOverridden
     throw UnimplementedError();
   }
 
   @override
   SetterElementImpl? getSetter2(String name) {
-    // TODO: implement getSetter2
     throw UnimplementedError();
   }
 
   @override
-  // TODO: implement getters2
   List<GetterElementImpl> get getters2 => throw UnimplementedError();
 
   @override
   bool hasModifier(Modifier modifier) {
-    // TODO: implement hasModifier
     throw UnimplementedError();
   }
 
   @override
-  // TODO: implement id
   int get id => throw UnimplementedError();
 
   @override
-  // TODO: implement identifier
   String get identifier => throw UnimplementedError();
 
   @override
-  // TODO: implement inheritanceManager
   InheritanceManager3 get inheritanceManager => throw UnimplementedError();
 
   @override
-  // TODO: implement inheritedConcreteMembers
   Map<Name, ExecutableElement2> get inheritedConcreteMembers =>
       throw UnimplementedError();
 
   @override
-  // TODO: implement inheritedMembers
   Map<Name, ExecutableElement2> get inheritedMembers =>
       throw UnimplementedError();
 
@@ -6500,7 +6482,6 @@ class MixinApplication2 implements InterfaceElementImpl2 {
     required List<DartType> typeArguments,
     required NullabilitySuffix nullabilitySuffix,
   }) {
-    // TODO: implement instantiate
     throw UnimplementedError();
   }
 
@@ -6509,43 +6490,34 @@ class MixinApplication2 implements InterfaceElementImpl2 {
     required List<TypeImpl> typeArguments,
     required NullabilitySuffix nullabilitySuffix,
   }) {
-    // TODO: implement instantiateImpl
     throw UnimplementedError();
   }
 
   @override
-  // TODO: implement interfaceMembers
   Map<Name, ExecutableElement2> get interfaceMembers =>
       throw UnimplementedError();
 
   @override
-  // TODO: implement interfaces
   List<InterfaceTypeImpl> get interfaces => throw UnimplementedError();
 
   @override
   bool isAccessibleIn2(LibraryElement2 library) {
-    // TODO: implement isAccessibleIn2
     throw UnimplementedError();
   }
 
   @override
-  // TODO: implement isPrivate
   bool get isPrivate => throw UnimplementedError();
 
   @override
-  // TODO: implement isPublic
   bool get isPublic => throw UnimplementedError();
 
   @override
-  // TODO: implement isSynthetic
   bool get isSynthetic => throw UnimplementedError();
 
   @override
-  // TODO: implement kind
   ElementKind get kind => throw UnimplementedError();
 
   @override
-  // TODO: implement library2
   LibraryElementImpl get library2 => throw UnimplementedError();
 
   @override
@@ -6553,7 +6525,6 @@ class MixinApplication2 implements InterfaceElementImpl2 {
     String methodName,
     LibraryElement2 library,
   ) {
-    // TODO: implement lookUpConcreteMethod
     throw UnimplementedError();
   }
 
@@ -6562,7 +6533,6 @@ class MixinApplication2 implements InterfaceElementImpl2 {
     required String name,
     required LibraryElement2 library,
   }) {
-    // TODO: implement lookUpGetter2
     throw UnimplementedError();
   }
 
@@ -6571,7 +6541,6 @@ class MixinApplication2 implements InterfaceElementImpl2 {
     String getterName,
     LibraryElement2 library,
   ) {
-    // TODO: implement lookUpInheritedConcreteGetter
     throw UnimplementedError();
   }
 
@@ -6580,7 +6549,6 @@ class MixinApplication2 implements InterfaceElementImpl2 {
     String methodName,
     LibraryElement2 library,
   ) {
-    // TODO: implement lookUpInheritedConcreteMethod
     throw UnimplementedError();
   }
 
@@ -6589,7 +6557,6 @@ class MixinApplication2 implements InterfaceElementImpl2 {
     String setterName,
     LibraryElement2 library,
   ) {
-    // TODO: implement lookUpInheritedConcreteSetter
     throw UnimplementedError();
   }
 
@@ -6598,7 +6565,6 @@ class MixinApplication2 implements InterfaceElementImpl2 {
     String methodName,
     LibraryElement2 library,
   ) {
-    // TODO: implement lookUpInheritedMethod
     throw UnimplementedError();
   }
 
@@ -6607,7 +6573,6 @@ class MixinApplication2 implements InterfaceElementImpl2 {
     required String methodName,
     required LibraryElement2 library,
   }) {
-    // TODO: implement lookUpInheritedMethod2
     throw UnimplementedError();
   }
 
@@ -6616,7 +6581,6 @@ class MixinApplication2 implements InterfaceElementImpl2 {
     required String name,
     required LibraryElement2 library,
   }) {
-    // TODO: implement lookUpMethod2
     throw UnimplementedError();
   }
 
@@ -6625,12 +6589,10 @@ class MixinApplication2 implements InterfaceElementImpl2 {
     required String name,
     required LibraryElement2 library,
   }) {
-    // TODO: implement lookUpSetter2
     throw UnimplementedError();
   }
 
   @override
-  // TODO: implement lookupName
   String? get lookupName => throw UnimplementedError();
 
   @override
@@ -6638,7 +6600,6 @@ class MixinApplication2 implements InterfaceElementImpl2 {
     String name,
     LibraryElement2 library,
   ) {
-    // TODO: implement lookupStaticGetter
     throw UnimplementedError();
   }
 
@@ -6647,7 +6608,6 @@ class MixinApplication2 implements InterfaceElementImpl2 {
     String name,
     LibraryElement2 library,
   ) {
-    // TODO: implement lookupStaticMethod
     throw UnimplementedError();
   }
 
@@ -6656,90 +6616,68 @@ class MixinApplication2 implements InterfaceElementImpl2 {
     String name,
     LibraryElement2 library,
   ) {
-    // TODO: implement lookupStaticSetter
     throw UnimplementedError();
   }
 
   @override
-  // TODO: implement metadata2
   MetadataImpl get metadata2 => throw UnimplementedError();
 
   @override
-  // TODO: implement methods2
   List<MethodElementImpl2> get methods2 => throw UnimplementedError();
 
   @override
-  // TODO: implement mixins
   List<InterfaceTypeImpl> get mixins => throw UnimplementedError();
 
   @override
-  // TODO: implement name3
   String? get name3 => delegatee.name;
 
   @override
-  // TODO: implement nonSynthetic2
   Element2 get nonSynthetic2 => throw UnimplementedError();
 
   @override
-  // TODO: implement reference
   Reference? get reference => throw UnimplementedError();
 
   @override
-  void resetCachedAllSupertypes() {
-    // TODO: implement resetCachedAllSupertypes
-  }
+  void resetCachedAllSupertypes() {}
 
   @override
-  // TODO: implement session
   AnalysisSession? get session => throw UnimplementedError();
 
   @override
-  void setModifier(Modifier modifier, bool value) {
-    // TODO: implement setModifier
-  }
+  void setModifier(Modifier modifier, bool value) {}
 
   @override
-  // TODO: implement setters2
   List<SetterElementImpl> get setters2 => throw UnimplementedError();
 
   @override
-  // TODO: implement sinceSdkVersion
   semver.Version? get sinceSdkVersion => throw UnimplementedError();
 
   @override
-  // TODO: implement supertype
   InterfaceTypeImpl? get supertype => throw UnimplementedError();
 
   @override
   Element2? thisOrAncestorMatching2(bool Function(Element2 p1) predicate) {
-    // TODO: implement thisOrAncestorMatching2
     throw UnimplementedError();
   }
 
   @override
   E? thisOrAncestorOfType2<E extends Element2>() {
-    // TODO: implement thisOrAncestorOfType2
     throw UnimplementedError();
   }
 
   @override
-  // TODO: implement thisType
   InterfaceTypeImpl get thisType => throw UnimplementedError();
 
   @override
-  // TODO: implement typeParameters2
   List<TypeParameterElementImpl2> get typeParameters2 =>
       throw UnimplementedError();
 
   @override
-  // TODO: implement unnamedConstructor2
   ConstructorElementImpl2? get unnamedConstructor2 =>
       throw UnimplementedError();
 
   @override
-  void visitChildren2<T>(ElementVisitor2<T> visitor) {
-    // TODO: implement visitChildren2
-  }
+  void visitChildren2<T>(ElementVisitor2<T> visitor) {}
 }
 
 bool _isSetterName(String name) => name.endsWith('=');

--- a/reflectable/lib/src/element_capability.dart
+++ b/reflectable/lib/src/element_capability.dart
@@ -197,8 +197,10 @@ const subtypeQuantifyCapability = _SubtypeQuantifyCapability();
 class SuperclassQuantifyCapability implements ReflecteeQuantifyCapability {
   final Element? upperBound;
   final bool excludeUpperBound;
-  const SuperclassQuantifyCapability(this.upperBound,
-      {this.excludeUpperBound = false});
+  const SuperclassQuantifyCapability(
+    this.upperBound, {
+    this.excludeUpperBound = false,
+  });
 }
 
 // Note that `null` represents the [ClassElement] for `Object`.
@@ -211,8 +213,9 @@ class TypeAnnotationQuantifyCapability implements ReflecteeQuantifyCapability {
 
 const typeAnnotationQuantifyCapability = TypeAnnotationQuantifyCapability();
 
-const typeAnnotationDeepQuantifyCapability =
-    TypeAnnotationQuantifyCapability(transitive: true);
+const typeAnnotationDeepQuantifyCapability = TypeAnnotationQuantifyCapability(
+  transitive: true,
+);
 
 const correspondingSetterQuantifyCapability =
     _CorrespondingSetterQuantifyCapability();
@@ -227,13 +230,13 @@ class ImportAttachedCapability {
 class GlobalQuantifyCapability extends ImportAttachedCapability {
   final String classNamePattern;
   const GlobalQuantifyCapability(this.classNamePattern, Element reflector)
-      : super(reflector);
+    : super(reflector);
 }
 
 class GlobalQuantifyMetaCapability extends ImportAttachedCapability {
   final Element metadataType;
   const GlobalQuantifyMetaCapability(this.metadataType, Element reflector)
-      : super(reflector);
+    : super(reflector);
 }
 
 class _ReflectedTypeCapability implements DeclarationsCapability {

--- a/reflectable/lib/src/incompleteness.dart
+++ b/reflectable/lib/src/incompleteness.dart
@@ -36,7 +36,8 @@ Never unreachableError(String message) {
 /// avoid warnings about a missing return problem, and the code may be more
 /// readable.
 Never unimplementedError(String message) {
-  var extendedMessage = '*** Unfortunately, this feature has not yet been '
+  var extendedMessage =
+      '*** Unfortunately, this feature has not yet been '
       'implemented: $message.\n'
       'If you wish to ensure that it is prioritized, please report it '
       'on github.com/dart-lang/reflectable.';

--- a/reflectable/lib/src/reflectable_base.dart
+++ b/reflectable/lib/src/reflectable_base.dart
@@ -54,30 +54,30 @@ class ReflectableBase {
 
   /// Const constructor, to enable usage as metadata, allowing for varargs
   /// style invocation with up to ten arguments.
-  const ReflectableBase(
-      [this._cap0,
-      this._cap1,
-      this._cap2,
-      this._cap3,
-      this._cap4,
-      this._cap5,
-      this._cap6,
-      this._cap7,
-      this._cap8,
-      this._cap9])
-      : _capabilitiesGivenAsList = false,
-        _capabilities = null;
+  const ReflectableBase([
+    this._cap0,
+    this._cap1,
+    this._cap2,
+    this._cap3,
+    this._cap4,
+    this._cap5,
+    this._cap6,
+    this._cap7,
+    this._cap8,
+    this._cap9,
+  ]) : _capabilitiesGivenAsList = false,
+       _capabilities = null;
 
   const ReflectableBase.fromList(this._capabilities)
-      : _capabilitiesGivenAsList = true,
-        _cap0 = null,
-        _cap1 = null,
-        _cap2 = null,
-        _cap3 = null,
-        _cap4 = null,
-        _cap5 = null,
-        _cap6 = null,
-        _cap7 = null,
-        _cap8 = null,
-        _cap9 = null;
+    : _capabilitiesGivenAsList = true,
+      _cap0 = null,
+      _cap1 = null,
+      _cap2 = null,
+      _cap3 = null,
+      _cap4 = null,
+      _cap5 = null,
+      _cap6 = null,
+      _cap7 = null,
+      _cap8 = null,
+      _cap9 = null;
 }

--- a/reflectable/lib/src/reflectable_builder_based.dart
+++ b/reflectable/lib/src/reflectable_builder_based.dart
@@ -110,15 +110,16 @@ class ReflectorData {
   Map<Type, TypeMirror>? _typeToTypeMirrorCache;
 
   ReflectorData(
-      this.typeMirrors,
-      this.memberMirrors,
-      this.parameterMirrors,
-      this.types,
-      this.supportedClassCount,
-      this.getters,
-      this.setters,
-      this.libraryMirrors,
-      this.parameterListShapes);
+    this.typeMirrors,
+    this.memberMirrors,
+    this.parameterMirrors,
+    this.types,
+    this.supportedClassCount,
+    this.getters,
+    this.setters,
+    this.libraryMirrors,
+    this.parameterListShapes,
+  );
 
   /// Returns a type mirror for the given [type].
   ///
@@ -135,9 +136,11 @@ class ReflectorData {
         // Note that [types] corresponds to the prefix of [typeMirrors] which
         // are class mirrors; [typeMirrors] continues with type variable
         // mirrors, and they are irrelevant here.
-        _typeToTypeMirrorCache = typeToTypeMirrorCache = <Type, TypeMirror>{
-          for (var i = 0; i < supportedClassCount; ++i) types[i]: typeMirrors[i]
-        };
+        _typeToTypeMirrorCache =
+            typeToTypeMirrorCache = <Type, TypeMirror>{
+              for (var i = 0; i < supportedClassCount; ++i)
+                types[i]: typeMirrors[i],
+            };
       }
       typeToTypeMirrorCache[_typeOf<void>()] = VoidMirrorImpl();
       typeToTypeMirrorCache[dynamic] = DynamicMirrorImpl();
@@ -154,7 +157,10 @@ class ReflectorData {
       if (typeMirror is GenericClassMirrorImpl) {
         if (typeMirror._isGenericRuntimeTypeOf(instance)) {
           return _createInstantiatedGenericClass(
-              typeMirror, instance.runtimeType, null);
+            typeMirror,
+            instance.runtimeType,
+            null,
+          );
         }
       }
     }
@@ -163,7 +169,8 @@ class ReflectorData {
   }
 }
 
-const String pleaseInitializeMessage = 'Reflectable has not been initialized.\n'
+const String pleaseInitializeMessage =
+    'Reflectable has not been initialized.\n'
     'Please make sure that the first action taken by your program\n'
     'in `main` is to call `initializeReflectable()`.';
 
@@ -216,7 +223,8 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
       // type of the reflectee is known.
       if (!_data.types.contains(reflectee.runtimeType)) {
         throw NoSuchCapabilityError(
-            'Reflecting on un-marked type "${reflectee.runtimeType}"');
+          'Reflecting on un-marked type "${reflectee.runtimeType}"',
+        );
       }
     }
   }
@@ -229,21 +237,29 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
   ClassMirror get type {
     if (!_supportsType) {
       throw NoSuchCapabilityError(
-          'Attempt to get `type` without `TypeCapability`.');
+        'Attempt to get `type` without `TypeCapability`.',
+      );
     }
     return _type!;
   }
 
   @override
-  Object? invoke(String methodName, List<Object?> positionalArguments,
-      [Map<Symbol, Object?>? namedArguments]) {
+  Object? invoke(
+    String methodName,
+    List<Object?> positionalArguments, [
+    Map<Symbol, Object?>? namedArguments,
+  ]) {
     Never fail() {
       // It could be a method that exists but the given capabilities rejected
       // it, it could be a method that does not exist at all, or it could be
       // a non-conforming argument list shape. In all cases we consider the
       // invocation to be a capability violation.
       throw reflectableNoSuchMethodError(
-          reflectee, methodName, positionalArguments, namedArguments);
+        reflectee,
+        methodName,
+        positionalArguments,
+        namedArguments,
+      );
     }
 
     // Obtain the tear-off closure for the method that we will invoke.
@@ -260,11 +276,17 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
       throw unreachableError('Attempt to `invoke` without class mirrors');
     }
     if (!_type!._checkInstanceParameterListShape(
-        methodName, positionalArguments.length, namedArguments?.keys)) {
+      methodName,
+      positionalArguments.length,
+      namedArguments?.keys,
+    )) {
       fail();
     }
     return Function.apply(
-        methodTearer(reflectee), positionalArguments, namedArguments);
+      methodTearer(reflectee),
+      positionalArguments,
+      namedArguments,
+    );
   }
 
   @override
@@ -283,26 +305,29 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
   @override
   dynamic delegate(Invocation invocation) {
     Never fail() {
-      StringInvocationKind kind = invocation.isGetter
-          ? StringInvocationKind.getter
-          : (invocation.isSetter
-              ? StringInvocationKind.setter
-              : StringInvocationKind.method);
+      StringInvocationKind kind =
+          invocation.isGetter
+              ? StringInvocationKind.getter
+              : (invocation.isSetter
+                  ? StringInvocationKind.setter
+                  : StringInvocationKind.method);
       // TODO(eernst) implement: Pass the de-minified `memberName` string, if
       // get support for translating arbitrary symbols to strings (the caller
       // could use `new Symbol(..)` so we cannot assume that this symbol is
       // known).
       throw reflectableNoSuchInvokableError(
-          reflectee,
-          '${invocation.memberName}',
-          invocation.positionalArguments,
-          invocation.namedArguments,
-          kind);
+        reflectee,
+        '${invocation.memberName}',
+        invocation.positionalArguments,
+        invocation.namedArguments,
+        kind,
+      );
     }
 
     if (memberSymbolMap == null) {
       throw NoSuchCapabilityError(
-          'Attempt to `delegate` without `delegateCapability`');
+        'Attempt to `delegate` without `delegateCapability`',
+      );
     }
     String? memberName = memberSymbolMap![invocation.memberName];
     if (memberName == null) {
@@ -325,8 +350,11 @@ class _InstanceMirrorImpl extends _DataCaching implements InstanceMirror {
       }
       return invokeSetter(memberName, invocation.positionalArguments[0]);
     } else {
-      return invoke(memberName, invocation.positionalArguments,
-          invocation.namedArguments);
+      return invoke(
+        memberName,
+        invocation.positionalArguments,
+        invocation.namedArguments,
+      );
     }
   }
 
@@ -392,8 +420,9 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     if (_superinterfaceIndices.length == 1 &&
         _superinterfaceIndices[0] == noCapabilityIndex) {
       throw NoSuchCapabilityError(
-          'Requesting `superinterfaces` of `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Requesting `superinterfaces` of `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return _superinterfaceIndices.map<ClassMirror>((int i) {
       if (i == noCapabilityIndex) {
@@ -402,8 +431,9 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
         // we do have the `typeRelationsCapability`, but we may still
         // encounter a single unsupported superinterface.
         throw NoSuchCapabilityError(
-            'Requesting a superinterface of `$qualifiedName` '
-            'without capability');
+          'Requesting a superinterface of `$qualifiedName` '
+          'without capability',
+        );
       }
       return _data.typeMirrors[i] as ClassMirror;
     }).toList();
@@ -450,23 +480,24 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
   final Map<String, int>? _parameterListShapes;
 
   ClassMirrorBase(
-      this.simpleName,
-      this.qualifiedName,
-      this._descriptor,
-      this._classIndex,
-      this._reflector,
-      this._declarationIndices,
-      this._instanceMemberIndices,
-      this._staticMemberIndices,
-      this._superclassIndex,
-      this._getters,
-      this._setters,
-      this._constructors,
-      this._ownerIndex,
-      this._mixinIndex,
-      this._superinterfaceIndices,
-      this._metadata,
-      this._parameterListShapes);
+    this.simpleName,
+    this.qualifiedName,
+    this._descriptor,
+    this._classIndex,
+    this._reflector,
+    this._declarationIndices,
+    this._instanceMemberIndices,
+    this._staticMemberIndices,
+    this._superclassIndex,
+    this._getters,
+    this._setters,
+    this._constructors,
+    this._ownerIndex,
+    this._mixinIndex,
+    this._superinterfaceIndices,
+    this._metadata,
+    this._parameterListShapes,
+  );
 
   @override
   bool get isAbstract => (_descriptor & constants.abstractAttribute != 0);
@@ -487,7 +518,8 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
         // that.
         if (declarationIndex == noCapabilityIndex) {
           throw NoSuchCapabilityError(
-              'Requesting declarations of "$qualifiedName" without capability');
+            'Requesting declarations of "$qualifiedName" without capability',
+          );
         }
         DeclarationMirror declarationMirror =
             _data.memberMirrors![declarationIndex];
@@ -508,7 +540,8 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       List<int>? instanceMemberIndices = _instanceMemberIndices;
       if (instanceMemberIndices == null) {
         throw NoSuchCapabilityError(
-            'Requesting instanceMembers without `declarationsCapability`.');
+          'Requesting instanceMembers without `declarationsCapability`.',
+        );
       }
       var result = <String, MethodMirror>{};
       for (int instanceMemberIndex in instanceMemberIndices) {
@@ -532,7 +565,8 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       List<int>? staticMemberIndices = _staticMemberIndices;
       if (staticMemberIndices == null) {
         throw NoSuchCapabilityError(
-            'Requesting instanceMembers without `declarationsCapability`.');
+          'Requesting instanceMembers without `declarationsCapability`.',
+        );
       }
       var result = <String, MethodMirror>{};
       for (int staticMemberIndex in staticMemberIndices) {
@@ -553,22 +587,28 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     if (_mixinIndex == noCapabilityIndex) {
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to get `mixin` for `$qualifiedName` '
-            'without `typeRelationsCapability`');
+          'Attempt to get `mixin` for `$qualifiedName` '
+          'without `typeRelationsCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Attempt to get mixin from "$simpleName" without capability');
+        'Attempt to get mixin from "$simpleName" without capability',
+      );
     }
     return _data.typeMirrors[_mixinIndex] as ClassMirror;
   }
 
   bool _checkParameterListShape(
-      String methodName,
+    String methodName,
+    int numberOfPositionalArguments,
+    Iterable<Symbol>? namedArgumentNames,
+    MethodMirrorProvider methodMirrorProvider,
+  ) {
+    bool checkUsingShape(
+      List parameterListShape,
       int numberOfPositionalArguments,
       Iterable<Symbol>? namedArgumentNames,
-      MethodMirrorProvider methodMirrorProvider) {
-    bool checkUsingShape(List parameterListShape,
-        int numberOfPositionalArguments, Iterable<Symbol>? namedArgumentNames) {
+    ) {
       assert(parameterListShape.length == 3);
       int numberOfPositionalParameters = parameterListShape[0];
       int numberOfOptionalPositionalParameters = parameterListShape[1];
@@ -586,8 +626,9 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // We do have named arguments; check that they are all known.
       return namesOfNamedParameters == null
           ? false
-          : namedArgumentNames
-              .every((Symbol name) => namesOfNamedParameters.contains(name));
+          : namedArgumentNames.every(
+            (Symbol name) => namesOfNamedParameters.contains(name),
+          );
     }
 
     Map<String, int>? parameterListShapes = _parameterListShapes;
@@ -605,8 +646,11 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // invocation received an argument list that it supports. It is a bug if
       // `shapeIndex` is out of range for `parameterListShapes`, but if that
       // happens the built-in range check will catch it.
-      return checkUsingShape(_data.parameterListShapes![shapeIndex],
-          numberOfPositionalArguments, namedArgumentNames);
+      return checkUsingShape(
+        _data.parameterListShapes![shapeIndex],
+        numberOfPositionalArguments,
+        namedArgumentNames,
+      );
     } else {
       // Without ready-to-use parameter list shape information we must compute
       // the shape from declaration mirrors.
@@ -627,29 +671,52 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       var methodMirrorImpl = methodMirror as MethodMirrorImpl;
       // Let the [methodMirrorImpl] check it based on declaration mirrors.
       return methodMirrorImpl._isArgumentListShapeAppropriate(
-          numberOfPositionalArguments, namedArgumentNames);
+        numberOfPositionalArguments,
+        namedArgumentNames,
+      );
     }
   }
 
-  bool _checkInstanceParameterListShape(String methodName,
-      int numberOfPositionalArguments, Iterable<Symbol>? namedArgumentNames) {
-    return _checkParameterListShape(methodName, numberOfPositionalArguments,
-        namedArgumentNames, (String name) => instanceMembers[name]);
+  bool _checkInstanceParameterListShape(
+    String methodName,
+    int numberOfPositionalArguments,
+    Iterable<Symbol>? namedArgumentNames,
+  ) {
+    return _checkParameterListShape(
+      methodName,
+      numberOfPositionalArguments,
+      namedArgumentNames,
+      (String name) => instanceMembers[name],
+    );
   }
 
-  bool _checkStaticParameterListShape(String methodName,
-      int numberOfPositionalArguments, Iterable<Symbol>? namedArgumentNames) {
-    return _checkParameterListShape(methodName, numberOfPositionalArguments,
-        namedArgumentNames, (String name) => staticMembers[name]);
+  bool _checkStaticParameterListShape(
+    String methodName,
+    int numberOfPositionalArguments,
+    Iterable<Symbol>? namedArgumentNames,
+  ) {
+    return _checkParameterListShape(
+      methodName,
+      numberOfPositionalArguments,
+      namedArgumentNames,
+      (String name) => staticMembers[name],
+    );
   }
 
   @override
-  Object newInstance(String constructorName, List positionalArguments,
-      [Map<Symbol, dynamic>? namedArguments]) {
+  Object newInstance(
+    String constructorName,
+    List positionalArguments, [
+    Map<Symbol, dynamic>? namedArguments,
+  ]) {
     Never fail() {
       Type? type = hasReflectedType ? reflectedType : null;
       throw reflectableNoSuchConstructorError(
-          type, constructorName, positionalArguments, namedArguments);
+        type,
+        constructorName,
+        positionalArguments,
+        namedArguments,
+      );
     }
 
     Function? constructor = _constructors[constructorName];
@@ -660,28 +727,41 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       fail();
     }
     return Function.apply(
-        constructor(true), positionalArguments, namedArguments);
+      constructor(true),
+      positionalArguments,
+      namedArguments,
+    );
   }
 
   @override
-  Object? invoke(String memberName, List positionalArguments,
-      [Map<Symbol, dynamic>? namedArguments]) {
+  Object? invoke(
+    String memberName,
+    List positionalArguments, [
+    Map<Symbol, dynamic>? namedArguments,
+  ]) {
     Never fail() {
       throw reflectableNoSuchMethodError(
-          hasReflectedType ? reflectedType : null,
-          memberName,
-          positionalArguments,
-          namedArguments);
+        hasReflectedType ? reflectedType : null,
+        memberName,
+        positionalArguments,
+        namedArguments,
+      );
     }
 
     StaticGetter? getter = _getters[memberName];
     if (getter == null) fail();
     if (!_checkStaticParameterListShape(
-        memberName, positionalArguments.length, namedArguments?.keys)) {
+      memberName,
+      positionalArguments.length,
+      namedArguments?.keys,
+    )) {
       fail();
     }
     return Function.apply(
-        getter() as Function, positionalArguments, namedArguments);
+      getter() as Function,
+      positionalArguments,
+      namedArguments,
+    );
   }
 
   @override
@@ -699,8 +779,9 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
         _isSetterName(name) ? name : _getterNameToSetterName(name);
     StaticSetter? setter = _setters[setterName];
     if (setter == null) {
-      throw reflectableNoSuchSetterError(
-          reflectedType, setterName, [value], {});
+      throw reflectableNoSuchSetterError(reflectedType, setterName, [
+        value,
+      ], {});
     }
     return setter(value);
   }
@@ -736,7 +817,8 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       String description =
           hasReflectedType ? reflectedType.toString() : qualifiedName;
       throw NoSuchCapabilityError(
-          'Requesting metadata of "$description" without capability');
+        'Requesting metadata of "$description" without capability',
+      );
     }
     return _metadata;
   }
@@ -762,12 +844,14 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // for access to superinterfaces here.
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to evaluate `isAssignableTo` for `$qualifiedName` '
-            'without `typeRelationsCapability`');
+          'Attempt to evaluate `isAssignableTo` for `$qualifiedName` '
+          'without `typeRelationsCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Attempt to evaluate `isAssignableTo` for `$qualifiedName` '
-          'without capability.');
+        'Attempt to evaluate `isAssignableTo` for `$qualifiedName` '
+        'without capability.',
+      );
     }
     return _isSubtypeOf(other) ||
         (other is ClassMirrorBase && other._isSubtypeOf(this));
@@ -785,12 +869,14 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // for access to superinterfaces here.
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to evaluate `isSubtypeOf` for `$qualifiedName` '
-            'without `typeRelationsCapability`');
+          'Attempt to evaluate `isSubtypeOf` for `$qualifiedName` '
+          'without `typeRelationsCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Attempt to evaluate `isSubtypeOf` for `$qualifiedName` '
-          'without capability.');
+        'Attempt to evaluate `isSubtypeOf` for `$qualifiedName` '
+        'without capability.',
+      );
     }
     return _isSubtypeOf(other);
   }
@@ -808,8 +894,10 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     // Recursively test hierarchy over `superclass`.
     if (superclass!._isSubtypeOf(other)) return true;
     // Recursively test hierarchy over remaining direct supertypes.
-    return superinterfaces.any((ClassMirror classMirror) =>
-        classMirror is ClassMirrorBase && classMirror._isSubtypeOf(other));
+    return superinterfaces.any(
+      (ClassMirror classMirror) =>
+          classMirror is ClassMirrorBase && classMirror._isSubtypeOf(other),
+    );
   }
 
   @override
@@ -824,12 +912,14 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
       // for access to superinterfaces here.
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to evaluate `isSubclassOf` for `$qualifiedName` '
-            'without `typeRelationsCapability`');
+          'Attempt to evaluate `isSubclassOf` for `$qualifiedName` '
+          'without `typeRelationsCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Attempt to evaluate `isSubclassOf` for $qualifiedName '
-          'without capability.');
+        'Attempt to evaluate `isSubclassOf` for $qualifiedName '
+        'without capability.',
+      );
     }
     return _isSubclassOf(other);
   }
@@ -852,12 +942,14 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     if (_ownerIndex == noCapabilityIndex) {
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to get `owner` of `$qualifiedName` '
-            'without `typeRelationsCapability`');
+          'Attempt to get `owner` of `$qualifiedName` '
+          'without `typeRelationsCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Trying to get owner of class `$qualifiedName` '
-          'without `libraryCapability`');
+        'Trying to get owner of class `$qualifiedName` '
+        'without `libraryCapability`',
+      );
     }
     return _data.libraryMirrors![_ownerIndex];
   }
@@ -867,11 +959,14 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
     if (_superclassIndex == noCapabilityIndex) {
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to get `superclass` of `$qualifiedName` '
-            'without `typeRelationsCapability`');
+          'Attempt to get `superclass` of `$qualifiedName` '
+          'without `typeRelationsCapability`',
+        );
       }
-      throw NoSuchCapabilityError('Requesting mirror on un-marked class, '
-          '`superclass` of `$qualifiedName`');
+      throw NoSuchCapabilityError(
+        'Requesting mirror on un-marked class, '
+        '`superclass` of `$qualifiedName`',
+      );
     }
     if (_superclassIndex == null) return null; // Superclass of [Object].
     return _data.typeMirrors[_superclassIndex] as ClassMirrorBase?;
@@ -880,30 +975,32 @@ abstract class ClassMirrorBase extends _DataCaching implements ClassMirror {
 
 class NonGenericClassMirrorImpl extends ClassMirrorBase {
   NonGenericClassMirrorImpl(
-      super.simpleName,
-      super.qualifiedName,
-      super.descriptor,
-      super.classIndex,
-      super.reflector,
-      super.declarationIndices,
-      super.instanceMemberIndices,
-      super.staticMemberIndices,
-      super.superclassIndex,
-      super.getters,
-      super.setters,
-      super.constructors,
-      super.ownerIndex,
-      super.mixinIndex,
-      super.superinterfaceIndices,
-      super.metadata,
-      super.parameterListShapes);
+    super.simpleName,
+    super.qualifiedName,
+    super.descriptor,
+    super.classIndex,
+    super.reflector,
+    super.declarationIndices,
+    super.instanceMemberIndices,
+    super.staticMemberIndices,
+    super.superclassIndex,
+    super.getters,
+    super.setters,
+    super.constructors,
+    super.ownerIndex,
+    super.mixinIndex,
+    super.superinterfaceIndices,
+    super.metadata,
+    super.parameterListShapes,
+  );
 
   @override
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `typeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `typeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return const <TypeMirror>[];
   }
@@ -913,8 +1010,9 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `typeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability` or `reflectedTypeCapability`');
+        'Attempt to get `typeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability` or `reflectedTypeCapability`',
+      );
     }
     return const <Type>[];
   }
@@ -923,8 +1021,9 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
   List<TypeVariableMirror> get typeVariables {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to evaluate `typeVariables` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to evaluate `typeVariables` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return const <TypeVariableMirror>[];
   }
@@ -936,8 +1035,9 @@ class NonGenericClassMirrorImpl extends ClassMirrorBase {
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `originalDeclaration` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `originalDeclaration` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return this;
   }
@@ -982,33 +1082,35 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   final int _dynamicReflectedTypeIndex;
 
   GenericClassMirrorImpl(
-      super.simpleName,
-      super.qualifiedName,
-      super.descriptor,
-      super.classIndex,
-      super.reflector,
-      super.declarationIndices,
-      super.instanceMemberIndices,
-      super.staticMemberIndices,
-      int super.superclassIndex,
-      super.getters,
-      super.setters,
-      super.constructors,
-      super.ownerIndex,
-      super.mixinIndex,
-      super.superinterfaceIndices,
-      super.metadata,
-      super.parameterListShapes,
-      this._isGenericRuntimeTypeOf,
-      this._typeVariableIndices,
-      this._dynamicReflectedTypeIndex);
+    super.simpleName,
+    super.qualifiedName,
+    super.descriptor,
+    super.classIndex,
+    super.reflector,
+    super.declarationIndices,
+    super.instanceMemberIndices,
+    super.staticMemberIndices,
+    int super.superclassIndex,
+    super.getters,
+    super.setters,
+    super.constructors,
+    super.ownerIndex,
+    super.mixinIndex,
+    super.superinterfaceIndices,
+    super.metadata,
+    super.parameterListShapes,
+    this._isGenericRuntimeTypeOf,
+    this._typeVariableIndices,
+    this._dynamicReflectedTypeIndex,
+  );
 
   @override
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `typeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `typeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     // This mirror represents the original declaration, so no actual type
     // arguments have been passed. By convention we represent this situation
@@ -1021,8 +1123,9 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability` or `reflectedTypeCapability`');
+        'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability` or `reflectedTypeCapability`',
+      );
     }
     // This mirror represents the original declaration, so no actual type
     // arguments have been passed. By convention we represent this situation
@@ -1040,11 +1143,13 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
     if (typeVariableIndices == null) {
       if (!_supportsTypeRelations(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to evaluate `typeVariables` for `$qualifiedName` '
-            'without `typeRelationsCapability`');
+          'Attempt to evaluate `typeVariables` for `$qualifiedName` '
+          'without `typeRelationsCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Requesting type variables of `$qualifiedName` without capability');
+        'Requesting type variables of `$qualifiedName` without capability',
+      );
     }
     var result = <TypeVariableMirror>[];
     for (int typeVariableIndex in typeVariableIndices) {
@@ -1062,8 +1167,9 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `originalDeclaration` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `originalDeclaration` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return this;
   }
@@ -1073,8 +1179,10 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
 
   @override
   Type get reflectedType {
-    throw UnsupportedError('Attempt to obtain `reflectedType` '
-        'from generic class `$qualifiedName`.');
+    throw UnsupportedError(
+      'Attempt to obtain `reflectedType` '
+      'from generic class `$qualifiedName`.',
+    );
   }
 
   @override
@@ -1085,12 +1193,14 @@ class GenericClassMirrorImpl extends ClassMirrorBase {
     if (_dynamicReflectedTypeIndex == noCapabilityIndex) {
       if (!_supportsReflectedType(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to evaluate `dynamicReflectedType` for `$qualifiedName` '
-            'without `reflectedTypeCapability`');
+          'Attempt to evaluate `dynamicReflectedType` for `$qualifiedName` '
+          'without `reflectedTypeCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Attempt to get `dynamicReflectedType` for `$qualifiedName` '
-          'without capability');
+        'Attempt to get `dynamicReflectedType` for `$qualifiedName` '
+        'without capability',
+      );
     }
     return _data.types[_dynamicReflectedTypeIndex];
   }
@@ -1112,33 +1222,35 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
   final List<int>? _reflectedTypeArgumentIndices;
 
   InstantiatedGenericClassMirrorImpl(
-      super.simpleName,
-      super.qualifiedName,
-      super.descriptor,
-      super.classIndex,
-      super.reflector,
-      super.declarationIndices,
-      super.instanceMemberIndices,
-      super.staticMemberIndices,
-      super.superclassIndex,
-      super.getters,
-      super.setters,
-      super.constructors,
-      super.ownerIndex,
-      super.mixinIndex,
-      super.superinterfaceIndices,
-      super.metadata,
-      super.parameterListShapes,
-      this._originalDeclaration,
-      this._reflectedType,
-      this._reflectedTypeArgumentIndices);
+    super.simpleName,
+    super.qualifiedName,
+    super.descriptor,
+    super.classIndex,
+    super.reflector,
+    super.declarationIndices,
+    super.instanceMemberIndices,
+    super.staticMemberIndices,
+    super.superclassIndex,
+    super.getters,
+    super.setters,
+    super.constructors,
+    super.ownerIndex,
+    super.mixinIndex,
+    super.superinterfaceIndices,
+    super.metadata,
+    super.parameterListShapes,
+    this._originalDeclaration,
+    this._reflectedType,
+    this._reflectedTypeArgumentIndices,
+  );
 
   @override
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `typeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `typeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return reflectedTypeArguments
         .map((Type type) => _reflector.reflectType(type))
@@ -1150,8 +1262,9 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability` or `reflectedTypeCapability`');
+        'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability` or `reflectedTypeCapability`',
+      );
     }
     List<int>? reflectedTypeArgumentIndices = _reflectedTypeArgumentIndices;
     if (reflectedTypeArgumentIndices == null) {
@@ -1173,8 +1286,9 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `originalDeclaration` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `originalDeclaration` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return _originalDeclaration;
   }
@@ -1188,8 +1302,10 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
     if (reflectedType != null) {
       return reflectedType;
     }
-    throw UnsupportedError('Cannot provide `reflectedType` of '
-        'instance of generic type `$simpleName`.');
+    throw UnsupportedError(
+      'Cannot provide `reflectedType` of '
+      'instance of generic type `$simpleName`.',
+    );
   }
 
   @override
@@ -1246,34 +1362,36 @@ class InstantiatedGenericClassMirrorImpl extends ClassMirrorBase {
 }
 
 InstantiatedGenericClassMirrorImpl _createInstantiatedGenericClass(
-    GenericClassMirrorImpl genericClassMirror,
-    Type? reflectedType,
-    List<int>? reflectedTypeArguments,
-    [int? descriptor]) {
+  GenericClassMirrorImpl genericClassMirror,
+  Type? reflectedType,
+  List<int>? reflectedTypeArguments, [
+  int? descriptor,
+]) {
   // TODO(eernst) implement: Pass a representation of type arguments to this
   // method, and create an instantiated generic class which includes that
   // information.
   return InstantiatedGenericClassMirrorImpl(
-      genericClassMirror.simpleName,
-      genericClassMirror.qualifiedName,
-      descriptor ?? genericClassMirror._descriptor,
-      genericClassMirror._classIndex,
-      genericClassMirror._reflector,
-      genericClassMirror._declarationIndices,
-      genericClassMirror._instanceMemberIndices,
-      genericClassMirror._staticMemberIndices,
-      genericClassMirror._superclassIndex,
-      genericClassMirror._getters,
-      genericClassMirror._setters,
-      genericClassMirror._constructors,
-      genericClassMirror._ownerIndex,
-      genericClassMirror._mixinIndex,
-      genericClassMirror._superinterfaceIndices,
-      genericClassMirror._metadata,
-      genericClassMirror._parameterListShapes,
-      genericClassMirror,
-      reflectedType,
-      reflectedTypeArguments);
+    genericClassMirror.simpleName,
+    genericClassMirror.qualifiedName,
+    descriptor ?? genericClassMirror._descriptor,
+    genericClassMirror._classIndex,
+    genericClassMirror._reflector,
+    genericClassMirror._declarationIndices,
+    genericClassMirror._instanceMemberIndices,
+    genericClassMirror._staticMemberIndices,
+    genericClassMirror._superclassIndex,
+    genericClassMirror._getters,
+    genericClassMirror._setters,
+    genericClassMirror._constructors,
+    genericClassMirror._ownerIndex,
+    genericClassMirror._mixinIndex,
+    genericClassMirror._superinterfaceIndices,
+    genericClassMirror._metadata,
+    genericClassMirror._parameterListShapes,
+    genericClassMirror,
+    reflectedType,
+    reflectedTypeArguments,
+  );
 }
 
 class TypeVariableMirrorImpl extends _DataCaching
@@ -1304,8 +1422,14 @@ class TypeVariableMirrorImpl extends _DataCaching
   /// means no metadata, null means no capability.
   final List<Object>? _metadata;
 
-  TypeVariableMirrorImpl(this.simpleName, this.qualifiedName, this._reflector,
-      this._upperBoundIndex, this._ownerIndex, this._metadata);
+  TypeVariableMirrorImpl(
+    this.simpleName,
+    this.qualifiedName,
+    this._reflector,
+    this._upperBoundIndex,
+    this._ownerIndex,
+    this._metadata,
+  );
 
   @override
   bool get isStatic => false;
@@ -1315,8 +1439,10 @@ class TypeVariableMirrorImpl extends _DataCaching
     int? upperBoundIndex = _upperBoundIndex;
     if (upperBoundIndex == null) return DynamicMirrorImpl();
     if (upperBoundIndex == noCapabilityIndex) {
-      throw NoSuchCapabilityError('Attempt to get `upperBound` from type '
-          'variable mirror without capability.');
+      throw NoSuchCapabilityError(
+        'Attempt to get `upperBound` from type '
+        'variable mirror without capability.',
+      );
     }
     return _data.typeMirrors[upperBoundIndex];
   }
@@ -1325,8 +1451,9 @@ class TypeVariableMirrorImpl extends _DataCaching
   bool isAssignableTo(TypeMirror other) {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `isAssignableTo` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `isAssignableTo` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return upperBound.isSubtypeOf(other) || other.isSubtypeOf(this);
   }
@@ -1335,8 +1462,9 @@ class TypeVariableMirrorImpl extends _DataCaching
   bool isSubtypeOf(TypeMirror other) {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `isSubtypeOf` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `isSubtypeOf` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return upperBound.isSubtypeOf(other);
   }
@@ -1345,8 +1473,9 @@ class TypeVariableMirrorImpl extends _DataCaching
   TypeMirror get originalDeclaration {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `originalDeclaration` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `originalDeclaration` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return this;
   }
@@ -1358,8 +1487,9 @@ class TypeVariableMirrorImpl extends _DataCaching
   List<TypeMirror> get typeArguments {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `typeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to get `typeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return const <TypeMirror>[];
   }
@@ -1369,8 +1499,9 @@ class TypeVariableMirrorImpl extends _DataCaching
     if (!_supportsTypeRelations(_reflector) ||
         !_supportsReflectedType(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
-          'without `typeRelationsCapability` or `reflectedTypeCapability`');
+        'Attempt to get `reflectedTypeArguments` for `$qualifiedName` '
+        'without `typeRelationsCapability` or `reflectedTypeCapability`',
+      );
     }
     return const <Type>[];
   }
@@ -1379,16 +1510,19 @@ class TypeVariableMirrorImpl extends _DataCaching
   List<TypeVariableMirror> get typeVariables {
     if (!_supportsTypeRelations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to evaluate `typeVariables` for `$qualifiedName` '
-          'without `typeRelationsCapability`');
+        'Attempt to evaluate `typeVariables` for `$qualifiedName` '
+        'without `typeRelationsCapability`',
+      );
     }
     return <TypeVariableMirror>[];
   }
 
   @override
   Type get reflectedType {
-    throw UnsupportedError('Attempt to get `reflectedType` from type '
-        'variable $simpleName');
+    throw UnsupportedError(
+      'Attempt to get `reflectedType` from type '
+      'variable $simpleName',
+    );
   }
 
   @override
@@ -1397,8 +1531,10 @@ class TypeVariableMirrorImpl extends _DataCaching
   @override
   List<Object> get metadata {
     if (_metadata == null) {
-      throw NoSuchCapabilityError('Attempt to get `metadata` from type '
-          'variable $simpleName without capability');
+      throw NoSuchCapabilityError(
+        'Attempt to get `metadata` from type '
+        'variable $simpleName without capability',
+      );
     }
     return <Object>[];
   }
@@ -1428,8 +1564,9 @@ class TypeVariableMirrorImpl extends _DataCaching
   DeclarationMirror get owner {
     if (_ownerIndex == noCapabilityIndex) {
       throw NoSuchCapabilityError(
-          'Trying to get owner of type parameter `$qualifiedName` '
-          'without capability');
+        'Trying to get owner of type parameter `$qualifiedName` '
+        'without capability',
+      );
     }
     return _data.typeMirrors[_ownerIndex];
   }
@@ -1461,14 +1598,15 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
   final Map<String, int>? _parameterListShapes;
 
   LibraryMirrorImpl(
-      this.simpleName,
-      this.uri,
-      this._reflector,
-      this._declarationIndices,
-      this.getters,
-      this.setters,
-      this._metadata,
-      this._parameterListShapes);
+    this.simpleName,
+    this.uri,
+    this._reflector,
+    this._declarationIndices,
+    this.getters,
+    this.setters,
+    this._metadata,
+    this._parameterListShapes,
+  );
 
   Map<String, DeclarationMirror>? _declarations;
 
@@ -1486,7 +1624,8 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
         // that.
         if (declarationIndex == noCapabilityIndex) {
           throw NoSuchCapabilityError(
-              'Requesting declarations of `$qualifiedName` without capability');
+            'Requesting declarations of `$qualifiedName` without capability',
+          );
         }
         DeclarationMirror declarationMirror =
             _data.memberMirrors![declarationIndex];
@@ -1503,10 +1642,16 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
     return declarations;
   }
 
-  bool _checkParameterListShape(String memberName,
-      int numberOfPositionalArguments, Iterable<Symbol>? namedArgumentNames) {
-    bool checkUsingShape(List parameterListShape,
-        int numberOfPositionalArguments, Iterable<Symbol>? namedArgumentNames) {
+  bool _checkParameterListShape(
+    String memberName,
+    int numberOfPositionalArguments,
+    Iterable<Symbol>? namedArgumentNames,
+  ) {
+    bool checkUsingShape(
+      List parameterListShape,
+      int numberOfPositionalArguments,
+      Iterable<Symbol>? namedArgumentNames,
+    ) {
       assert(parameterListShape.length == 3);
       int numberOfPositionalParameters = parameterListShape[0];
       int numberOfOptionalPositionalParameters = parameterListShape[1];
@@ -1518,8 +1663,9 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
         return false;
       }
       if (namedArgumentNames == null) return true;
-      return namedArgumentNames
-          .every((Symbol name) => namesOfNamedParameters.contains(name));
+      return namedArgumentNames.every(
+        (Symbol name) => namesOfNamedParameters.contains(name),
+      );
     }
 
     Map<String, int>? parameterListShapes = _parameterListShapes;
@@ -1537,8 +1683,11 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
       // invocation received an argument list that it supports. It is a bug if
       // `shapeIndex` is out of range for `parameterListShapes`, but if that
       // happens the built-in range check will catch it.
-      return checkUsingShape(_data.parameterListShapes![shapeIndex],
-          numberOfPositionalArguments, namedArgumentNames);
+      return checkUsingShape(
+        _data.parameterListShapes![shapeIndex],
+        numberOfPositionalArguments,
+        namedArgumentNames,
+      );
     } else {
       // Without ready-to-use parameter list shape information we must compute
       // the shape from declaration mirrors.
@@ -1562,26 +1711,41 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
       var methodMirrorImpl = methodMirror as MethodMirrorImpl;
       // Let the [methodMirrorImpl] check it based on declaration mirrors.
       return methodMirrorImpl._isArgumentListShapeAppropriate(
-          numberOfPositionalArguments, namedArgumentNames);
+        numberOfPositionalArguments,
+        namedArgumentNames,
+      );
     }
   }
 
   @override
-  Object? invoke(String memberName, List positionalArguments,
-      [Map<Symbol, dynamic>? namedArguments]) {
+  Object? invoke(
+    String memberName,
+    List positionalArguments, [
+    Map<Symbol, dynamic>? namedArguments,
+  ]) {
     Never fail() {
       throw reflectableNoSuchMethodError(
-          null, memberName, positionalArguments, namedArguments);
+        null,
+        memberName,
+        positionalArguments,
+        namedArguments,
+      );
     }
 
     StaticGetter? getter = getters[memberName];
     if (getter == null) fail();
     if (!_checkParameterListShape(
-        memberName, positionalArguments.length, namedArguments?.keys)) {
+      memberName,
+      positionalArguments.length,
+      namedArguments?.keys,
+    )) {
       fail();
     }
     return Function.apply(
-        getter() as Function, positionalArguments, namedArguments);
+      getter() as Function,
+      positionalArguments,
+      namedArguments,
+    );
   }
 
   @override
@@ -1621,7 +1785,8 @@ class LibraryMirrorImpl extends _DataCaching implements LibraryMirror {
     List<Object>? metadata = _metadata;
     if (metadata == null) {
       throw NoSuchCapabilityError(
-          'Requesting metadata of library `$simpleName` without capability');
+        'Requesting metadata of library `$simpleName` without capability',
+      );
     }
     return metadata;
   }
@@ -1696,16 +1861,17 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   final List<Object>? _metadata;
 
   MethodMirrorImpl(
-      this._name,
-      this._descriptor,
-      this._ownerIndex,
-      this._returnTypeIndex,
-      this._reflectedReturnTypeIndex,
-      this._dynamicReflectedReturnTypeIndex,
-      this._reflectedTypeArgumentsOfReturnType,
-      this._parameterIndices,
-      this._reflector,
-      this._metadata);
+    this._name,
+    this._descriptor,
+    this._ownerIndex,
+    this._returnTypeIndex,
+    this._reflectedReturnTypeIndex,
+    this._dynamicReflectedReturnTypeIndex,
+    this._reflectedTypeArgumentsOfReturnType,
+    this._parameterIndices,
+    this._reflector,
+    this._metadata,
+  );
 
   int get kind => constants.kindFromEncoding(_descriptor);
 
@@ -1713,8 +1879,9 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   DeclarationMirror get owner {
     if (_ownerIndex == noCapabilityIndex) {
       throw NoSuchCapabilityError(
-          'Trying to get owner of method `$qualifiedName` '
-          'without `LibraryCapability`');
+        'Trying to get owner of method `$qualifiedName` '
+        'without `LibraryCapability`',
+      );
     }
     return isTopLevel
         ? _data.libraryMirrors![_ownerIndex]
@@ -1792,7 +1959,8 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
     List<Object>? metadata = _metadata;
     if (metadata == null) {
       throw NoSuchCapabilityError(
-          'Requesting metadata of method `$simpleName` without capability');
+        'Requesting metadata of method `$simpleName` without capability',
+      );
     }
     return metadata;
   }
@@ -1801,7 +1969,8 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   List<ParameterMirror> get parameters {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `parameters` without `DeclarationsCapability`');
+        'Attempt to get `parameters` without `DeclarationsCapability`',
+      );
     }
     return _parameterIndices
         .map((int parameterIndex) => _data.parameterMirrors![parameterIndex])
@@ -1818,15 +1987,17 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
     if (_hasNeverReturnType) return VoidMirrorImpl();
     if (_returnTypeIndex == noCapabilityIndex) {
       throw NoSuchCapabilityError(
-          'Requesting returnType of method `$simpleName` without capability');
+        'Requesting returnType of method `$simpleName` without capability',
+      );
     }
     if (_hasClassReturnType) {
       TypeMirror typeMirror = _data.typeMirrors[_returnTypeIndex];
       return _hasGenericReturnType
           ? _createInstantiatedGenericClass(
-              typeMirror as GenericClassMirrorImpl,
-              null,
-              _reflectedTypeArgumentsOfReturnType)
+            typeMirror as GenericClassMirrorImpl,
+            null,
+            _reflectedTypeArgumentsOfReturnType,
+          )
           : typeMirror;
     }
     throw unreachableError('Unexpected kind of returnType');
@@ -1845,8 +2016,10 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
     if (_hasDynamicReturnType) return dynamic;
     if (_hasNeverReturnType) return Never;
     if (_reflectedReturnTypeIndex == noCapabilityIndex) {
-      throw NoSuchCapabilityError('Requesting reflectedReturnType of method '
-          '`$simpleName` without capability');
+      throw NoSuchCapabilityError(
+        'Requesting reflectedReturnType of method '
+        '`$simpleName` without capability',
+      );
     }
     return _data.types[_reflectedReturnTypeIndex];
   }
@@ -1864,9 +2037,10 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   }
 
   @override
-  String get simpleName => isConstructor
-      ? (_name == '' ? owner.simpleName : '${owner.simpleName}.$_name')
-      : _name;
+  String get simpleName =>
+      isConstructor
+          ? (_name == '' ? owner.simpleName : '${owner.simpleName}.$_name')
+          : _name;
 
   @override
   String? get source => null;
@@ -1928,7 +2102,9 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
   Set<Symbol>? _namesOfNamedParameters;
 
   bool _isArgumentListShapeAppropriate(
-      int numberOfPositionalArguments, Iterable<Symbol>? namedArgumentNames) {
+    int numberOfPositionalArguments,
+    Iterable<Symbol>? namedArgumentNames,
+  ) {
     if (numberOfPositionalArguments <
             numberOfPositionalParameters -
                 numberOfOptionalPositionalParameters ||
@@ -1936,8 +2112,9 @@ class MethodMirrorImpl extends _DataCaching implements MethodMirror {
       return false;
     }
     if (namedArgumentNames == null) return true;
-    return namedArgumentNames
-        .every((Symbol name) => namesOfNamedParameters.contains(name));
+    return namedArgumentNames.every(
+      (Symbol name) => namesOfNamedParameters.contains(name),
+    );
   }
 
   @override
@@ -1958,7 +2135,10 @@ abstract class ImplicitAccessorMirrorImpl extends _DataCaching
       _data.memberMirrors![_variableMirrorIndex] as VariableMirrorImpl;
 
   ImplicitAccessorMirrorImpl(
-      this._reflector, this._variableMirrorIndex, this._selfIndex);
+    this._reflector,
+    this._variableMirrorIndex,
+    this._selfIndex,
+  );
 
   int get kind => constants.kindFromEncoding(_variableMirror._descriptor);
 
@@ -2032,7 +2212,10 @@ abstract class ImplicitAccessorMirrorImpl extends _DataCaching
 
 class ImplicitGetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   ImplicitGetterMirrorImpl(
-      super.reflector, super.variableMirrorIndex, super.selfIndex);
+    super.reflector,
+    super.variableMirrorIndex,
+    super.selfIndex,
+  );
 
   @override
   bool get isGetter => true;
@@ -2044,7 +2227,8 @@ class ImplicitGetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   List<ParameterMirror> get parameters {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `parameters` without `DeclarationsCapability`');
+        'Attempt to get `parameters` without `DeclarationsCapability`',
+      );
     }
     return <ParameterMirror>[];
   }
@@ -2061,7 +2245,10 @@ class ImplicitGetterMirrorImpl extends ImplicitAccessorMirrorImpl {
 
 class ImplicitSetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   ImplicitSetterMirrorImpl(
-      super.reflector, super.variableMirrorIndex, super.selfIndex);
+    super.reflector,
+    super.variableMirrorIndex,
+    super.selfIndex,
+  );
 
   @override
   bool get isGetter => false;
@@ -2087,21 +2274,23 @@ class ImplicitSetterMirrorImpl extends ImplicitAccessorMirrorImpl {
   List<ParameterMirror> get parameters {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `parameters` without `DeclarationsCapability`');
+        'Attempt to get `parameters` without `DeclarationsCapability`',
+      );
     }
     return <ParameterMirror>[
       ParameterMirrorImpl(
-          _variableMirror.simpleName,
-          _parameterDescriptor,
-          _selfIndex,
-          _variableMirror._reflector,
-          _variableMirror._classMirrorIndex,
-          _variableMirror._reflectedTypeIndex,
-          _variableMirror._dynamicReflectedTypeIndex,
-          _variableMirror._reflectedTypeArguments,
-          const <Object>[],
-          null,
-          null)
+        _variableMirror.simpleName,
+        _parameterDescriptor,
+        _selfIndex,
+        _variableMirror._reflector,
+        _variableMirror._classMirrorIndex,
+        _variableMirror._reflectedTypeIndex,
+        _variableMirror._dynamicReflectedTypeIndex,
+        _variableMirror._reflectedTypeArguments,
+        const <Object>[],
+        null,
+        null,
+      ),
     ];
   }
 
@@ -2131,15 +2320,16 @@ abstract class VariableMirrorBase extends _DataCaching
   final List<Object>? _metadata;
 
   VariableMirrorBase(
-      this._name,
-      this._descriptor,
-      this._ownerIndex,
-      this._reflector,
-      this._classMirrorIndex,
-      this._reflectedTypeIndex,
-      this._dynamicReflectedTypeIndex,
-      this._reflectedTypeArguments,
-      this._metadata);
+    this._name,
+    this._descriptor,
+    this._ownerIndex,
+    this._reflector,
+    this._classMirrorIndex,
+    this._reflectedTypeIndex,
+    this._dynamicReflectedTypeIndex,
+    this._reflectedTypeArguments,
+    this._metadata,
+  );
 
   int get kind => constants.kindFromEncoding(_descriptor);
 
@@ -2176,7 +2366,8 @@ abstract class VariableMirrorBase extends _DataCaching
     List<Object>? metadata = _metadata;
     if (metadata == null) {
       throw NoSuchCapabilityError(
-          'Requesting metadata of field `$simpleName` without capability');
+        'Requesting metadata of field `$simpleName` without capability',
+      );
     }
     return metadata;
   }
@@ -2195,10 +2386,12 @@ abstract class VariableMirrorBase extends _DataCaching
     if (_classMirrorIndex == noCapabilityIndex) {
       if (!_supportsType(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to get `type` without `TypeCapability`');
+          'Attempt to get `type` without `TypeCapability`',
+        );
       }
       throw NoSuchCapabilityError(
-          'Attempt to get class mirror for un-marked class (type of `$_name`)');
+        'Attempt to get class mirror for un-marked class (type of `$_name`)',
+      );
     }
     if (_isClassType) {
       TypeMirror typeMirror = _data.typeMirrors[_classMirrorIndex];
@@ -2206,10 +2399,11 @@ abstract class VariableMirrorBase extends _DataCaching
           typeMirror.isNonNullable != _isNonNullable) {
         if (_isGenericType) {
           return _createInstantiatedGenericClass(
-              typeMirror as GenericClassMirrorImpl,
-              hasReflectedType ? reflectedType : null,
-              _reflectedTypeArguments,
-              _descriptor);
+            typeMirror as GenericClassMirrorImpl,
+            hasReflectedType ? reflectedType : null,
+            _reflectedTypeArguments,
+            _descriptor,
+          );
         } else {
           var classMirror = typeMirror as NonGenericClassMirrorImpl;
           return NonGenericClassMirrorImpl(
@@ -2235,9 +2429,10 @@ abstract class VariableMirrorBase extends _DataCaching
       } else {
         return _isGenericType
             ? _createInstantiatedGenericClass(
-                typeMirror as GenericClassMirrorImpl,
-                hasReflectedType ? reflectedType : null,
-                _reflectedTypeArguments)
+              typeMirror as GenericClassMirrorImpl,
+              hasReflectedType ? reflectedType : null,
+              _reflectedTypeArguments,
+            )
             : typeMirror;
       }
     }
@@ -2259,10 +2454,12 @@ abstract class VariableMirrorBase extends _DataCaching
     if (_reflectedTypeIndex == noCapabilityIndex) {
       if (!_supportsReflectedType(_reflector)) {
         throw NoSuchCapabilityError(
-            'Attempt to get `reflectedType` without `reflectedTypeCapability`');
+          'Attempt to get `reflectedType` without `reflectedTypeCapability`',
+        );
       }
       throw UnsupportedError(
-          'Attempt to get reflectedType without capability (of `$_name`)');
+        'Attempt to get reflectedType without capability (of `$_name`)',
+      );
     }
     return _data.types[_reflectedTypeIndex];
   }
@@ -2292,8 +2489,9 @@ class VariableMirrorImpl extends VariableMirrorBase {
   DeclarationMirror get owner {
     if (_ownerIndex == noCapabilityIndex) {
       throw NoSuchCapabilityError(
-          'Trying to get owner of variable `$qualifiedName` '
-          'without capability');
+        'Trying to get owner of variable `$qualifiedName` '
+        'without capability',
+      );
     }
     return isTopLevel
         ? _data.libraryMirrors![_ownerIndex]
@@ -2307,15 +2505,16 @@ class VariableMirrorImpl extends VariableMirrorBase {
   bool get isConst => (_descriptor & constants.constAttribute != 0);
 
   VariableMirrorImpl(
-      super.name,
-      super.descriptor,
-      super.ownerIndex,
-      super.reflectable,
-      super.classMirrorIndex,
-      super.reflectedTypeIndex,
-      super.dynamicReflectedTypeIndex,
-      super.reflectedTypeArguments,
-      super.metadata);
+    super.name,
+    super.descriptor,
+    super.ownerIndex,
+    super.reflectable,
+    super.classMirrorIndex,
+    super.reflectedTypeIndex,
+    super.dynamicReflectedTypeIndex,
+    super.reflectedTypeArguments,
+    super.metadata,
+  );
 
   // Note that the corresponding implementation of [hashCode] is inherited from
   // [VariableMirrorBase].
@@ -2347,7 +2546,8 @@ class ParameterMirrorImpl extends VariableMirrorBase
   bool get hasDefaultValue {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `hasDefaultValue` without `DeclarationsCapability`');
+        'Attempt to get `hasDefaultValue` without `DeclarationsCapability`',
+      );
     }
     return (_descriptor & constants.hasDefaultValueAttribute != 0);
   }
@@ -2356,7 +2556,8 @@ class ParameterMirrorImpl extends VariableMirrorBase
   Object? get defaultValue {
     if (!_supportsDeclarations(_reflector)) {
       throw NoSuchCapabilityError(
-          'Attempt to get `defaultValue` without `DeclarationsCapability`');
+        'Attempt to get `defaultValue` without `DeclarationsCapability`',
+      );
     }
     return _defaultValue;
   }
@@ -2371,17 +2572,18 @@ class ParameterMirrorImpl extends VariableMirrorBase
   MethodMirror get owner => _data.memberMirrors![_ownerIndex] as MethodMirror;
 
   ParameterMirrorImpl(
-      super.name,
-      super.descriptor,
-      super.ownerIndex,
-      super.reflectable,
-      super.classMirrorIndex,
-      super.reflectedTypeIndex,
-      super.dynamicReflectedTypeIndex,
-      super.reflectedTypeArguments,
-      super.metadata,
-      this._defaultValue,
-      this._nameSymbol);
+    super.name,
+    super.descriptor,
+    super.ownerIndex,
+    super.reflectable,
+    super.classMirrorIndex,
+    super.reflectedTypeIndex,
+    super.dynamicReflectedTypeIndex,
+    super.reflectedTypeArguments,
+    super.metadata,
+    this._defaultValue,
+    this._nameSymbol,
+  );
 
   // Note that the corresponding implementation of [hashCode] is inherited from
   // [VariableMirrorBase].
@@ -2534,20 +2736,21 @@ abstract class ReflectableImpl extends ReflectableBase
     implements ReflectableInterface {
   /// Const constructor, to enable usage as metadata, allowing for varargs
   /// style invocation with up to ten arguments.
-  const ReflectableImpl(
-      [super.cap0,
-      super.cap1,
-      super.cap2,
-      super.cap3,
-      super.cap4,
-      super.cap5,
-      super.cap6,
-      super.cap7,
-      super.cap8,
-      super.cap9]);
+  const ReflectableImpl([
+    super.cap0,
+    super.cap1,
+    super.cap2,
+    super.cap3,
+    super.cap4,
+    super.cap5,
+    super.cap6,
+    super.cap7,
+    super.cap8,
+    super.cap9,
+  ]);
 
   const ReflectableImpl.fromList(List<ReflectCapability> super.capabilities)
-      : super.fromList();
+    : super.fromList();
 
   @override
   bool canReflect(Object reflectee) {
@@ -2560,8 +2763,9 @@ abstract class ReflectableImpl extends ReflectableBase
   }
 
   bool get _hasTypeCapability {
-    return capabilities
-        .any((ReflectCapability capability) => capability is TypeCapability);
+    return capabilities.any(
+      (ReflectCapability capability) => capability is TypeCapability,
+    );
   }
 
   @override
@@ -2574,7 +2778,8 @@ abstract class ReflectableImpl extends ReflectableBase
     TypeMirror? result = data[this]!.typeMirrorForType(type);
     if (result == null || !_hasTypeCapability) {
       throw NoSuchCapabilityError(
-          'Reflecting on type `$type` without capability');
+        'Reflecting on type `$type` without capability',
+      );
     }
     return result;
   }
@@ -2583,8 +2788,10 @@ abstract class ReflectableImpl extends ReflectableBase
   LibraryMirror findLibrary(String libraryName) {
     ReflectorData reflectorData = data[this]!;
     if (reflectorData.libraryMirrors == null) {
-      throw NoSuchCapabilityError('Using `findLibrary` without capability. '
-          'Try adding `libraryCapability`.');
+      throw NoSuchCapabilityError(
+        'Using `findLibrary` without capability. '
+        'Try adding `libraryCapability`.',
+      );
     }
     // The specification says that an exception shall be thrown if there
     // is anything other than one library with a matching name.
@@ -2610,8 +2817,10 @@ abstract class ReflectableImpl extends ReflectableBase
   Map<Uri, LibraryMirror> get libraries {
     ReflectorData reflectorData = data[this]!;
     if (reflectorData.libraryMirrors == null) {
-      throw NoSuchCapabilityError('Using `libraries` without capability. '
-          'Try adding `libraryCapability`.');
+      throw NoSuchCapabilityError(
+        'Using `libraries` without capability. '
+        'Try adding `libraryCapability`.',
+      );
     }
     var result = <Uri, LibraryMirror>{};
     for (LibraryMirror library in reflectorData.libraryMirrors!) {
@@ -2623,7 +2832,8 @@ abstract class ReflectableImpl extends ReflectableBase
   @override
   Iterable<ClassMirror> get annotatedClasses {
     return List<ClassMirror>.unmodifiable(
-        data[this]!.typeMirrors.whereType<ClassMirror>());
+      data[this]!.typeMirrors.whereType<ClassMirror>(),
+    );
   }
 }
 
@@ -2643,21 +2853,25 @@ bool _isSetterName(String name) => name.endsWith('=');
 String _getterNameToSetterName(String name) => '$name=';
 
 bool _supportsType(ReflectableImpl reflector) {
-  return reflector.capabilities
-      .any((ReflectCapability capability) => capability is TypeCapability);
+  return reflector.capabilities.any(
+    (ReflectCapability capability) => capability is TypeCapability,
+  );
 }
 
 bool _supportsTypeRelations(ReflectableImpl reflector) {
   return reflector.capabilities.any(
-      (ReflectCapability capability) => capability is TypeRelationsCapability);
+    (ReflectCapability capability) => capability is TypeRelationsCapability,
+  );
 }
 
 bool _supportsReflectedType(ReflectableImpl reflector) {
   return reflector.capabilities.any(
-      (ReflectCapability capability) => capability == reflectedTypeCapability);
+    (ReflectCapability capability) => capability == reflectedTypeCapability,
+  );
 }
 
 bool _supportsDeclarations(ReflectableImpl reflector) {
   return reflector.capabilities.any(
-      (ReflectCapability capability) => capability is DeclarationsCapability);
+    (ReflectCapability capability) => capability is DeclarationsCapability,
+  );
 }

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -1,11 +1,11 @@
 name: reflectable
-version: 4.0.13
+version: 4.0.14
 description: >
   Reflection support based on code generation, using 'capabilities' to
   specify which operations to support, on which objects.
 homepage: https://github.com/google/reflectable.dart
 environment:
-  sdk: '>=3.6.0 <4.0.0'
+  sdk: '>=3.7.0 <4.0.0'
 dependencies:
   analyzer: ^7.0.0
   build: ^2.4.0

--- a/reflectable/pubspec.yaml
+++ b/reflectable/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/reflectable.dart
 environment:
   sdk: '>=3.6.0 <4.0.0'
 dependencies:
-  analyzer: ^6.8.0
+  analyzer: ^7.0.0
   build: ^2.4.0
   build_resolvers: ^2.4.0
   build_config: ^1.1.0

--- a/test_reflectable/build.yaml
+++ b/test_reflectable/build.yaml
@@ -3,6 +3,6 @@ targets:
     builders:
       reflectable:
         generate_for:
-          - test/new_instance_native_test.dart
+          - test/global_quantify_test.dart
         options:
           formatted: true

--- a/test_reflectable/build.yaml
+++ b/test_reflectable/build.yaml
@@ -3,6 +3,6 @@ targets:
     builders:
       reflectable:
         generate_for:
-          - test/global_quantify_test.dart
+          - test/**_test.dart
         options:
           formatted: true

--- a/test_reflectable/build.yaml
+++ b/test_reflectable/build.yaml
@@ -3,6 +3,6 @@ targets:
     builders:
       reflectable:
         generate_for:
-          - test/**_test.dart
+          - test/new_instance_native_test.dart
         options:
           formatted: true


### PR DESCRIPTION
This PR changes the version of the analyzer to ^7.0.0, such that there is no dependency on `_macros` (which doesn't exist with Flutter 3.35, so we really need this step).

It makes minimal changes with respect to the new element model (`Element2`), just enough to make the code generator and generated code work in this new context. This implies that there will be another update where reflectable switches to the new element model (which will allow reflectable to use yet newer versions of the analyser).

This PR also prepares reflectable for being published as version 4.0.14.